### PR TITLE
convert incoming body from snake case to camel case

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -2,11 +2,12 @@ export const POWERED_BY: string = "rubeus";
 
 export const HEADER_KEYS: Record<string, string> = {
   MODE: `x-${POWERED_BY}-mode`,
-  RETRIES: `x-${POWERED_BY}-retry-count`,
+  RETRIES: `x-${POWERED_BY}-retry-count`
 }
 
 export const RESPONSE_HEADER_KEYS: Record<string, string> = {
-  RETRY_ATTEMPT_COUNT: `x-${POWERED_BY}-retry-attempt-count`
+  RETRY_ATTEMPT_COUNT: `x-${POWERED_BY}-retry-attempt-count`,
+  LAST_USED_OPTION_INDEX: `x-${POWERED_BY}-last-used-option-index`
 }
 
 export const RETRY_STATUS_CODES = [429, 500, 502, 503, 504];

--- a/src/handlers/chatCompleteHandler.ts
+++ b/src/handlers/chatCompleteHandler.ts
@@ -1,5 +1,5 @@
-import { Options, RequestBody } from "../types/requestBody";
-import { getProviderOptionsByMode, tryProvidersInSequence } from "./handlerUtils";
+import { RequestBody } from "../types/requestBody";
+import { fetchProviderOptionsFromConfig, tryProvidersInSequence } from "./handlerUtils";
 import { Context } from "hono";
 
 // const OPENAI_CHAT_MODELS = ["gpt-4-0613","gpt-3.5-turbo-16k-0613","gpt-3.5-turbo-0301","gpt-3.5-turbo","gpt-3.5-turbo-0613","gpt-4","gpt-4-0314","gpt-3.5-turbo-16k","gpt-4-32k-0314","gpt-4-32k-0613","gpt-4-32k"]
@@ -25,20 +25,7 @@ import { Context } from "hono";
  * @throws Will throw an error if no provider options can be determined or if the request to the provider(s) fails.
  */
 export async function chatCompleteHandler(c: Context, env: any, request: RequestBody, requestHeaders: Record<string, string>): Promise<Response> {
-  let providerOptions:Options[]|null;
-  let mode:string;
-  
-  if ('provider' in request.config) {
-    providerOptions = [{
-      provider: request.config.provider, 
-      apiKeyName: request.config.apiKeyName, 
-      apiKey: request.config.apiKey
-    }];
-    mode = "single";
-  } else {
-    mode = request.config.mode;
-    providerOptions = getProviderOptionsByMode(mode, request.config);
-  }
+  const providerOptions = fetchProviderOptionsFromConfig(request.config);
 
   if (!providerOptions) {
     const errorResponse = {

--- a/src/handlers/completeHandler.ts
+++ b/src/handlers/completeHandler.ts
@@ -1,5 +1,5 @@
-import { Options, RequestBody } from "../types/requestBody";
-import { getProviderOptionsByMode, tryProvidersInSequence } from "./handlerUtils";
+import { RequestBody } from "../types/requestBody";
+import { fetchProviderOptionsFromConfig, getProviderOptionsByMode, tryProvidersInSequence } from "./handlerUtils";
 import { Context } from "hono";
 
 // const OPENAI_CHAT_MODELS = ["gpt-4-0613","gpt-3.5-turbo-16k-0613","gpt-3.5-turbo-0301","gpt-3.5-turbo","gpt-3.5-turbo-0613","gpt-4","gpt-4-0314","gpt-3.5-turbo-16k","gpt-4-32k-0314","gpt-4-32k-0613","gpt-4-32k"]
@@ -15,20 +15,7 @@ import { Context } from "hono";
  * @throws Will throw an error if no provider options can be determined or if the request to the provider(s) fails.
  */
 export async function completeHandler(c: Context, env: any, request: RequestBody, requestHeaders: Record<string, string>): Promise<Response> {
-  let providerOptions:Options[]|null;
-  let mode:string;
-
-  if ('provider' in request.config) {
-    providerOptions = [{
-      provider: request.config.provider, 
-      apiKeyName: request.config.apiKeyName, 
-      apiKey: request.config.apiKey
-    }];
-    mode = "single";
-  } else {
-    mode = request.config.mode;
-    providerOptions = getProviderOptionsByMode(mode, request.config);
-  }
+  const providerOptions = fetchProviderOptionsFromConfig(request.config)
 
   if (!providerOptions) {
     const errorResponse = {

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,7 +42,7 @@ app.onError((err, c) => {
       return err.getResponse()
   }
   c.status(500);
-  return c.json(c.error);
+  return c.json({ok: false, message: err.message});
 });
 
 /**
@@ -100,7 +100,14 @@ app.post("/v1/embed", async (c) => {
     let cheaders = Object.fromEntries(c.req.headers)
     return await embedHandler(c, c.env, cjson, cheaders);
   } catch(err:any) {
-    throw new HTTPException(500, { message: err.message })
+    throw new HTTPException(err.status, { 
+      res: new Response(err.errorObj, {
+        status: err.status,
+        headers: {
+          "content-type": "application/json"
+        }
+      }) 
+    })
   }
 });
 

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -17,7 +17,7 @@ export interface Options {
   /** The name of the provider. */
   provider: string|undefined;
   /** The name of the API key for the provider. */
-  apiKeyName?: string;
+  virtualKey?: string;
   /** The API key for the provider. */
   apiKey?: string;
   /** The weight of the provider, used for load balancing. */
@@ -25,7 +25,7 @@ export interface Options {
   /** The retry settings for the provider. */
   retry?: RetrySettings;
   /** The parameters to override in the request. */
-  override_params?: Params;
+  overrideParams?: Params;
   /** The actual url used to make llm calls */
   urlToFetch?: string;
   /** Azure specific */
@@ -33,6 +33,8 @@ export interface Options {
   deploymentId?: string;
   apiVersion?: string;
   adAuth?:string;
+  /** provider option index picked based on weight in loadbalance mode */
+  index?: number;
 }
 
 /**
@@ -123,11 +125,11 @@ interface FullRequestBody {
  * A shortened structure of the request body, with a simpler configuration.
  * @interface
  */
-interface ShortConfig {
+export interface ShortConfig {
   /** The name of the provider. */
   provider: string;
   /** The name of the API key for the provider. */
-  apiKeyName?: string;
+  virtualKey?: string;
   /** The API key for the provider. */
   apiKey?: string;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,3 +15,36 @@ export const getStreamModeSplitPattern = (proxyProvider: string) => {
 export const getStreamingMode = (reqBody: Params) => {
     return reqBody.stream 
 }
+
+export function convertKeysToCamelCase<T>(
+    obj: Record<string, any>,
+    parentKeysToPreserve: string[] = []
+  ): T {
+    if (typeof obj !== 'object' || obj === null) {
+      return obj; // Return unchanged for non-objects or null
+    }
+  
+    if (Array.isArray(obj)) {
+      // If it's an array, recursively convert each element
+      return obj.map((item) => convertKeysToCamelCase(item, parentKeysToPreserve)) as T;
+    }
+  
+    return Object.keys(obj).reduce((result: any, key: string) => {
+      const value = obj[key];
+      const camelCaseKey = toCamelCase(key);
+      const isParentKeyToPreserve = parentKeysToPreserve.includes(key);
+      if (typeof value === 'object' && !isParentKeyToPreserve) {
+        // Recursively convert child objects
+        result[camelCaseKey] = convertKeysToCamelCase(value, parentKeysToPreserve);
+      } else {
+        // Add key in camelCase to the result
+        result[camelCaseKey] = value;
+      }
+  
+      return result;
+    }, {} as T);
+  
+    function toCamelCase(snakeCase: string): string {
+      return snakeCase.replace(/(_\w)/g, (match) => match[1].toUpperCase());
+    }
+  }


### PR DESCRIPTION
- Rubeus now accepts all input body params as snake case. This PR introduces a generic function to convert snake_case to camelCase with fine control over what keys to ignore.
- Cleanup all the references which were using camelCase.
- Send the last option index picked in the response header for better DevX.