### PR TITLE
add wait time during stream to avoid irregular worker behaviour

### DIFF
--- a/src/handlers/streamHandler.ts
+++ b/src/handlers/streamHandler.ts
@@ -31,6 +31,8 @@ export async function* readStream(reader: ReadableStreamDefaultReader, splitPatt
                     if (isFirstChunk) {
                         isFirstChunk = false;
                         await new Promise(resolve => setTimeout(resolve, 25));
+                    } else {
+                        await new Promise(resolve => setTimeout(resolve, 1));
                     }
 
                     if (transformFunction) {


### PR DESCRIPTION
- Worker environments show a strange behaviour for streams. Clients receive irregular stream chunks sometime which causes issue. Adding a minor wait time solves the issue. Need to debug this and provide a solid fix in future 