### PR TITLE
overwrite stream mode to false when cache status is hit

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -156,7 +156,7 @@ export async function tryPostProxy(c: Context, providerOption:Options, requestBo
     if (cacheResponse) {
       response = await responseHandler(new Response(cacheResponse, {headers: {
         "content-type": "application/json"
-      }}), isStreamingMode, provider, undefined);
+      }}), false, provider, undefined);
       c.set("requestOptions", [...requestOptions, {
         providerOptions: {...providerOption, requestURL: url, rubeusURL: fn},
         requestParams: params,
@@ -253,7 +253,7 @@ export async function tryPost(c: Context, providerOption:Options, requestBody: R
     if (cacheResponse) {
       response = await responseHandler(new Response(cacheResponse, {headers: {
         "content-type": "application/json"
-      }}), isStreamingMode, provider, undefined);
+      }}), false, provider, undefined);
       c.set("requestOptions", [...requestOptions, {
         providerOptions: {...providerOption, requestURL: url, rubeusURL: fn},
         requestParams: transformedRequestBody,

--- a/src/handlers/proxyHandler.ts
+++ b/src/handlers/proxyHandler.ts
@@ -90,11 +90,11 @@ export async function proxyHandler(c: Context, env: any, request: HonoRequest<"/
     const requestOptions = c.get('requestOptions') ?? [];
     let cacheResponse, cacheStatus;
     if (getFromCacheFunction) {
-      [cacheResponse, cacheStatus] = await getFromCacheFunction(c.env, {...requestHeaders, ...fetchOptions.headers}, store.reqBody, 'proxy', cacheIdentifier);
+      [cacheResponse, cacheStatus] = await getFromCacheFunction(c.env, {...requestHeaders, ...fetchOptions.headers}, store.reqBody, urlToFetch, cacheIdentifier);
       if (cacheResponse) {
         const cacheMappedResponse = await responseHandler(new Response(cacheResponse, {headers: {
           "content-type": "application/json"
-        }}), store.isStreamingMode, store.proxyProvider, undefined);
+        }}), false, store.proxyProvider, undefined);
         c.set("requestOptions", [...requestOptions, {
           providerOptions: {...store.reqBody, provider: store.proxyProvider, requestURL: urlToFetch, rubeusURL: 'proxy'},
           requestParams: store.reqBody,


### PR DESCRIPTION
- Currently, rubeus supports middlewares where user can write their own cache logic. The response for cache hits is supposed to be json even in case of stream mode. So, we need to overwrite stream mode to false in case of parsing cache response.