### PR TITLE
Fix : Add anthropic version header with each request

### DIFF
--- a/src/providers/anthropic/api.ts
+++ b/src/providers/anthropic/api.ts
@@ -3,7 +3,10 @@ import { ProviderAPIConfig } from "../types";
 const AnthropicAPIConfig: ProviderAPIConfig = {
   baseURL: "https://api.anthropic.com/v1",
   headers: (API_KEY:string) => {
-    return {"X-API-Key": `${API_KEY}`}
+    return {
+      "X-API-Key": `${API_KEY}`,
+      "Anthropic-Version": "2023-06-01"
+    }
   },
   complete: "/complete",
   chatComplete: "/complete",


### PR DESCRIPTION
The anthropic implementation was breaking so added a version header by default , we could potentially make this configurable but there is no publically available list of versions as per my research 