### PR TITLE
update hono package version to 3.12.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@hono/node-server": "^1.3.3",
         "async-retry": "^1.3.3",
-        "hono": "^3.2.2",
+        "hono": "^3.12.0",
         "zod": "^3.22.4"
       },
       "bin": {
@@ -1340,9 +1340,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "3.2.5",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-3.2.5.tgz",
-      "integrity": "sha512-saAKnPNGXO3vLq198IJO6ZwunQyXOYj6FkAZS08pBNKXn34lF9b7vb/pdyTrQWv3WvUPFjGCQfDyUjMhcubAMw==",
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-3.12.0.tgz",
+      "integrity": "sha512-UPEtZuLY7Wo7g0mqKWSOjLFdT8t7wJ60IYEcxKl3AQNU4u+R2QqU2fJMPmSu24C+/ag20Z8mOTQOErZzK4DMvA==",
       "engines": {
         "node": ">=16.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
   "dependencies": {
     "@hono/node-server": "^1.3.3",
     "async-retry": "^1.3.3",
-    "hono": "^3.2.2",
+    "hono": "^3.12.0",
     "zod": "^3.22.4"
   },
   "devDependencies": {


### PR DESCRIPTION
**Title:** 
- Update hono package version to 3.12.0

**Description:** (optional)
- Run npm update hono --save which will change package.json and package-lock.json

**Motivation:** (optional)
- This is advised by hono team as there is some vulnerability reported for the previous hono version. The vulnerability is in TrieRouter **which is NOT used anywhere in this code**. But its better to update package to avoid future risk.

**Related Issues:** (optional)
Closes #113 
