### PR TITLE
add logprobs and top_logprobs mapping for openai chat completions config

### DIFF
--- a/src/providers/openai/chatComplete.ts
+++ b/src/providers/openai/chatComplete.ts
@@ -73,6 +73,13 @@ export const OpenAIChatCompleteConfig: ProviderConfig = {
   },
   response_format: {
     param: "response_format"
+  },
+  logprobs: {
+    param: "logprobs",
+    default: false
+  },
+  top_logprobs: {
+    param: "top_logprobs"
   }
 };
 


### PR DESCRIPTION
**Title:** 
- add `logprobs` and `top_logprobs` mapping for openai chat completions config

**Description:** (optional)
- add logprobs -> logprobs mapping with default value `false`
- add top_logprobs -> top_logprobs mapping

**Motivation:** (optional)
- To map and forward both the params to OpenAI while making the request

**Related Issues:** (optional)
- Closes #121 
