### PR TITLE
fix: change mistral-ai safe_mode param to safe_prompt

### DIFF
--- a/src/providers/mistral-ai/chatComplete.ts
+++ b/src/providers/mistral-ai/chatComplete.ts
@@ -40,8 +40,9 @@ export const MistralAIChatCompleteConfig: ProviderConfig = {
         param: "random_seed",
         default: null,
     },
-    safe_mode: {
-        param: "safe_mode",
+    safe_prompt: {
+        param: "safe_prompt",
+        default: false
     },
 };
 

--- a/src/providers/mistral-ai/chatComplete.ts
+++ b/src/providers/mistral-ai/chatComplete.ts
@@ -44,6 +44,11 @@ export const MistralAIChatCompleteConfig: ProviderConfig = {
         param: "safe_prompt",
         default: false
     },
+    // TODO: deprecate this and move to safe_prompt in next release
+    safe_mode: {
+        param: "safe_prompt",
+        default: false
+    },
 };
 
 interface MistralAIChatCompleteResponse extends ChatCompletionResponse {


### PR DESCRIPTION
**Title:** 
- change mistral-ai safe_mode param to safe_prompt

**Description:** (optional)
- Update chat complete config for mistral-ai provider

**Motivation:** (optional)
- To stay up-to-date with mistral API specs and avoid validation errors

**Related Issues:** (optional)
- Closes #157 
