### PR TITLE
fix: propagate response for failed fallbacks

### DIFF
--- a/src/handlers/chatCompletionsHandler.ts
+++ b/src/handlers/chatCompletionsHandler.ts
@@ -14,7 +14,6 @@ export async function chatCompletionsHandler(c: Context): Promise<Response> {
         let request = await c.req.json();
         let requestHeaders = Object.fromEntries(c.req.raw.headers);
         const camelCaseConfig = constructConfigFromRequestHeaders(requestHeaders)
-        const errors: any = [];
         const tryTargetsResponse = await tryTargetsRecursively(
             c,
             camelCaseConfig ?? {},
@@ -22,7 +21,6 @@ export async function chatCompletionsHandler(c: Context): Promise<Response> {
             requestHeaders,
             "chatComplete",
             "POST",
-            errors,
             "config"
         );
 

--- a/src/handlers/chatCompletionsHandler.ts
+++ b/src/handlers/chatCompletionsHandler.ts
@@ -26,14 +26,6 @@ export async function chatCompletionsHandler(c: Context): Promise<Response> {
             "config"
         );
 
-        if (!tryTargetsResponse) {
-            return new Response(errors[errors.length - 1].errorObj, {
-                status: errors[errors.length - 1].status,
-                headers: {
-                    "content-type": "application/json"
-                }
-            });
-        }
         return tryTargetsResponse;
     } catch (err: any) {
         console.log("chatCompletion error", err.message);

--- a/src/handlers/completionsHandler.ts
+++ b/src/handlers/completionsHandler.ts
@@ -27,14 +27,6 @@ export async function completionsHandler(c: Context): Promise<Response> {
             "config"
         );
 
-        if (!tryTargetsResponse) {
-            return new Response(errors[errors.length - 1].errorObj, {
-                status: errors[errors.length - 1].status,
-                headers: {
-                    "content-type": "application/json"
-                }
-            });
-        }
         return tryTargetsResponse;
     } catch (err: any) {
         console.log("completion error", err.message);

--- a/src/handlers/completionsHandler.ts
+++ b/src/handlers/completionsHandler.ts
@@ -14,7 +14,6 @@ export async function completionsHandler(c: Context): Promise<Response> {
         let request = await c.req.json();
         let requestHeaders = Object.fromEntries(c.req.raw.headers);
         const camelCaseConfig = constructConfigFromRequestHeaders(requestHeaders);
-        const errors: any = [];
 
         const tryTargetsResponse = await tryTargetsRecursively(
             c,
@@ -23,7 +22,6 @@ export async function completionsHandler(c: Context): Promise<Response> {
             requestHeaders,
             "complete",
             "POST",
-            errors,
             "config"
         );
 

--- a/src/handlers/embeddingsHandler.ts
+++ b/src/handlers/embeddingsHandler.ts
@@ -28,14 +28,6 @@ export async function embeddingsHandler(c: Context): Promise<Response> {
             "config"
         );
 
-        if (!tryTargetsResponse) {
-            return new Response(errors[errors.length - 1].errorObj, {
-                status: errors[errors.length - 1].status,
-                headers: {
-                    "content-type": "application/json"
-                }
-            });
-        }
         return tryTargetsResponse;
     } catch (err: any) {
         console.log("completion error", err.message);

--- a/src/handlers/embeddingsHandler.ts
+++ b/src/handlers/embeddingsHandler.ts
@@ -15,8 +15,6 @@ export async function embeddingsHandler(c: Context): Promise<Response> {
         let requestHeaders = Object.fromEntries(c.req.raw.headers);
         const camelCaseConfig = constructConfigFromRequestHeaders(requestHeaders)
 
-        const errors: any = [];
-
         const tryTargetsResponse = await tryTargetsRecursively(
             c,
             camelCaseConfig,
@@ -24,7 +22,6 @@ export async function embeddingsHandler(c: Context): Promise<Response> {
             requestHeaders,
             "embed",
             "POST",
-            errors,
             "config"
         );
 

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -521,7 +521,6 @@ export async function tryTargetsRecursively(
     requestHeaders: Record<string, string>,
     fn: endpointStrings,
     method: string,
-    errors: any,
     jsonPath: string,
     inheritedConfig: Record<string, any> = {}
 ): Promise<Response> {
@@ -563,7 +562,6 @@ export async function tryTargetsRecursively(
                     requestHeaders,
                     fn,
                     method,
-                    errors,
                     `${currentJsonPath}.targets[${index}]`,
                     currentInheritedConfig
                 );
@@ -601,7 +599,6 @@ export async function tryTargetsRecursively(
                         requestHeaders,
                         fn,
                         method,
-                        errors,
                         currentJsonPath,
                         currentInheritedConfig
                     );
@@ -619,7 +616,6 @@ export async function tryTargetsRecursively(
                 requestHeaders,
                 fn,
                 method,
-                errors,
                 `${currentJsonPath}.targets[0]`,
                 currentInheritedConfig
             );
@@ -637,11 +633,6 @@ export async function tryTargetsRecursively(
             );
           } catch (error: any) {
             response = error.response;
-            errors.push({
-                provider: targetGroup.provider,
-                errorObj: error.message,
-                status: error.status,
-            });
           }
           break;
     }

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -429,8 +429,9 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
   // If the response was not ok, throw an error
   if (!response.ok) {
     // Check if this request needs to be retried
-    const errorObj: any = new Error(await mappedResponse.text());
+    const errorObj: any = new Error(await mappedResponse.clone().text());
     errorObj.status = mappedResponse.status;
+    errorObj.response = mappedResponse
     throw errorObj;
   }
 
@@ -502,7 +503,7 @@ export async function tryTargetsRecursively(
     errors: any,
     jsonPath: string,
     inheritedConfig: Record<string, any> = {}
-): Promise<Response | undefined> {
+): Promise<Response> {
     let currentTarget: any = {...targetGroup};
     let currentJsonPath = jsonPath;
     const strategyMode = currentTarget.strategy?.mode;
@@ -614,6 +615,7 @@ export async function tryTargetsRecursively(
                 currentJsonPath
             );
           } catch (error: any) {
+            response = error.response;
             errors.push({
                 provider: targetGroup.provider,
                 errorObj: error.message,


### PR DESCRIPTION
**Title:** 
- propagate response for failed fallbacks

**Description:** (optional)
- Set response even when a tryPost call fails in tryTargetsRecursively.
- Forward the response in the errorObj thrown from tryPost function
- Remove explicit error handler in chatCompletionsHandler, completionsHandler and embeddingsHandler and use the response returned by tryTargetsRecursively function instead.

**Motivation:** (optional)
- Fix behaviour of fallbacks on on_status_codes_property

**Related Issues:** (optional)
- Closes #166 
- Closes #165 
