### PR TITLE
feat: support dimensions param for openai embeddings

### DIFF
--- a/src/providers/openai/embed.ts
+++ b/src/providers/openai/embed.ts
@@ -13,6 +13,12 @@ export const OpenAIEmbedConfig: ProviderConfig = {
     param: "input",
     required: true,
   },
+  encoding_format: {
+    param: "encoding_format"
+  },
+  dimensions: {
+    param: "dimensions"
+  },
   user: {
     param: "user",
   },


### PR DESCRIPTION
**Title:** 
-support dimensions param for openai embeddings

**Description:** (optional)
- Add config mapping for dimensions and encoding_format in OpenAI embeddings config

**Motivation:** (optional)
- To allow use of newly introduced params

**Related Issues:** (optional)
- Closes #174 
