### PR TITLE
[GitOps] Add triage label workflow

### DIFF
--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -1,0 +1,22 @@
+name: Auto Triage Label
+
+on:
+  issues:
+    types: [opened]
+
+jobs:
+  label_issues:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4.1.1
+      - name: Add Triage Label
+        uses: actions/github-script@v7.0.1
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['triage']
+            })
+          github-token: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
**Title:** 
- Adding triage label workflow for all newly opened issues.

For now, the label gets added to all issues, we will triage all issues manually to start with. 