### PR TITLE
Feat: configurable request timeout

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -18,6 +18,7 @@ export const RESPONSE_HEADER_KEYS: Record<string, string> = {
 
 export const RETRY_STATUS_CODES = [429, 500, 502, 503, 504];
 export const MAX_RETRIES = 5;
+export const REQUEST_TIMEOUT_STATUS_CODE = 408;
 
 export const OPEN_AI:string = "openai";
 export const COHERE:string = "cohere";

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -346,7 +346,7 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
   let retryCount:number|undefined;
 
   providerOption.retry = {
-    attempts: providerOption.retry?.attempts ?? 1,
+    attempts: providerOption.retry?.attempts ?? 0,
     onStatusCodes: providerOption.retry?.onStatusCodes ?? []
   }
 
@@ -412,7 +412,7 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
       }
   }
 
-  [response, retryCount] = await retryRequest(url, fetchOptions, providerOption.retry.attempts, providerOption.retry.onStatusCodes);
+  [response, retryCount] = await retryRequest(url, fetchOptions, providerOption.retry.attempts, providerOption.retry.onStatusCodes, providerOption.requestTimeout || null);
 
   const mappedResponse = await responseHandler(response, isStreamingMode, provider, fn, url);
   updateResponseHeaders(mappedResponse, currentIndex, params, cacheStatus, retryCount ?? 0, requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
@@ -535,7 +535,14 @@ export async function tryTargetsRecursively(
         ...currentTarget.overrideParams
       },
       retry: currentTarget.retry ? {...currentTarget.retry} : {...inheritedConfig.retry},
-      cache: currentTarget.cache ? {...currentTarget.cache} : {...inheritedConfig.cache}
+      cache: currentTarget.cache ? {...currentTarget.cache} : {...inheritedConfig.cache},
+      requestTimeout: null
+    }
+
+    if (currentTarget.requestTimeout) {
+      currentInheritedConfig.requestTimeout = currentTarget.requestTimeout
+    } else if (inheritedConfig.requestTimeout) {
+      currentInheritedConfig.requestTimeout = inheritedConfig.requestTimeout;
     }
     currentTarget.overrideParams = {
         ...currentInheritedConfig.overrideParams

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -201,11 +201,11 @@ export async function tryPostProxy(c: Context, providerOption:Options, inputPara
 
   if (providerOption.retry && typeof providerOption.retry === "object") {
     providerOption.retry = { 
-      attempts: providerOption.retry?.attempts ?? 1, 
+      attempts: providerOption.retry?.attempts ?? 0, 
       onStatusCodes: providerOption.retry?.onStatusCodes ?? RETRY_STATUS_CODES
     };
   } else if (typeof providerOption.retry === "number") {
-    providerOption.retry = { 
+    providerOption.retry = {
       attempts: providerOption.retry, 
       onStatusCodes: RETRY_STATUS_CODES
     };

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -258,7 +258,7 @@ export async function tryPostProxy(c: Context, providerOption:Options, inputPara
     }
   }
 
-    [response, retryCount] = await retryRequest(url, fetchOptions, providerOption.retry.attempts, providerOption.retry.onStatusCodes);
+    [response, retryCount] = await retryRequest(url, fetchOptions, providerOption.retry.attempts, providerOption.retry.onStatusCodes, null);
   const mappedResponse = await responseHandler(response, isStreamingMode, provider, undefined, url);
   updateResponseHeaders(mappedResponse, currentIndex, params, cacheStatus, retryCount ?? 0, requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
 

--- a/src/handlers/proxyGetHandler.ts
+++ b/src/handlers/proxyGetHandler.ts
@@ -64,7 +64,7 @@ export async function proxyGetHandler(c: Context): Promise<Response> {
 
     let retryCount = Math.min(parseInt(requestHeaders[HEADER_KEYS.RETRIES])||1, MAX_RETRIES);
 
-    let [lastResponse, lastAttempt] = await retryRequest(urlToFetch, fetchOptions, retryCount, RETRY_STATUS_CODES);
+    let [lastResponse, lastAttempt] = await retryRequest(urlToFetch, fetchOptions, retryCount, RETRY_STATUS_CODES, null);
 
     const mappedResponse = await responseHandler(lastResponse, store.isStreamingMode, store.proxyProvider, undefined, urlToFetch);
     updateResponseHeaders(mappedResponse, 0, store.reqBody, "DISABLED", lastAttempt ?? 0, requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");

--- a/src/handlers/proxyHandler.ts
+++ b/src/handlers/proxyHandler.ts
@@ -183,7 +183,7 @@ export async function proxyHandler(c: Context): Promise<Response> {
     }
 
     // Make the API call to the provider
-    let [lastResponse, lastAttempt] = await retryRequest(urlToFetch, fetchOptions, retryCount, retryStatusCodes);
+    let [lastResponse, lastAttempt] = await retryRequest(urlToFetch, fetchOptions, retryCount, retryStatusCodes, null);
     const mappedResponse = await responseHandler(lastResponse, store.isStreamingMode, store.proxyProvider, undefined, urlToFetch);
     updateResponseHeaders(mappedResponse, 0, store.reqBody, cacheStatus, (lastAttempt ?? 0), requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
 

--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -53,7 +53,7 @@ export const retryRequest = async (
   options: RequestInit,
   retryCount: number,
   statusCodesToRetry: number[],
-  timeout: number | null = null
+  timeout: number | null
 ): Promise<[Response, number | undefined]> => {
   let lastError: any | undefined;
   let lastResponse: Response | undefined;

--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -1,5 +1,40 @@
 import retry from 'async-retry';
 
+async function fetchWithTimeout(url: string, options: RequestInit, timeout: number) {
+  const timeoutRequestOptions = {
+    ...options,
+    signal: AbortSignal.timeout(timeout)
+  }
+
+  let response;
+
+  try {
+    response = await fetch(url, timeoutRequestOptions);
+  } catch (err: any) {
+    if (err.name === "TimeoutError") {
+      response = new Response(JSON.stringify(
+        {
+          error: {
+            "message": `Request exceeded the timeout sent in the request: ${timeout}ms`,
+            "type": "timeout_error",
+            "param": null,
+            "code": null
+          }
+        }
+      ), {
+        headers: {
+          "content-type": "application/json"
+        },
+        status: 408
+      })
+    } else {
+      throw err;
+    }
+  }
+
+  return response;
+}
+
 /**
  * Tries making a fetch request a specified number of times until it succeeds.
  * If the response's status code is included in the statusCodesToRetry array,
@@ -17,9 +52,9 @@ export const retryRequest = async (
   url: string,
   options: RequestInit,
   retryCount: number,
-  statusCodesToRetry: number[]
+  statusCodesToRetry: number[],
+  timeout: number | null = null
 ): Promise<[Response, number | undefined]> => {
-
   let lastError: any | undefined;
   let lastResponse: Response | undefined;
   let lastAttempt: number | undefined;
@@ -27,7 +62,7 @@ export const retryRequest = async (
     await retry(
       async (bail: any, attempt: number) => {
         try {
-          const response: Response = await fetch(url, options);
+          const response: Response = timeout ? await fetchWithTimeout(url, options, timeout) : await fetch(url, options);
           if (statusCodesToRetry.includes(response.status)) {
             const errorObj: any = new Error(await response.text());
             errorObj.status = response.status;

--- a/src/handlers/streamHandler.ts
+++ b/src/handlers/streamHandler.ts
@@ -1,4 +1,4 @@
-import { AZURE_OPEN_AI, CONTENT_TYPES, COHERE, GOOGLE } from "../globals";
+import { AZURE_OPEN_AI, CONTENT_TYPES, COHERE, GOOGLE, REQUEST_TIMEOUT_STATUS_CODE } from "../globals";
 import { OpenAIChatCompleteResponse } from "../providers/openai/chatComplete";
 import { OpenAICompleteResponse } from "../providers/openai/complete";
 import { getStreamModeSplitPattern } from "../utils";
@@ -55,6 +55,13 @@ export async function* readStream(reader: ReadableStreamDefaultReader, splitPatt
 }
 
 export async function handleNonStreamingMode(response: Response, responseTransformer: Function | undefined) {
+    // 408 is thrown whenever a request takes more than request_timeout to respond.
+    // In that case, response thrown by gateway is already in OpenAI format.
+    // So no need to transform it again.
+    if (response.status === REQUEST_TIMEOUT_STATUS_CODE) {
+        return response;
+    }
+
     let responseBodyJson = await response.json();
     if (responseTransformer) {
         responseBodyJson = responseTransformer(responseBodyJson, response.status);

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -92,7 +92,8 @@ export const configSchema: any = z
                 hasProviderApiKey ||
                 hasModeTargets ||
                 value.cache ||
-                value.retry
+                value.retry ||
+                value.request_timeout
             );
         },
         {

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -80,6 +80,7 @@ export const configSchema: any = z
         weight: z.number().optional(),
         on_status_codes: z.array(z.number()).optional(),
         targets: z.array(z.lazy(() => configSchema)).optional(),
+        request_timeout: z.number().optional(),
     })
     .refine(
         (value) => {

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -98,6 +98,6 @@ export const configSchema: any = z
         },
         {
             message:
-                "Invalid configuration. It must have either 'provider' and 'api_key', or 'strategy' and 'targets', or 'cache', or 'target'",
+                "Invalid configuration. It must have either 'provider' and 'api_key', or 'strategy' and 'targets', or 'cache', or 'retry', or 'request_timeout'",
         }
     );

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -47,6 +47,7 @@ export interface Options {
   index?: number;
   cache?: CacheSettings | string;
   metadata?: Record<string, string>;
+  requestTimeout?: number;
 }
 
 /**


### PR DESCRIPTION
**Title:** 
- Configurable request timeout

**Description:** (optional)
- Add support for `request_timeout` setting in configs to end/retry/fallback a request if it takes more than the specified duration.
- Change default retry attempt count to 0 to avoid any unexpected retries.
- Example usage is mentioned in the issue.

**Motivation:** (optional)
- To have more control over LLM request by having a setting to end it if it takes more than some threshold time.

**Related Issues:** (optional)
- Closes #186 
- Closes #185 
