### PR TITLE
Feat: together-ai embedding, tools and latest updates

### DIFF
--- a/src/providers/together-ai/api.ts
+++ b/src/providers/together-ai/api.ts
@@ -6,7 +6,8 @@ const TogetherAIApiConfig: ProviderAPIConfig = {
     return {"Authorization": `Bearer ${API_KEY}`}
   },
   chatComplete: "/v1/chat/completions",
-  complete: "/v1/completions"
+  complete: "/v1/completions",
+  embed: "/v1/embeddings"
 };
 
 export default TogetherAIApiConfig;

--- a/src/providers/together-ai/chatComplete.ts
+++ b/src/providers/together-ai/chatComplete.ts
@@ -53,7 +53,13 @@ export const TogetherAIChatCompleteConfig: ProviderConfig = {
   },
 };
 
-export interface TogetherAIChatCompleteResponse extends ChatCompletionResponse {}
+export interface TogetherAIChatCompleteResponse extends ChatCompletionResponse {
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  }
+}
 
 export interface TogetherAIErrorResponse {
   model: string;
@@ -125,9 +131,9 @@ export const TogetherAIChatCompleteResponseTransform: (response: TogetherAIChatC
           }
         }),
         usage: {
-          prompt_tokens: response.usage?.prompt_tokens || -1,
-          completion_tokens: response.usage?.completion_tokens || -1,
-          total_tokens: response.usage?.total_tokens || -1
+          prompt_tokens: response.usage?.prompt_tokens,
+          completion_tokens: response.usage?.completion_tokens,
+          total_tokens: response.usage?.total_tokens
         }
       }
     }

--- a/src/providers/together-ai/chatComplete.ts
+++ b/src/providers/together-ai/chatComplete.ts
@@ -53,18 +53,7 @@ export const TogetherAIChatCompleteConfig: ProviderConfig = {
   },
 };
 
-export interface TogetherAIChatCompleteResponse {
-  id: string;
-  choices: {
-    message: {
-      role: string;
-      content: string;
-    };
-  }[];
-  created: number;
-  model: string;
-  object: string;
-}
+export interface TogetherAIChatCompleteResponse extends ChatCompletionResponse {}
 
 export interface TogetherAIErrorResponse {
   model: string;
@@ -119,18 +108,26 @@ export const TogetherAIChatCompleteResponseTransform: (response: TogetherAIChatC
         created: response.created,
         model: response.model,
         provider: TOGETHER_AI,
-        choices: [
-          {
-            message: {"role": "assistant", content: response.choices[0]?.message.content},
+        choices: response.choices.map(choice => {
+          return {
+            message: {
+              role: "assistant",
+              content: choice.message.content,
+              tool_calls: choice.message.tool_calls ? choice.message.tool_calls.map((toolCall: any) => ({
+                id: toolCall.id,
+                type: toolCall.type,
+                function: toolCall.function
+              })) : null
+            },
             index: 0,
             logprobs: null,
-            finish_reason: "",
+            finish_reason: choice.finish_reason,
           }
-        ],
+        }),
         usage: {
-          prompt_tokens: -1,
-          completion_tokens: -1,
-          total_tokens: -1
+          prompt_tokens: response.usage?.prompt_tokens || -1,
+          completion_tokens: response.usage?.completion_tokens || -1,
+          total_tokens: response.usage?.total_tokens || -1
         }
       }
     }

--- a/src/providers/together-ai/complete.ts
+++ b/src/providers/together-ai/complete.ts
@@ -1,4 +1,6 @@
+import { TOGETHER_AI } from "../../globals";
 import { CompletionResponse, ErrorResponse, ProviderConfig } from "../types";
+import { TogetherAIErrorResponse } from "./chatComplete";
 
 export const TogetherAICompleteConfig: ProviderConfig = {
   model: {
@@ -52,13 +54,6 @@ interface TogetherAICompleteResponse {
   object: string;
 }
 
-interface TogetherAICompleteErrorResponse {
-  model: string;
-  job_id: string;
-  request_id: string;
-  error: string;
-}
-
 interface TogetherAICompletionStreamChunk {
   id: string;
   request_id: string;
@@ -67,7 +62,7 @@ interface TogetherAICompletionStreamChunk {
   }[];
 }
 
-export const TogetherAICompleteResponseTransform: (response: TogetherAICompleteResponse | TogetherAICompleteErrorResponse, responseStatus: number) => CompletionResponse | ErrorResponse = (response, responseStatus) => {
+export const TogetherAICompleteResponseTransform: (response: TogetherAICompleteResponse | TogetherAIErrorResponse, responseStatus: number) => CompletionResponse | ErrorResponse = (response, responseStatus) => {
     if (responseStatus !== 200) {
       return {
           error: {
@@ -76,7 +71,7 @@ export const TogetherAICompleteResponseTransform: (response: TogetherAICompleteR
               param: null,
               code: null
           },
-          provider: "together-ai"
+          provider: TOGETHER_AI
       } as ErrorResponse;
     } 
 
@@ -86,7 +81,7 @@ export const TogetherAICompleteResponseTransform: (response: TogetherAICompleteR
         object: response.object,
         created: response.created,
         model: response.model,
-        provider: "together-ai",
+        provider: TOGETHER_AI,
         choices: [
           {
             text: response.choices[0]?.text,
@@ -105,7 +100,7 @@ export const TogetherAICompleteResponseTransform: (response: TogetherAICompleteR
           param: null,
           code: null
       },
-      provider: "together-ai"
+      provider: TOGETHER_AI
     } as ErrorResponse;
   }
 
@@ -122,7 +117,7 @@ export const TogetherAICompleteStreamChunkTransform: (response: string) => strin
       object: "text_completion",
       created: Math.floor(Date.now() / 1000),
       model: "",
-      provider: "together-ai",
+      provider: TOGETHER_AI,
       choices: [
         {
           text: parsedChunk.choices[0]?.text,

--- a/src/providers/together-ai/embed.ts
+++ b/src/providers/together-ai/embed.ts
@@ -1,0 +1,71 @@
+import { TOGETHER_AI } from "../../globals";
+import { EmbedParams, EmbedResponse } from "../../types/embedRequestBody";
+import { ErrorResponse, ProviderConfig } from "../types";
+import { TogetherAIErrorResponse } from "./chatComplete";
+
+export const TogetherAIEmbedConfig: ProviderConfig = {
+    model: {
+        param: "model",
+        required: true,
+        default: "mistral-embed",
+    },
+    input: {
+        param: "input",
+        required: true,
+        transform: (params: EmbedParams) => {
+            if (Array.isArray(params.input)) {
+                return params.input;
+            }
+
+            return [params.input];
+        },
+    },
+};
+
+interface TogetherAIEmbedResponse extends EmbedResponse {}
+
+export const TogetherAIEmbedResponseTransform: (
+    response: TogetherAIEmbedResponse | TogetherAIErrorResponse,
+    responseStatus: number
+) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+    if ("error" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.error,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: TOGETHER_AI,
+        } as ErrorResponse;
+    }
+
+    if ("data" in response) {
+        return {
+            object: response.object,
+            data: response.data.map((d) => ({
+                object: d.object,
+                embedding: d.embedding,
+                index: d.index,
+            })),
+            model: response.model,
+            usage: {
+                prompt_tokens: 0,
+                total_tokens: 0,
+            },
+            provider: TOGETHER_AI,
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${TOGETHER_AI}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: TOGETHER_AI,
+    } as ErrorResponse;
+};

--- a/src/providers/together-ai/embed.ts
+++ b/src/providers/together-ai/embed.ts
@@ -1,7 +1,7 @@
 import { TOGETHER_AI } from "../../globals";
 import { EmbedParams, EmbedResponse } from "../../types/embedRequestBody";
 import { ErrorResponse, ProviderConfig } from "../types";
-import { TogetherAIErrorResponse } from "./chatComplete";
+import { TogetherAIErrorResponse, TogetherAIErrorResponseTransform } from "./chatComplete";
 
 export const TogetherAIEmbedConfig: ProviderConfig = {
     model: {
@@ -28,17 +28,10 @@ export const TogetherAIEmbedResponseTransform: (
     response: TogetherAIEmbedResponse | TogetherAIErrorResponse,
     responseStatus: number
 ) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
-    if ("error" in response && responseStatus !== 200) {
-        return {
-            error: {
-                message: response.error,
-                type: null,
-                param: null,
-                code: null,
-            },
-            provider: TOGETHER_AI,
-        } as ErrorResponse;
-    }
+    if (responseStatus !== 200 && !("data" in response) ) {
+        const errorResponse = TogetherAIErrorResponseTransform(response);
+        if (errorResponse) return errorResponse;
+      }
 
     if ("data" in response) {
         return {

--- a/src/providers/together-ai/index.ts
+++ b/src/providers/together-ai/index.ts
@@ -2,16 +2,19 @@ import { ProviderConfigs } from "../types";
 import TogetherAIApiConfig from "./api";
 import {TogetherAIChatCompleteConfig, TogetherAIChatCompleteResponseTransform, TogetherAIChatCompleteStreamChunkTransform } from "./chatComplete";
 import { TogetherAICompleteConfig, TogetherAICompleteResponseTransform, TogetherAICompleteStreamChunkTransform } from "./complete";
+import { TogetherAIEmbedConfig, TogetherAIEmbedResponseTransform } from "./embed";
 
 const TogetherAIConfig: ProviderConfigs = {
   complete: TogetherAICompleteConfig,
   chatComplete: TogetherAIChatCompleteConfig,
+  embed: TogetherAIEmbedConfig,
   api: TogetherAIApiConfig,
   responseTransforms: {
     'stream-complete': TogetherAICompleteStreamChunkTransform,
     'complete': TogetherAICompleteResponseTransform,
     'chatComplete': TogetherAIChatCompleteResponseTransform,
-    'stream-chatComplete': TogetherAIChatCompleteStreamChunkTransform
+    'stream-chatComplete': TogetherAIChatCompleteStreamChunkTransform,
+    'embed': TogetherAIEmbedResponseTransform
   }
 };
 


### PR DESCRIPTION
**Title:** 
- together-ai embedding, tools and updated schema

**Description:** (optional)
- Add support for tools and tool_choice for together-ai chat completions.
- Add embeddings route support for together-ai.
- Update response transformers for chat and completions for together-ai with their latest changes.

**Motivation:** (optional)
- Making all the latest together-ai changes available in gateway

NOTE: together-ai `function call streaming` cannot be transformed into OpenAI compatible stream chunks as it sends the whole tool call response as separate chunks instead of sending name first and then sending arguments incrementally. Once they change this behaviour, we can accommodate the same in gateway as well 

**Related Issues:** (optional)
- Closes #190 
