### PR TITLE
feat: add anyscale validation error response transformer

### DIFF
--- a/src/providers/anyscale/chatComplete.ts
+++ b/src/providers/anyscale/chatComplete.ts
@@ -194,7 +194,7 @@ export const AnyscaleChatCompleteResponseTransform: (response: AnyscaleChatCompl
       object: parsedChunk.object,
       created: parsedChunk.created,
       model: parsedChunk.model,
-      provider: "anyscale",
+      provider: ANYSCALE,
       choices: parsedChunk.choices
     })}` + '\n\n'
   };

--- a/src/providers/anyscale/chatComplete.ts
+++ b/src/providers/anyscale/chatComplete.ts
@@ -71,6 +71,13 @@ export const AnyscaleChatCompleteConfig: ProviderConfig = {
   },
   response_format: {
     param: "response_format"
+  },
+  logprobs: {
+    param: "logprobs",
+    default: false
+  },
+  top_logprobs: {
+    param: "top_logprobs"
   }
 };
 

--- a/src/providers/anyscale/chatComplete.ts
+++ b/src/providers/anyscale/chatComplete.ts
@@ -1,3 +1,4 @@
+import { ANYSCALE } from "../../globals";
 import { ChatCompletionResponse, ErrorResponse, ProviderConfig } from "../types";
 
 // TODOS: this configuration does not enforce the maximum token limit for the input parameter. If you want to enforce this, you might need to add a custom validation function or a max property to the ParameterConfig interface, and then use it in the input configuration. However, this might be complex because the token count is not a simple length check, but depends on the specific tokenization method used by the model.
@@ -73,7 +74,17 @@ export const AnyscaleChatCompleteConfig: ProviderConfig = {
   }
 };
 
-export interface AnyscaleChatCompleteResponse extends ChatCompletionResponse, ErrorResponse {}
+export interface AnyscaleChatCompleteResponse extends ChatCompletionResponse {}
+
+export interface AnyscaleValidationErrorResponse {
+    detail: {
+        loc: Array<any>;
+        msg: string;
+        type: string;
+    }[];
+}
+
+export interface AnyscaleErrorResponse extends ErrorResponse {}
 
 export interface AnyscaleStreamChunk {
     id: string;
@@ -89,8 +100,43 @@ export interface AnyscaleStreamChunk {
     }[]
 }
 
-export const AnyscaleChatCompleteResponseTransform: (response: AnyscaleChatCompleteResponse, responseStatus: number) => ChatCompletionResponse | ErrorResponse = (response, responseStatus) => {
-    if (responseStatus !== 200) {
+export const AnyscaleValidationErrorResponseTransform: (response: AnyscaleValidationErrorResponse) => ErrorResponse = (response) => {
+  let firstError: Record<string, any> | undefined;
+  let errorField: string | null = null;
+  let errorMessage: string | undefined;
+  let errorType: string | null = null;
+
+  if (Array.isArray(response.detail)) {
+    [firstError] = response.detail;
+    errorField = firstError?.loc?.join(".") ?? "";
+    errorMessage = firstError.msg;
+    errorType = firstError.type;
+  } else {
+    errorMessage = response.detail;
+  }
+
+  return {
+    error: {
+      message: `${errorField ? `${errorField}: ` : ""}${errorMessage}`,
+      type: errorType,
+      param: null,
+      code: null,
+    },
+    provider: ANYSCALE,
+  } as ErrorResponse;
+}
+
+export const AnyscaleChatCompleteResponseTransform: (response: AnyscaleChatCompleteResponse | AnyscaleErrorResponse | AnyscaleValidationErrorResponse, responseStatus: number) => ChatCompletionResponse | ErrorResponse = (response, responseStatus) => {
+    if (
+      "detail" in response &&
+      responseStatus !== 200 &&
+      response.detail.length
+    ) {
+      return AnyscaleValidationErrorResponseTransform(response);
+    }
+      
+
+    if ('error' in response && responseStatus !== 200) {
       return {
           error: {
               message: response.error?.message,
@@ -98,19 +144,33 @@ export const AnyscaleChatCompleteResponseTransform: (response: AnyscaleChatCompl
               param: null,
               code: null
           },
-          provider: "anyscale"
+          provider: ANYSCALE
       } as ErrorResponse;
     } 
-  
-    return {
-      id: response.id,
-      object: response.object,
-      created: response.created,
-      model: response.model,
-      provider: "anyscale",
-      choices: response.choices,
-      usage: response.usage
+    
+    if ('choices' in response) {
+      return {
+        id: response.id,
+        object: response.object,
+        created: response.created,
+        model: response.model,
+        provider: ANYSCALE,
+        choices: response.choices,
+        usage: response.usage
+      }
     }
+
+    return {
+      error: {
+        message: `Invalid response recieved from ${ANYSCALE}: ${JSON.stringify(
+          response
+        )}`,
+        type: null,
+        param: null,
+        code: null,
+      },
+      provider: ANYSCALE,
+    } as ErrorResponse;
   }
     
   

--- a/src/providers/anyscale/complete.ts
+++ b/src/providers/anyscale/complete.ts
@@ -142,7 +142,7 @@ export const AnyscaleCompleteStreamChunkTransform: (response: string) => string 
       object: parsedChunk.object,
       created: parsedChunk.created,
       model: parsedChunk.model,
-      provider: "anyscale",
+      provider: ANYSCALE,
       choices: parsedChunk.choices
     })}` + '\n\n'
   };

--- a/src/providers/anyscale/embed.ts
+++ b/src/providers/anyscale/embed.ts
@@ -1,5 +1,7 @@
+import { ANYSCALE } from "../../globals";
 import { EmbedResponse } from "../../types/embedRequestBody";
 import { ErrorResponse, ProviderConfig } from "../types";
+import { AnyscaleErrorResponse, AnyscaleValidationErrorResponse, AnyscaleValidationErrorResponseTransform } from "./chatComplete";
 
 export const AnyscaleEmbedConfig: ProviderConfig = {
   model: {
@@ -16,11 +18,20 @@ export const AnyscaleEmbedConfig: ProviderConfig = {
   }
 };
 
-export interface AnyscaleEmbedResponse extends EmbedResponse, ErrorResponse {}
+export interface AnyscaleEmbedResponse extends EmbedResponse {}
 
 
-export const AnyscaleEmbedResponseTransform: (response: AnyscaleEmbedResponse, responseStatus: number) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
-    if (responseStatus !== 200) {
+export const AnyscaleEmbedResponseTransform: (response: AnyscaleEmbedResponse | AnyscaleErrorResponse | AnyscaleValidationErrorResponse, responseStatus: number) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+    if (
+      "detail" in response &&
+      responseStatus !== 200 &&
+      response.detail.length
+    ) {
+      return AnyscaleValidationErrorResponseTransform(response);
+    }
+      
+
+    if ('error' in response && responseStatus !== 200) {
       return {
           error: {
               message: response.error?.message,
@@ -28,14 +39,28 @@ export const AnyscaleEmbedResponseTransform: (response: AnyscaleEmbedResponse, r
               param: null,
               code: null
           },
-          provider: "anyscale"
+          provider: ANYSCALE
       } as ErrorResponse;
     } 
-  
-    return {
+    
+    if ('data' in response) {
+      return {
         object: response.object,
         data: response.data,
         model: response.model,
         usage: response.usage,
       }
+    }
+
+    return {
+      error: {
+        message: `Invalid response recieved from ${ANYSCALE}: ${JSON.stringify(
+          response
+        )}`,
+        type: null,
+        param: null,
+        code: null,
+      },
+      provider: ANYSCALE,
+    } as ErrorResponse;
   }


### PR DESCRIPTION
**Title:** 
- add anyscale validation error response transformer

**Description:** (optional)
- Add transformer to map anyscale 400 error response structure for chat, completions and embeddings. Sample 400 status code response example:
```json
{
    "detail": [
        {
            "loc": [
                "body",
                "model"
            ],
            "msg": "field required",
            "type": "value_error.missing"
        }
    ]
}
```
- Separate out interfaces for anyscale to have separate interface for error and success response. 

**Motivation:** (optional)
- To stay up-to-date with anyscale release

**Related Issues:** (optional)
- Closes #191 
