### PR TITLE
Fix: cache settings

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -220,13 +220,14 @@ export async function tryPostProxy(c: Context, providerOption:Options, inputPara
   const cacheIdentifier = c.get('cacheIdentifier');
   const requestOptions = c.get('requestOptions') ?? [];
 
-  let cacheResponse, cacheKey, cacheMode;
+  let cacheResponse, cacheKey, cacheMode, cacheMaxAge;
   let cacheStatus = "DISABLED";
 
   if (requestHeaders[HEADER_KEYS.CACHE]) {
-    cacheMode = requestHeaders[HEADER_KEYS.CACHE]
+    cacheMode = requestHeaders[HEADER_KEYS.CACHE];
   } else if (providerOption?.cache && typeof providerOption.cache === "object" && providerOption.cache.mode) {
     cacheMode = providerOption.cache.mode;
+    cacheMaxAge = providerOption.cache.maxAge;
   } else if (providerOption?.cache && typeof providerOption.cache === "string") {
     cacheMode = providerOption.cache
   }
@@ -251,7 +252,8 @@ export async function tryPostProxy(c: Context, providerOption:Options, inputPara
         cacheStatus: cacheStatus,
         lastUsedOptionIndex: currentIndex,
         cacheKey: cacheKey,
-        cacheMode: cacheMode
+        cacheMode: cacheMode,
+        cacheMaxAge: cacheMaxAge
       }])
       updateResponseHeaders(response, currentIndex, params, cacheStatus, 0, requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
       return response;
@@ -356,11 +358,12 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
       c.get("requestOptions") ?? [],
   ];
 
-  let cacheResponse, cacheKey, cacheMode;
+  let cacheResponse, cacheKey, cacheMode, cacheMaxAge;
   let cacheStatus = "DISABLED";
 
   if (typeof providerOption.cache === "object" && providerOption.cache?.mode) {
     cacheMode = providerOption.cache.mode;
+    cacheMaxAge = providerOption.cache.maxAge;
   } else if (typeof providerOption.cache === "string") {
     cacheMode = providerOption.cache
   }
@@ -423,7 +426,8 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
     cacheStatus: cacheStatus,
     lastUsedOptionIndex: currentIndex,
     cacheKey: cacheKey,
-    cacheMode: cacheMode
+    cacheMode: cacheMode,
+    cacheMaxAge: cacheMaxAge
   }])
   // If the response was not ok, throw an error
   if (!response.ok) {

--- a/src/handlers/proxyHandler.ts
+++ b/src/handlers/proxyHandler.ts
@@ -159,7 +159,7 @@ export async function proxyHandler(c: Context): Promise<Response> {
 
     if (requestConfig?.cache && typeof requestConfig.cache === "object" && requestConfig.cache.mode) {
       cacheMode = requestConfig.cache.mode;
-      cacheMaxAge = requestConfig.cache.maxAge;
+      cacheMaxAge = requestConfig.cache.max_age;
     } else if (requestConfig?.cache && typeof requestConfig.cache === "string") {
       cacheMode = requestConfig.cache
     }

--- a/src/handlers/proxyHandler.ts
+++ b/src/handlers/proxyHandler.ts
@@ -3,7 +3,7 @@ import { retryRequest } from "./retryHandler";
 import Providers from "../providers";
 import { ANTHROPIC, MAX_RETRIES, HEADER_KEYS, RETRY_STATUS_CODES, POWERED_BY, RESPONSE_HEADER_KEYS, AZURE_OPEN_AI, CONTENT_TYPES } from "../globals";
 import { fetchProviderOptionsFromConfig, responseHandler, tryProvidersInSequence, updateResponseHeaders } from "./handlerUtils";
-import { getStreamingMode } from "../utils";
+import { convertKeysToCamelCase, getStreamingMode } from "../utils";
 import { Config, ShortConfig } from "../types/requestBody";
 import { env } from "hono/adapter"
 // Find the proxy provider
@@ -133,6 +133,10 @@ export async function proxyHandler(c: Context): Promise<Response> {
       }
     }
 
+    if (requestConfig) {
+      requestConfig  = convertKeysToCamelCase(requestConfig as Record<string, any>, ["override_params", "params", "metadata"]) as Config | ShortConfig;
+    }
+
     let fetchOptions = {
         headers: headersToSend(requestHeaders, store.customHeadersToAvoid),
         method: c.req.method,
@@ -159,7 +163,7 @@ export async function proxyHandler(c: Context): Promise<Response> {
 
     if (requestConfig?.cache && typeof requestConfig.cache === "object" && requestConfig.cache.mode) {
       cacheMode = requestConfig.cache.mode;
-      cacheMaxAge = requestConfig.cache.max_age;
+      cacheMaxAge = requestConfig.cache.maxAge;
     } else if (requestConfig?.cache && typeof requestConfig.cache === "string") {
       cacheMode = requestConfig.cache
     }

--- a/src/handlers/proxyHandler.ts
+++ b/src/handlers/proxyHandler.ts
@@ -153,12 +153,13 @@ export async function proxyHandler(c: Context): Promise<Response> {
     const getFromCacheFunction = c.get('getFromCache');
     const cacheIdentifier = c.get('cacheIdentifier');
 
-    let cacheResponse, cacheKey;
+    let cacheResponse, cacheKey, cacheMaxAge;
     let cacheStatus = "DISABLED";
     let cacheMode = requestHeaders[HEADER_KEYS.CACHE];
 
     if (requestConfig?.cache && typeof requestConfig.cache === "object" && requestConfig.cache.mode) {
       cacheMode = requestConfig.cache.mode;
+      cacheMaxAge = requestConfig.cache.maxAge;
     } else if (requestConfig?.cache && typeof requestConfig.cache === "string") {
       cacheMode = requestConfig.cache
     }
@@ -193,7 +194,8 @@ export async function proxyHandler(c: Context): Promise<Response> {
       response: mappedResponse.clone(),
       cacheStatus: cacheStatus,
       cacheKey: cacheKey,
-      cacheMode: cacheMode
+      cacheMode: cacheMode,
+      cacheMaxAge: cacheMaxAge
     }])
 
     return mappedResponse;

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -12,6 +12,7 @@ interface RetrySettings {
 interface CacheSettings {
   mode: string;
   maxAge?: number;
+  max_age?: number;
 }
 
 interface Strategy {

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -12,7 +12,6 @@ interface RetrySettings {
 interface CacheSettings {
   mode: string;
   maxAge?: number;
-  max_age?: number;
 }
 
 interface Strategy {


### PR DESCRIPTION
**Title:** 
- fix cache settings behaviour

**Description:** (optional)
- Fetch cache max_age from config and pass it to downstream functions

**Motivation:** (optional)
- To avoid any unintended expiry for cached records.

**Related Issues:** (optional)
- Fixes #201 
