### PR TITLE
fix: pass cache max age in get from cache call

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -239,7 +239,8 @@ export async function tryPostProxy(c: Context, providerOption:Options, inputPara
         params,
         url,
         cacheIdentifier,
-        cacheMode
+        cacheMode,
+        cacheMaxAge
     );
     if (cacheResponse) {
       response = await responseHandler(new Response(cacheResponse, {headers: {
@@ -375,7 +376,8 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
           transformedRequestBody,
           fn,
           cacheIdentifier,
-          cacheMode
+          cacheMode,
+          cacheMaxAge
       );
       if (cacheResponse) {
           response = await responseHandler(

--- a/src/handlers/proxyHandler.ts
+++ b/src/handlers/proxyHandler.ts
@@ -180,7 +180,8 @@ export async function proxyHandler(c: Context): Promise<Response> {
           response: cacheMappedResponse.clone(),
           cacheStatus: cacheStatus,
           cacheKey: cacheKey,
-          cacheMode: cacheMode
+          cacheMode: cacheMode,
+          cacheMaxAge: cacheMaxAge
         }])
         updateResponseHeaders(cacheMappedResponse, 0, store.reqBody, cacheStatus, 0, requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
         return cacheMappedResponse;


### PR DESCRIPTION
**Title:** 
- pass cache max age in get from cache call

**Related Issues:** (optional)
- Closes #201 
