### PR TITLE
fix: set retry randomize to false

### DIFF
--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -93,6 +93,7 @@ export const retryRequest = async (
         lastAttempt = attempt;
         console.warn(`Failed in Retry attempt ${attempt}. Error: ${error}`);
       },
+      randomize: false
     }
     );
   } catch (error: any) {


### PR DESCRIPTION
**Title:** 
- Set retry randomize flag to false

**Description:** (optional)
- Set `randomize: false` in async-retry settings

**Motivation:** (optional)
- To avoid random retry timeout patterns

**Related Issues:** (optional)
- Closes #205 
