### PR TITLE
Fix: audio and octet stream response

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -44,5 +44,6 @@ export const CONTENT_TYPES = {
   MULTIPART_FORM_DATA: "multipart/form-data",
   EVENT_STREAM: "text/event-stream",
   AUDIO_MPEG: "audio/mpeg",
-  APPLICATION_OCTET_STREAM: "application/octet-stream"
+  APPLICATION_OCTET_STREAM: "application/octet-stream",
+  GENERIC_AUDIO_PATTERN: "audio"
 }

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -519,7 +519,7 @@ export function responseHandler(response: Response, streamingMode: boolean, prox
       return handleJSONToStreamResponse(response, proxyProvider, responseTransformerFunction)
   } else if (streamingMode && response.status === 200) {
     return handleStreamingMode(response, proxyProvider, responseTransformerFunction, requestURL)
-  } else if (responseContentType === CONTENT_TYPES.AUDIO_MPEG) {
+  } else if (responseContentType?.startsWith(CONTENT_TYPES.GENERIC_AUDIO_PATTERN)) {
       return handleAudioResponse(response)
   } else if (responseContentType === CONTENT_TYPES.APPLICATION_OCTET_STREAM) {
       return handleOctetStreamResponse(response)

--- a/src/handlers/streamHandler.ts
+++ b/src/handlers/streamHandler.ts
@@ -71,11 +71,11 @@ export async function handleNonStreamingMode(response: Response, responseTransfo
 }
 
 export async function handleAudioResponse(response: Response) {
-    return new Response(JSON.stringify(response.body), response);
+    return new Response(response.body, response);
 }
 
 export async function handleOctetStreamResponse(response: Response) {
-    return new Response(JSON.stringify(response.body), response);
+    return new Response(response.body, response);
 }
 
 


### PR DESCRIPTION
**Title:** 
- Fix: audio and octet stream response 

**Description:** (optional)
- Replace the hardcoded audio/mpeg content type check to a broader startsWith audio check to handle other audio response types.
- Remove JSON.stringify() from audio and octet stream response handler

**Motivation:** (optional)
- To fix audio and octet stream response 

**Related Issues:** (optional)
- Closes #209 