### PR TITLE
docs: add deploy to Zeabur guide

### DIFF
--- a/docs/installation-deployments.md
+++ b/docs/installation-deployments.md
@@ -56,6 +56,12 @@ docker compose up -d
 ```
 3. The service is now running and listening on port 8787
 
+# Deploy to Zeabur
+
+Click on the button below to deploy.
+
+[![Deploy on Zeabur](https://zeabur.com/button.svg)](https://zeabur.com/templates/RU38E3)
+
 # Deploy to Vercel
 Docs to be written, please help!
 


### PR DESCRIPTION
**Title:** 
- Add deploy to Zeabur guide.

**Description:** (optional)
- Zeabur is a platform for deploying services easily. I've made a template for everyone to deploy Gateway with one click on Zeabur. Below is the successful deployment.

![ai-gateway-running-demo](https://github.com/Portkey-AI/gateway/assets/63531512/dcdcab7c-14e3-4b27-b2f2-bd4ecb8cd24b)
<img width="1512" alt="image" src="https://github.com/Portkey-AI/gateway/assets/63531512/8ba43428-a1fd-49db-9de1-73533f6a3529">


**Motivation:** (optional)
- I just saw that you need help with the self host documentations so I added deploy to Zeabur tutorial into the list

**Related Issues:** (optional)
- #issue-number

