### PR TITLE
fix: add issue write permission to triage action

### DIFF
--- a/.github/workflows/triage-label.yml
+++ b/.github/workflows/triage-label.yml
@@ -7,6 +7,10 @@ on:
 jobs:
   label_issues:
     runs-on: ubuntu-latest
+
+    permissions:
+      issues: write
+
     steps:
       - uses: actions/checkout@v4.1.1
       - name: Add Triage Label


### PR DESCRIPTION
**Title:** 
- add issue write permission to triage action

**Description:** (optional)
- Add `issue: write` permission for triage labelling job

**Motivation:** (optional)
- Allow github action to add triage label to new issues

**Related Issues:** (optional)
- Fixes #214 
