### PR TITLE
Feat/aws bedrock integration

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,9 @@
       "version": "1.0.6",
       "license": "MIT",
       "dependencies": {
+        "@aws-crypto/sha256-js": "^5.2.0",
         "@hono/node-server": "^1.3.3",
+        "@smithy/signature-v4": "^2.1.1",
         "async-retry": "^1.3.3",
         "hono": "^3.12.0",
         "zod": "^3.22.4"
@@ -27,6 +29,74 @@
         "rollup": "^4.9.1",
         "tsx": "^4.7.0",
         "wrangler": "^3.0.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/crc32/-/crc32-3.0.0.tgz",
+      "integrity": "sha512-IzSgsrxUcsrejQbPVilIKy16kAT52EwB6zSaI+M3xxIhKh5+aldEyvI+z6erM7TCLB2BJsFrtHjp6/4/sr+3dA==",
+      "dependencies": {
+        "@aws-crypto/util": "^3.0.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/@aws-crypto/util": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+      "integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@aws-sdk/util-utf8-browser": "^3.0.0",
+        "tslib": "^1.11.1"
+      }
+    },
+    "node_modules/@aws-crypto/crc32/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
+    "node_modules/@aws-crypto/sha256-js": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-5.2.0.tgz",
+      "integrity": "sha512-FFQQyu7edu4ufvIZ+OadFpHHOt+eSTBaYaki44c+akjg7qZg9oOQeLlk77F6tSYqjDAFClrHJk9tMf0HdVyOvA==",
+      "dependencies": {
+        "@aws-crypto/util": "^5.2.0",
+        "@aws-sdk/types": "^3.222.0",
+        "tslib": "^2.6.2"
+      },
+      "engines": {
+        "node": ">=16.0.0"
+      }
+    },
+    "node_modules/@aws-crypto/util": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-5.2.0.tgz",
+      "integrity": "sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==",
+      "dependencies": {
+        "@aws-sdk/types": "^3.222.0",
+        "@smithy/util-utf8": "^2.0.0",
+        "tslib": "^2.6.2"
+      }
+    },
+    "node_modules/@aws-sdk/types": {
+      "version": "3.515.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.515.0.tgz",
+      "integrity": "sha512-B3gUpiMlpT6ERaLvZZ61D0RyrQPsFYDkCncLPVkZOKkCOoFU46zi1o6T5JcYiz8vkx1q9RGloQ5exh79s5pU/w==",
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@aws-sdk/util-utf8-browser": {
+      "version": "3.259.0",
+      "resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+      "integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+      "dependencies": {
+        "tslib": "^2.3.1"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
@@ -824,6 +894,115 @@
       "os": [
         "win32"
       ]
+    },
+    "node_modules/@smithy/eventstream-codec": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/eventstream-codec/-/eventstream-codec-2.1.1.tgz",
+      "integrity": "sha512-E8KYBxBIuU4c+zrpR22VsVrOPoEDzk35bQR3E+xm4k6Pa6JqzkDOdMyf9Atac5GPNKHJBdVaQ4JtjdWX2rl/nw==",
+      "dependencies": {
+        "@aws-crypto/crc32": "3.0.0",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "tslib": "^2.5.0"
+      }
+    },
+    "node_modules/@smithy/is-array-buffer": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/is-array-buffer/-/is-array-buffer-2.1.1.tgz",
+      "integrity": "sha512-xozSQrcUinPpNPNPds4S7z/FakDTh1MZWtRP/2vQtYB/u3HYrX2UXuZs+VhaKBd6Vc7g2XPr2ZtwGBNDN6fNKQ==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/signature-v4": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/signature-v4/-/signature-v4-2.1.1.tgz",
+      "integrity": "sha512-Hb7xub0NHuvvQD3YwDSdanBmYukoEkhqBjqoxo+bSdC0ryV9cTfgmNjuAQhTPYB6yeU7hTR+sPRiFMlxqv6kmg==",
+      "dependencies": {
+        "@smithy/eventstream-codec": "^2.1.1",
+        "@smithy/is-array-buffer": "^2.1.1",
+        "@smithy/types": "^2.9.1",
+        "@smithy/util-hex-encoding": "^2.1.1",
+        "@smithy/util-middleware": "^2.1.1",
+        "@smithy/util-uri-escape": "^2.1.1",
+        "@smithy/util-utf8": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/types": {
+      "version": "2.9.1",
+      "resolved": "https://registry.npmjs.org/@smithy/types/-/types-2.9.1.tgz",
+      "integrity": "sha512-vjXlKNXyprDYDuJ7UW5iobdmyDm6g8dDG+BFUncAg/3XJaN45Gy5RWWWUVgrzIK7S4R1KWgIX5LeJcfvSI24bw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-buffer-from": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-buffer-from/-/util-buffer-from-2.1.1.tgz",
+      "integrity": "sha512-clhNjbyfqIv9Md2Mg6FffGVrJxw7bgK7s3Iax36xnfVj6cg0fUG7I4RH0XgXJF8bxi+saY5HR21g2UPKSxVCXg==",
+      "dependencies": {
+        "@smithy/is-array-buffer": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-hex-encoding": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-hex-encoding/-/util-hex-encoding-2.1.1.tgz",
+      "integrity": "sha512-3UNdP2pkYUUBGEXzQI9ODTDK+Tcu1BlCyDBaRHwyxhA+8xLP8agEKQq4MGmpjqb4VQAjq9TwlCQX0kP6XDKYLg==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-middleware": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-middleware/-/util-middleware-2.1.1.tgz",
+      "integrity": "sha512-mKNrk8oz5zqkNcbcgAAepeJbmfUW6ogrT2Z2gDbIUzVzNAHKJQTYmH9jcy0jbWb+m7ubrvXKb6uMjkSgAqqsFA==",
+      "dependencies": {
+        "@smithy/types": "^2.9.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-uri-escape": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-uri-escape/-/util-uri-escape-2.1.1.tgz",
+      "integrity": "sha512-saVzI1h6iRBUVSqtnlOnc9ssU09ypo7n+shdQ8hBTZno/9rZ3AuRYvoHInV57VF7Qn7B+pFJG7qTzFiHxWlWBw==",
+      "dependencies": {
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@smithy/util-utf8": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/@smithy/util-utf8/-/util-utf8-2.1.1.tgz",
+      "integrity": "sha512-BqTpzYEcUMDwAKr7/mVRUtHDhs6ZoXDi9NypMvMfOr/+u1NW7JgqodPDECiiLboEm6bobcPcECxzjtQh865e9A==",
+      "dependencies": {
+        "@smithy/util-buffer-from": "^2.1.1",
+        "tslib": "^2.5.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
     },
     "node_modules/@types/async-retry": {
       "version": "1.4.5",
@@ -2093,10 +2272,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "2.5.3",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.3.tgz",
-      "integrity": "sha512-mSxlJJwl3BMEQCUNnxXBU9jP4JBktcEGhURcPR6VQVlnP0FdDEsIaz0C35dXNGLyRfrATNofF0F5p2KPxQgB+w==",
-      "dev": true
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.2.tgz",
+      "integrity": "sha512-AEYxH93jGFPn/a2iVAwW87VuUIkR1FVUKB77NwMF7nBTDkDrrT/Hpt/IrCJ0QXhW27jTBDcf5ZY7w6RiqTMw2Q=="
     },
     "node_modules/tsx": {
       "version": "4.7.0",

--- a/package.json
+++ b/package.json
@@ -33,7 +33,9 @@
     "start:node": "node build/start-server.js"
   },
   "dependencies": {
+    "@aws-crypto/sha256-js": "^5.2.0",
     "@hono/node-server": "^1.3.3",
+    "@smithy/signature-v4": "^2.1.1",
     "async-retry": "^1.3.3",
     "hono": "^3.12.0",
     "zod": "^3.22.4"

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -37,6 +37,7 @@ export const STABILITY_AI: string = "stability-ai";
 export const NOMIC: string = "nomic";
 export const OLLAMA: string = "ollama";
 export const AI21: string = "ai21";
+export const BEDROCK: string = "bedrock";
 
 export const providersWithStreamingSupport = [OPEN_AI, AZURE_OPEN_AI, ANTHROPIC, COHERE];
 export const allowedProxyProviders = [OPEN_AI, COHERE, AZURE_OPEN_AI, ANTHROPIC];

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -389,7 +389,7 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
     baseUrl = baseUrl;
     endpoint = apiConfig.getEndpoint(fn, providerOption.apiKey, transformedRequestBody.model, params.stream);
   } else if (provider === BEDROCK && apiConfig.getBaseURL && apiConfig.getEndpoint) {
-    baseUrl = baseUrl || apiConfig.getBaseURL();
+    baseUrl = baseUrl || apiConfig.getBaseURL(providerOption.awsRegion);
     endpoint = apiConfig.getEndpoint(fn, params.model, params.stream);
     fetchOptions = constructRequest(await apiConfig.headers(providerOption, transformedRequestBody, `${baseUrl}${endpoint}`), provider, "POST", forwardHeaders, requestHeaders);
   } else if (provider === AI21 && apiConfig.getEndpoint && apiConfig.baseURL) {

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -1,5 +1,5 @@
 import { Context } from "hono";
-import { AI21, ANTHROPIC, AZURE_OPEN_AI, CONTENT_TYPES, GOOGLE, HEADER_KEYS, OLLAMA, PALM, POWERED_BY, RESPONSE_HEADER_KEYS, RETRY_STATUS_CODES, STABILITY_AI } from "../globals";
+import { AI21, ANTHROPIC, AZURE_OPEN_AI, BEDROCK, CONTENT_TYPES, GOOGLE, HEADER_KEYS, OLLAMA, PALM, POWERED_BY, RESPONSE_HEADER_KEYS, RETRY_STATUS_CODES, STABILITY_AI } from "../globals";
 import Providers from "../providers";
 import { ProviderAPIConfig, endpointStrings } from "../providers/types";
 import transformToProviderRequest from "../services/transformToProviderRequest";
@@ -270,9 +270,19 @@ export async function tryPostProxy(c: Context, providerOption:Options, inputPara
         cacheMaxAge
     );
     if (cacheResponse) {
-      response = await responseHandler(new Response(cacheResponse, {headers: {
-        "content-type": "application/json"
-      }}), false, provider, undefined, url);
+      response = await responseHandler(
+          new Response(cacheResponse, {
+              headers: {
+                  "content-type": "application/json",
+              },
+          }),
+          false,
+          provider,
+          undefined,
+          url,
+          false,
+          params
+      );
       c.set("requestOptions", [...requestOptions, {
         providerOptions: {...providerOption, requestURL: url, rubeusURL: fn},
         requestParams: params,
@@ -289,7 +299,15 @@ export async function tryPostProxy(c: Context, providerOption:Options, inputPara
   }
 
     [response, retryCount] = await retryRequest(url, fetchOptions, providerOption.retry.attempts, providerOption.retry.onStatusCodes, null);
-  const mappedResponse = await responseHandler(response, isStreamingMode, provider, undefined, url);
+  const mappedResponse = await responseHandler(
+      response,
+      isStreamingMode,
+      provider,
+      undefined,
+      url,
+      false,
+      params
+  );
   updateResponseHeaders(mappedResponse, currentIndex, params, cacheStatus, retryCount ?? 0, requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
 
   c.set("requestOptions", [...requestOptions, {
@@ -370,6 +388,10 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
     fetchOptions = constructRequest(apiConfig.headers(), provider, "POST", forwardHeaders, requestHeaders);
     baseUrl = baseUrl;
     endpoint = apiConfig.getEndpoint(fn, providerOption.apiKey, transformedRequestBody.model, params.stream);
+  } else if (provider === BEDROCK && apiConfig.getBaseURL && apiConfig.getEndpoint) {
+    baseUrl = baseUrl || apiConfig.getBaseURL();
+    endpoint = apiConfig.getEndpoint(fn, params.model, params.stream);
+    fetchOptions = constructRequest(await apiConfig.headers(providerOption, transformedRequestBody, `${baseUrl}${endpoint}`), provider, "POST", forwardHeaders, requestHeaders);
   } else if (provider === AI21 && apiConfig.getEndpoint && apiConfig.baseURL) {
     baseUrl = baseUrl || apiConfig.baseURL;
     endpoint = apiConfig.getEndpoint(fn, params.model);
@@ -428,7 +450,8 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
               provider,
               fn,
               url,
-              true
+              true,
+              params
           );
           c.set("requestOptions", [
               ...requestOptions,
@@ -461,7 +484,15 @@ export async function tryPost(c: Context, providerOption:Options, inputParams: P
 
   [response, retryCount] = await retryRequest(url, fetchOptions, providerOption.retry.attempts, providerOption.retry.onStatusCodes, providerOption.requestTimeout || null);
 
-  const mappedResponse = await responseHandler(response, isStreamingMode, provider, fn, url);
+  const mappedResponse = await responseHandler(
+      response,
+      isStreamingMode,
+      provider,
+      fn,
+      url,
+      false,
+      params
+  );
   updateResponseHeaders(mappedResponse, currentIndex, params, cacheStatus, retryCount ?? 0, requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
   c.set("requestOptions", [...requestOptions, {
     providerOptions: {...providerOption, requestURL: url, rubeusURL: fn},
@@ -530,15 +561,22 @@ export async function tryProvidersInSequence(c: Context, providers:Options[], pa
  * @param {boolean} [isCacheHit=false] - Indicates whether the response is a cache hit.
  * @returns {Promise<Response>} - A promise that resolves to the processed response.
  */
-export function responseHandler(response: Response, streamingMode: boolean, proxyProvider: string, responseTransformer: string | undefined, requestURL: string, isCacheHit: boolean = false): Promise<Response> {
+export function responseHandler(response: Response, streamingMode: boolean, proxyProvider: string, responseTransformer: string | undefined, requestURL: string, isCacheHit: boolean = false, gatewayRequest: Params): Promise<Response> {
   let responseTransformerFunction: Function | undefined;
   const responseContentType = response.headers?.get("content-type");
 
+  const providerConfig = Providers[proxyProvider];
+  let providerTransformers = Providers[proxyProvider]?.responseTransforms;
+
+  if (providerConfig.getConfig) {
+    providerTransformers = providerConfig.getConfig(gatewayRequest).responseTransforms;
+  }
+
   // Checking status 200 so that errors are not considered as stream mode.
   if (responseTransformer && streamingMode && response.status === 200) {
-    responseTransformerFunction = Providers[proxyProvider]?.responseTransforms?.[`stream-${responseTransformer}`];
+    responseTransformerFunction = providerTransformers?.[`stream-${responseTransformer}`];
   } else if (responseTransformer) {
-    responseTransformerFunction = Providers[proxyProvider]?.responseTransforms?.[responseTransformer];
+    responseTransformerFunction = providerTransformers?.[responseTransformer];
   }
 
   // JSON to text/event-stream conversion is only allowed for unified routes: chat completions and completions.
@@ -754,6 +792,13 @@ export function constructConfigFromRequestHeaders(
       apiVersion: requestHeaders[`x-${POWERED_BY}-azure-api-version`]
     }
 
+    const bedrockConfig = {
+      awsAccessKeyId: requestHeaders[`x-${POWERED_BY}-aws-access-key-id`],
+      awsSecretAccessKey: requestHeaders[`x-${POWERED_BY}-aws-secret-access-key`],
+      awsSessionToken: requestHeaders[`x-${POWERED_BY}-aws-session-token`],
+      awsRegion: requestHeaders[`x-${POWERED_BY}-aws-region`]
+    }
+
     if (
       requestHeaders[`x-${POWERED_BY}-config`]
     ) {
@@ -762,12 +807,21 @@ export function constructConfigFromRequestHeaders(
         if (!parsedConfigJson.provider && !parsedConfigJson.targets) {
           parsedConfigJson.provider = requestHeaders[`x-${POWERED_BY}-provider`];
           parsedConfigJson.api_key = requestHeaders["authorization"]?.replace("Bearer ", "");
+
           if (parsedConfigJson.provider === AZURE_OPEN_AI) {
             parsedConfigJson = {
               ...parsedConfigJson,
               ...azureConfig
             }
           }
+
+          if (parsedConfigJson.provider === BEDROCK) {
+            parsedConfigJson = {
+              ...parsedConfigJson,
+              ...bedrockConfig
+            }
+          }
+
         }
         return convertKeysToCamelCase(
             parsedConfigJson,
@@ -778,7 +832,8 @@ export function constructConfigFromRequestHeaders(
     return {
       provider: requestHeaders[`x-${POWERED_BY}-provider`],
       apiKey: requestHeaders["authorization"]?.replace("Bearer ", ""),
-      ...(requestHeaders[`x-${POWERED_BY}-provider`] === AZURE_OPEN_AI && azureConfig)
+      ...(requestHeaders[`x-${POWERED_BY}-provider`] === AZURE_OPEN_AI && azureConfig),
+      ...(requestHeaders[`x-${POWERED_BY}-provider`] === BEDROCK && bedrockConfig)
     };
 }
     

--- a/src/handlers/proxyGetHandler.ts
+++ b/src/handlers/proxyGetHandler.ts
@@ -73,7 +73,15 @@ export async function proxyGetHandler(c: Context): Promise<Response> {
 
     let [lastResponse, lastAttempt] = await retryRequest(urlToFetch, fetchOptions, retryCount, RETRY_STATUS_CODES, null);
 
-    const mappedResponse = await responseHandler(lastResponse, store.isStreamingMode, store.proxyProvider, undefined, urlToFetch);
+    const mappedResponse = await responseHandler(
+        lastResponse,
+        store.isStreamingMode,
+        store.proxyProvider,
+        undefined,
+        urlToFetch,
+        false,
+        store.reqBody
+    );
     updateResponseHeaders(mappedResponse, 0, store.reqBody, "DISABLED", lastAttempt ?? 0, requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
 
     c.set("requestOptions", [{

--- a/src/handlers/proxyHandler.ts
+++ b/src/handlers/proxyHandler.ts
@@ -181,9 +181,19 @@ export async function proxyHandler(c: Context): Promise<Response> {
     if (getFromCacheFunction && cacheMode) {
       [cacheResponse, cacheStatus, cacheKey] = await getFromCacheFunction(env(c), {...requestHeaders, ...fetchOptions.headers}, store.reqBody, urlToFetch, cacheIdentifier, cacheMode);
       if (cacheResponse) {
-        const cacheMappedResponse = await responseHandler(new Response(cacheResponse, {headers: {
-          "content-type": "application/json"
-        }}), false, store.proxyProvider, undefined, urlToFetch);
+        const cacheMappedResponse = await responseHandler(
+            new Response(cacheResponse, {
+                headers: {
+                    "content-type": "application/json",
+                },
+            }),
+            false,
+            store.proxyProvider,
+            undefined,
+            urlToFetch,
+            false,
+            store.reqBody
+        );
         c.set("requestOptions", [{
           providerOptions: {...store.reqBody, provider: store.proxyProvider, requestURL: urlToFetch, rubeusURL: 'proxy'},
           requestParams: store.reqBody,
@@ -200,7 +210,15 @@ export async function proxyHandler(c: Context): Promise<Response> {
 
     // Make the API call to the provider
     let [lastResponse, lastAttempt] = await retryRequest(urlToFetch, fetchOptions, retryCount, retryStatusCodes, null);
-    const mappedResponse = await responseHandler(lastResponse, store.isStreamingMode, store.proxyProvider, undefined, urlToFetch);
+    const mappedResponse = await responseHandler(
+        lastResponse,
+        store.isStreamingMode,
+        store.proxyProvider,
+        undefined,
+        urlToFetch,
+        false,
+        store.reqBody
+    );
     updateResponseHeaders(mappedResponse, 0, store.reqBody, cacheStatus, (lastAttempt ?? 0), requestHeaders[HEADER_KEYS.TRACE_ID] ?? "");
 
     c.set("requestOptions", [{

--- a/src/handlers/streamHandler.ts
+++ b/src/handlers/streamHandler.ts
@@ -1,7 +1,95 @@
-import { AZURE_OPEN_AI, CONTENT_TYPES, COHERE, GOOGLE, REQUEST_TIMEOUT_STATUS_CODE, OLLAMA } from "../globals";
+import { AZURE_OPEN_AI, BEDROCK, CONTENT_TYPES, COHERE, GOOGLE, REQUEST_TIMEOUT_STATUS_CODE } from "../globals";
 import { OpenAIChatCompleteResponse } from "../providers/openai/chatComplete";
 import { OpenAICompleteResponse } from "../providers/openai/complete";
 import { getStreamModeSplitPattern } from "../utils";
+
+function readUInt32BE(buffer: Uint8Array, offset: number) {
+    return (
+        (buffer[offset] << 24) |
+        (buffer[offset + 1] << 16) |
+        (buffer[offset + 2] << 8) |
+        buffer[offset + 3]
+    ) >>> 0; // Ensure the result is an unsigned integer
+}
+
+function getPayloadFromAWSChunk (chunk: Uint8Array): string {
+    const decoder = new TextDecoder();
+    const chunkLength = readUInt32BE(chunk, 0);
+    const headersLength = readUInt32BE(chunk, 4);
+
+    // prelude 8 + Prelude crc 4 = 12
+    const headersEnd = 12 + headersLength;
+
+    const payloadLength = chunkLength - headersEnd - 4; // Subtracting 4 for the message crc
+    const payload = chunk.slice(headersEnd, headersEnd + payloadLength);
+    return decoder.decode(payload);
+} 
+
+function concatenateUint8Arrays(a: Uint8Array, b: Uint8Array): Uint8Array {
+    const result = new Uint8Array(a.length + b.length);
+    result.set(a, 0); // Copy contents of array 'a' into 'result' starting at index 0
+    result.set(b, a.length); // Copy contents of array 'b' into 'result' starting at index 'a.length'
+    return result;
+}
+
+export async function* readAWSStream(reader: ReadableStreamDefaultReader, transformFunction: Function | undefined, fallbackChunkId: string) {
+    let buffer = new Uint8Array();
+    let expectedLength = 0;
+    while (true) {
+        const { done, value } = await reader.read();
+        if (done) {
+            if (buffer.length) {
+                expectedLength = readUInt32BE(buffer, 0);
+                while(buffer.length >= expectedLength && buffer.length !== 0) {
+                    const data = buffer.subarray(0, expectedLength);
+                    buffer = buffer.subarray(expectedLength);
+                    expectedLength = readUInt32BE(buffer, 0);
+                    const payload = Buffer.from(JSON.parse(getPayloadFromAWSChunk(data)).bytes, 'base64').toString();
+                    if (transformFunction) {
+                        const transformedChunk = transformFunction(payload, fallbackChunkId);
+                        if (Array.isArray(transformedChunk)) {
+                            for (var item of transformedChunk) {
+                                yield item;
+                            }
+                        } else {
+                            yield transformedChunk;
+                        }
+                    } else {
+                        yield data;
+                    }
+                }
+            }
+            break;
+        }
+
+        if (expectedLength === 0) {
+            expectedLength = readUInt32BE(value, 0);
+        }
+
+        buffer = concatenateUint8Arrays(buffer, value);
+
+        while(buffer.length >= expectedLength && buffer.length !== 0) {
+            const data = buffer.subarray(0, expectedLength);
+            buffer = buffer.subarray(expectedLength);
+
+            expectedLength = readUInt32BE(buffer, 0);
+            const payload = Buffer.from(JSON.parse(getPayloadFromAWSChunk(data)).bytes, 'base64').toString();
+
+            if (transformFunction) {
+                const transformedChunk = transformFunction(payload, fallbackChunkId);
+                if (Array.isArray(transformedChunk)) {
+                    for (var item of transformedChunk) {
+                        yield item;
+                    }
+                } else {
+                    yield transformedChunk;
+                }
+            } else {
+                yield data;
+            }
+        }
+    }
+}
 
 export async function* readStream(reader: ReadableStreamDefaultReader, splitPattern: string, transformFunction: Function | undefined, isSleepTimeRequired: boolean, fallbackChunkId: string) {
     let buffer = '';
@@ -64,7 +152,7 @@ export async function handleNonStreamingMode(response: Response, responseTransfo
 
     let responseBodyJson = await response.json();
     if (responseTransformer) {
-        responseBodyJson = responseTransformer(responseBodyJson, response.status);
+        responseBodyJson = responseTransformer(responseBodyJson, response.status, response.headers);
     }
 
     return new Response(JSON.stringify(responseBodyJson), response);
@@ -92,15 +180,25 @@ export async function handleStreamingMode(response: Response, proxyProvider: str
     const isSleepTimeRequired = proxyProvider === AZURE_OPEN_AI ? true : false;
     const encoder = new TextEncoder();
 
-    (async () => {
-        for await (const chunk of readStream(reader, splitPattern, responseTransformer, isSleepTimeRequired, fallbackChunkId)) {
-            await writer.write(encoder.encode(chunk));
-        }
-        writer.close();
-    })();
+    if (proxyProvider === BEDROCK) {
+        (async () => {
+            for await (const chunk of readAWSStream(reader, responseTransformer, fallbackChunkId)) {
+                await writer.write(encoder.encode(chunk));
+            }
+            writer.close();
+        })();
+    } else {
+        (async () => {
+            for await (const chunk of readStream(reader, splitPattern, responseTransformer, isSleepTimeRequired, fallbackChunkId)) {
+                await writer.write(encoder.encode(chunk));
+            }
+            writer.close();
+        })();
+    }
+    
 
     // Convert GEMINI/COHERE json stream to text/event-stream for non-proxy calls
-    if ([GOOGLE, COHERE].includes(proxyProvider) && responseTransformer) {
+    if ([GOOGLE, COHERE, BEDROCK].includes(proxyProvider) && responseTransformer) {
         return new Response(readable, {
             ...response,
             headers: new Headers({

--- a/src/middlewares/requestValidator/index.ts
+++ b/src/middlewares/requestValidator/index.ts
@@ -17,6 +17,7 @@ import {
     NOMIC,
     OLLAMA,
     AI21,
+    BEDROCK
 } from "../../globals";
 import { configSchema } from "./schema/config";
 
@@ -65,7 +66,7 @@ export const requestValidator = (c: Context, next: any) => {
     }
     if (
         requestHeaders[`x-${POWERED_BY}-provider`] &&
-        ![OPEN_AI, AZURE_OPEN_AI, COHERE, ANTHROPIC, ANYSCALE, PALM, TOGETHER_AI, GOOGLE, MISTRAL_AI, PERPLEXITY_AI, DEEPINFRA, NOMIC, STABILITY_AI, OLLAMA, AI21].includes(
+        ![OPEN_AI, AZURE_OPEN_AI, COHERE, ANTHROPIC, ANYSCALE, PALM, TOGETHER_AI, GOOGLE, MISTRAL_AI, PERPLEXITY_AI, DEEPINFRA, NOMIC, STABILITY_AI, OLLAMA, AI21, BEDROCK].includes(
             requestHeaders[`x-${POWERED_BY}-provider`]
         )
     ) {

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -13,6 +13,7 @@ import {
     NOMIC,
     STABILITY_AI,
     OLLAMA,
+    BEDROCK,
     AI21,
 } from "../../../globals";
 
@@ -53,7 +54,8 @@ export const configSchema: any = z
                         NOMIC,
                         STABILITY_AI,
                         OLLAMA,
-                        AI21
+                        AI21,
+                        BEDROCK,
                     ].includes(value),
                 {
                     message:
@@ -62,6 +64,10 @@ export const configSchema: any = z
             )
             .optional(),
         api_key: z.string().optional(),
+        aws_secret_access_key: z.string().optional(),
+        aws_access_key_id: z.string().optional(),
+        aws_session_token: z.string().optional(),
+        aws_region: z.string().optional(),
         cache: z
             .object({
                 mode: z
@@ -99,6 +105,7 @@ export const configSchema: any = z
             const hasModeTargets =
                 value.strategy !== undefined && value.targets !== undefined;
             const isOllamaProvider = value.provider === OLLAMA;
+            const hasAWSDetails = value.aws_access_key_id && value.aws_secret_access_key;
 
             return (
                 hasProviderApiKey ||
@@ -106,7 +113,8 @@ export const configSchema: any = z
                 value.cache ||
                 value.retry ||
                 value.request_timeout ||
-                isOllamaProvider
+                isOllamaProvider ||
+                hasAWSDetails
             );
         },
         {

--- a/src/providers/bedrock/api.ts
+++ b/src/providers/bedrock/api.ts
@@ -1,0 +1,56 @@
+import { Options } from "../../types/requestBody";
+import { ProviderAPIConfig } from "../types";
+import { generateAWSHeaders } from "./utils";
+
+const BedrockAPIConfig: ProviderAPIConfig = {
+    getBaseURL: (REGION: string = "us-east-1") =>
+        `https://bedrock-runtime.${REGION}.amazonaws.com`,
+    headers: async (
+        providerOption: Options,
+        body: Record<string, any>,
+        url: string
+    ) => {
+        const headers = {
+            "content-type": "application/json",
+        };
+
+        return generateAWSHeaders(
+            body,
+            headers,
+            url,
+            "POST",
+            "bedrock",
+            providerOption.awsRegion || "",
+            providerOption.awsAccessKeyId || "",
+            providerOption.awsSecretAccessKey || "",
+            providerOption.awsSessionToken || ""
+        );
+    },
+    getEndpoint: (fn: string, model: string, stream: boolean) => {
+        let mappedFn = fn;
+        if (stream) {
+            mappedFn = `stream-${fn}`;
+        }
+        const endpoint = `/model/${model}/invoke`;
+        const streamEndpoint = `/model/${model}/invoke-with-response-stream`;
+        switch (mappedFn) {
+            case "chatComplete": {
+                return endpoint;
+            }
+            case "stream-chatComplete": {
+                return streamEndpoint;
+            }
+            case "complete": {
+                return endpoint;
+            }
+            case "stream-complete": {
+                return streamEndpoint;
+            }
+            case "embed": {
+                return endpoint;
+            }
+        }
+    },
+};
+
+export default BedrockAPIConfig;

--- a/src/providers/bedrock/api.ts
+++ b/src/providers/bedrock/api.ts
@@ -49,6 +49,9 @@ const BedrockAPIConfig: ProviderAPIConfig = {
             case "embed": {
                 return endpoint;
             }
+            case "imageGenerate": {
+                return endpoint;
+            }
         }
     },
 };

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -1,0 +1,877 @@
+import { BEDROCK } from "../../globals";
+import { Message, Params } from "../../types/requestBody";
+import {
+    ChatCompletionResponse,
+    CompletionResponse,
+    ErrorResponse,
+    ProviderConfig,
+} from "../types";
+import {
+    BedrockAI21CompleteResponse,
+    BedrockAnthropicCompleteResponse,
+    BedrockAnthropicStreamChunk,
+    BedrockCohereCompleteResponse,
+    BedrockCohereStreamChunk,
+    BedrockLlamaCompleteResponse,
+    BedrockLlamaStreamChunk,
+    BedrockTitanCompleteResponse,
+    BedrockTitanStreamChunk,
+} from "./complete";
+import { BedrockErrorResponse } from "./embed";
+
+export const BedrockAnthropicChatCompleteConfig: ProviderConfig = {
+    messages: {
+        param: "prompt",
+        required: true,
+        transform: (params: Params) => {
+            let prompt: string = "";
+            if (!!params.messages) {
+                let messages: Message[] = params.messages;
+                messages.forEach((msg, index) => {
+                    if (index === 0 && msg.role === "system") {
+                        prompt += `System: ${messages}\n`;
+                    } else if (msg.role == "user") {
+                        prompt += `Human: ${msg.content}\n`;
+                    } else if (msg.role == "assistant") {
+                        prompt += `Assistant: ${msg.content}\n`;
+                    } else {
+                        prompt += `${msg.role}: ${msg.content}\n`;
+                    }
+                });
+                prompt += "Assistant:";
+            }
+            return prompt;
+        },
+    },
+    max_tokens: {
+        param: "max_tokens_to_sample",
+        required: true,
+    },
+    temperature: {
+        param: "temperature",
+        default: 1,
+        min: 0,
+        max: 1,
+    },
+    top_p: {
+        param: "top_p",
+        default: -1,
+        min: -1,
+    },
+    top_k: {
+        param: "top_k",
+        default: -1,
+    },
+    stop: {
+        param: "stop_sequences",
+        transform: (params: Params) => {
+            if (params.stop === null) {
+                return [];
+            }
+            return params.stop;
+        },
+    },
+    user: {
+        param: "metadata.user_id",
+    },
+};
+
+export const BedrockCohereChatCompleteConfig: ProviderConfig = {
+    messages: {
+        param: "prompt",
+        required: true,
+        transform: (params: Params) => {
+            let prompt: string = "";
+            if (!!params.messages) {
+                let messages: Message[] = params.messages;
+                messages.forEach((msg, index) => {
+                    if (index === 0 && msg.role === "system") {
+                        prompt += `system: ${messages}\n`;
+                    } else if (msg.role == "user") {
+                        prompt += `user: ${msg.content}\n`;
+                    } else if (msg.role == "assistant") {
+                        prompt += `assistant: ${msg.content}\n`;
+                    } else {
+                        prompt += `${msg.role}: ${msg.content}\n`;
+                    }
+                });
+                prompt += "Assistant:";
+            }
+            return prompt;
+        },
+    },
+    max_tokens: {
+        param: "max_tokens",
+        default: 20,
+        min: 1,
+    },
+    temperature: {
+        param: "temperature",
+        default: 0.75,
+        min: 0,
+        max: 5,
+    },
+    top_p: {
+        param: "p",
+        default: 0.75,
+        min: 0,
+        max: 1,
+    },
+    top_k: {
+        param: "k",
+        default: 0,
+        max: 500,
+    },
+    frequency_penalty: {
+        param: "frequency_penalty",
+        default: 0,
+        min: 0,
+        max: 1,
+    },
+    presence_penalty: {
+        param: "presence_penalty",
+        default: 0,
+        min: 0,
+        max: 1,
+    },
+    logit_bias: {
+        param: "logit_bias",
+    },
+    n: {
+        param: "num_generations",
+        default: 1,
+        min: 1,
+        max: 5,
+    },
+    stop: {
+        param: "end_sequences",
+    },
+    stream: {
+        param: "stream",
+    },
+};
+
+export const BedrockLLamaChatCompleteConfig: ProviderConfig = {
+    messages: {
+        param: "prompt",
+        required: true,
+        transform: (params: Params) => {
+            let prompt: string = "";
+            if (!!params.messages) {
+                let messages: Message[] = params.messages;
+                messages.forEach((msg, index) => {
+                    if (index === 0 && msg.role === "system") {
+                        prompt += `system: ${messages}\n`;
+                    } else if (msg.role == "user") {
+                        prompt += `user: ${msg.content}\n`;
+                    } else if (msg.role == "assistant") {
+                        prompt += `assistant: ${msg.content}\n`;
+                    } else {
+                        prompt += `${msg.role}: ${msg.content}\n`;
+                    }
+                });
+                prompt += "Assistant:";
+            }
+            return prompt;
+        },
+    },
+    max_tokens: {
+        param: "max_gen_len",
+        default: 512,
+        min: 1,
+        max: 2048,
+    },
+    temperature: {
+        param: "temperature",
+        default: 0.5,
+        min: 0,
+        max: 1,
+    },
+    top_p: {
+        param: "top_p",
+        default: 0.9,
+        min: 0,
+        max: 1,
+    },
+};
+
+const transformTitanGenerationConfig = (params: Params) => {
+    const generationConfig: Record<string, any> = {};
+    if (params["temperature"]) {
+        generationConfig["temperature"] = params["temperature"];
+    }
+    if (params["top_p"]) {
+        generationConfig["topP"] = params["top_p"];
+    }
+    if (params["max_tokens"]) {
+        generationConfig["maxTokenCount"] = params["max_tokens"];
+    }
+    if (params["stop"]) {
+        generationConfig["stopSequences"] = params["stop"];
+    }
+    return generationConfig;
+};
+
+export const BedrockTitanChatompleteConfig: ProviderConfig = {
+    messages: {
+        param: "inputText",
+        required: true,
+        transform: (params: Params) => {
+            let prompt: string = "";
+            if (!!params.messages) {
+                let messages: Message[] = params.messages;
+                messages.forEach((msg, index) => {
+                    if (index === 0 && msg.role === "system") {
+                        prompt += `system: ${messages}\n`;
+                    } else if (msg.role == "user") {
+                        prompt += `user: ${msg.content}\n`;
+                    } else if (msg.role == "assistant") {
+                        prompt += `assistant: ${msg.content}\n`;
+                    } else {
+                        prompt += `${msg.role}: ${msg.content}\n`;
+                    }
+                });
+                prompt += "Assistant:";
+            }
+            return prompt;
+        },
+    },
+    temperature: {
+        param: "textGenerationConfig",
+        transform: (params: Params) => transformTitanGenerationConfig(params),
+    },
+    max_tokens: {
+        param: "textGenerationConfig",
+        transform: (params: Params) => transformTitanGenerationConfig(params),
+    },
+    top_p: {
+        param: "textGenerationConfig",
+        transform: (params: Params) => transformTitanGenerationConfig(params),
+    },
+};
+
+export const BedrockAI21ChatCompleteConfig: ProviderConfig = {
+    messages: {
+        param: "inputText",
+        required: true,
+        transform: (params: Params) => {
+            let prompt: string = "";
+            if (!!params.messages) {
+                let messages: Message[] = params.messages;
+                messages.forEach((msg, index) => {
+                    if (index === 0 && msg.role === "system") {
+                        prompt += `system: ${messages}\n`;
+                    } else if (msg.role == "user") {
+                        prompt += `user: ${msg.content}\n`;
+                    } else if (msg.role == "assistant") {
+                        prompt += `assistant: ${msg.content}\n`;
+                    } else {
+                        prompt += `${msg.role}: ${msg.content}\n`;
+                    }
+                });
+                prompt += "Assistant:";
+            }
+            return prompt;
+        },
+    },
+    max_tokens: {
+        param: "maxTokens",
+        default: 200,
+    },
+    temperature: {
+        param: "temperature",
+        default: 0.7,
+        min: 0,
+        max: 1,
+    },
+    top_p: {
+        param: "topP",
+        default: 1,
+    },
+    stop: {
+        param: "stopSequences",
+    },
+    presence_penalty: {
+        param: "presencePenalty",
+        transform: (params: Params) => {
+            return {
+                scale: params.presence_penalty,
+            };
+        },
+    },
+    frequency_penalty: {
+        param: "frequencyPenalty",
+        transform: (params: Params) => {
+            return {
+                scale: params.frequency_penalty,
+            };
+        },
+    },
+    countPenalty: {
+        param: "countPenalty",
+    },
+    frequencyPenalty: {
+        param: "frequencyPenalty",
+    },
+    presencePenalty: {
+        param: "presencePenalty",
+    },
+};
+
+export const BedrockLlamaChatCompleteResponseTransform: (
+    response: BedrockLlamaCompleteResponse | BedrockErrorResponse,
+    responseStatus: number
+) => ChatCompletionResponse | ErrorResponse = (response, responseStatus) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("generation" in response) {
+        return {
+            id: Date.now().toString(),
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: "assistant",
+                        content: response.generation,
+                    },
+                    finish_reason: response.stop_reason,
+                },
+            ],
+            usage: {
+                prompt_tokens: response.prompt_token_count,
+                completion_tokens: response.generation_token_count,
+                total_tokens:
+                    response.prompt_token_count +
+                    response.generation_token_count,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export const BedrockLlamaChatCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string
+) => string | string[] = (responseChunk, fallbackId) => {
+    let chunk = responseChunk.trim();
+    chunk = chunk.trim();
+    const parsedChunk: BedrockLlamaStreamChunk = JSON.parse(chunk);
+
+    if (parsedChunk.stop_reason) {
+        return [
+            `data: ${JSON.stringify({
+                id: fallbackId,
+                object: "text_completion",
+                created: Math.floor(Date.now() / 1000),
+                model: "",
+                provider: BEDROCK,
+                choices: [
+                    {
+                        delta: {},
+                        index: 0,
+                        logprobs: null,
+                        finish_reason: parsedChunk.stop_reason,
+                    },
+                ],
+                usage: {
+                    prompt_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount,
+                    completion_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                    total_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount +
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                },
+            })}\n\n`,
+            `data: [DONE]\n\n`,
+        ];
+    }
+
+    return `data: ${JSON.stringify({
+        id: fallbackId,
+        object: "chat.completion.chunk",
+        created: Math.floor(Date.now() / 1000),
+        model: "",
+        provider: BEDROCK,
+        choices: [
+            {
+                index: 0,
+                delta: {
+                    role: "assistant",
+                    content: parsedChunk.generation,
+                },
+                finish_reason: null,
+            },
+        ],
+    })}\n\n`;
+};
+
+export const BedrockTitanChatCompleteResponseTransform: (
+    response: BedrockTitanCompleteResponse | BedrockErrorResponse,
+    responseStatus: number
+) => ChatCompletionResponse | ErrorResponse = (response, responseStatus) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("results" in response) {
+        const completionTokens = response.results
+            .map((r) => r.tokenCount)
+            .reduce((partialSum, a) => partialSum + a, 0);
+        return {
+            id: Date.now().toString(),
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: response.results.map((generation, index) => ({
+                index: index,
+                message: {
+                    role: "assistant",
+                    content: generation.outputText,
+                },
+                finish_reason: generation.completionReason,
+            })),
+            usage: {
+                prompt_tokens: response.inputTextTokenCount,
+                completion_tokens: completionTokens,
+                total_tokens: response.inputTextTokenCount + completionTokens,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export const BedrockTitanChatCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string
+) => string | string[] = (responseChunk, fallbackId) => {
+    let chunk = responseChunk.trim();
+    chunk = chunk.trim();
+    const parsedChunk: BedrockTitanStreamChunk = JSON.parse(chunk);
+
+    return [
+        `data: ${JSON.stringify({
+            id: fallbackId,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: [
+                {
+                    index: 0,
+                    delta: {
+                        role: "assistant",
+                        content: parsedChunk.outputText,
+                    },
+                    finish_reason: null,
+                },
+            ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+            id: fallbackId,
+            object: "chat.completion.chunk",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: [
+                {
+                    index: 0,
+                    delta: {},
+                    finish_reason: parsedChunk.completionReason,
+                },
+            ],
+            usage: {
+                prompt_tokens:
+                    parsedChunk["amazon-bedrock-invocationMetrics"]
+                        .inputTokenCount,
+                completion_tokens:
+                    parsedChunk["amazon-bedrock-invocationMetrics"]
+                        .outputTokenCount,
+                total_tokens:
+                    parsedChunk["amazon-bedrock-invocationMetrics"]
+                        .inputTokenCount +
+                    parsedChunk["amazon-bedrock-invocationMetrics"]
+                        .outputTokenCount,
+            },
+        })}\n\n`,
+        `data: [DONE]\n\n`,
+    ];
+};
+
+export const BedrockAI21ChatCompleteResponseTransform: (
+    response: BedrockAI21CompleteResponse | BedrockErrorResponse,
+    responseStatus: number,
+    responseHeaders: Headers
+) => ChatCompletionResponse | ErrorResponse = (
+    response,
+    responseStatus,
+    responseHeaders
+) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("completions" in response) {
+        const prompt_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Input-Token-Count")) ||
+            0;
+        const completion_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Output-Token-Count")) ||
+            0;
+        return {
+            id: response.id.toString(),
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: response.completions.map((completion, index) => ({
+                index: index,
+                message: {
+                    role: "assistant",
+                    content: completion.data.text,
+                },
+                finish_reason: completion.finishReason?.reason,
+            })),
+            usage: {
+                prompt_tokens: prompt_tokens,
+                completion_tokens: completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export const BedrockAnthropicChatCompleteResponseTransform: (
+    response: BedrockAnthropicCompleteResponse | BedrockErrorResponse,
+    responseStatus: number,
+    responseHeaders: Headers
+) => ChatCompletionResponse | ErrorResponse = (
+    response,
+    responseStatus,
+    responseHeaders
+) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: "",
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("completion" in response) {
+        const prompt_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Input-Token-Count")) ||
+            0;
+        const completion_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Output-Token-Count")) ||
+            0;
+        return {
+            id: Date.now().toString(),
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: [
+                {
+                    index: 0,
+                    message: {
+                        role: "assistant",
+                        content: response.completion,
+                    },
+                    finish_reason: response.stop_reason,
+                },
+            ],
+            usage: {
+                prompt_tokens: prompt_tokens,
+                completion_tokens: completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export const BedrockAnthropicChatCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string
+) => string | string[] = (responseChunk, fallbackId) => {
+    let chunk = responseChunk.trim();
+
+    const parsedChunk: BedrockAnthropicStreamChunk = JSON.parse(chunk);
+    if (parsedChunk.stop_reason) {
+        return [
+            `data: ${JSON.stringify({
+                id: fallbackId,
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: "",
+                provider: BEDROCK,
+                choices: [
+                    {
+                        index: 0,
+                        delta: {
+                            role: "assistant",
+                            content: parsedChunk.completion,
+                        },
+                        finish_reason: null,
+                    },
+                ],
+            })}\n\n`,
+            `data: ${JSON.stringify({
+                id: fallbackId,
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: "",
+                provider: BEDROCK,
+                choices: [
+                    {
+                        index: 0,
+                        delta: {},
+                        finish_reason: parsedChunk.stop_reason,
+                    },
+                ],
+                usage: {
+                    prompt_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount,
+                    completion_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                    total_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount +
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                },
+            })}\n\n`,
+            `data: [DONE]\n\n`,
+        ];
+    }
+
+    return `data: ${JSON.stringify({
+        id: fallbackId,
+        object: "chat.completion.chunk",
+        created: Math.floor(Date.now() / 1000),
+        model: "",
+        provider: BEDROCK,
+        choices: [
+            {
+                index: 0,
+                delta: {
+                    role: "assistant",
+                    content: parsedChunk.completion,
+                },
+                finish_reason: null,
+            },
+        ],
+    })}\n\n`;
+};
+
+export const BedrockCohereChatCompleteResponseTransform: (
+    response: BedrockCohereCompleteResponse | BedrockErrorResponse,
+    responseStatus: number,
+    responseHeaders: Headers
+) => ChatCompletionResponse | ErrorResponse = (
+    response,
+    responseStatus,
+    responseHeaders
+) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("generations" in response) {
+        const prompt_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Input-Token-Count")) ||
+            0;
+        const completion_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Output-Token-Count")) ||
+            0;
+        return {
+            id: Date.now().toString(),
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: response.generations.map((generation, index) => ({
+                index: index,
+                message: {
+                    role: "assistant",
+                    content: generation.text,
+                },
+                finish_reason: generation.finish_reason,
+            })),
+            usage: {
+                prompt_tokens: prompt_tokens,
+                completion_tokens: completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export const BedrockCohereChatCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string
+) => string | string[] = (responseChunk, fallbackId) => {
+    let chunk = responseChunk.trim();
+    chunk = chunk.replace(/^data: /, "");
+    chunk = chunk.trim();
+    const parsedChunk: BedrockCohereStreamChunk = JSON.parse(chunk);
+
+    // discard the last cohere chunk as it sends the whole response combined.
+    if (parsedChunk.is_finished) {
+        return [
+            `data: ${JSON.stringify({
+                id: fallbackId,
+                object: "chat.completion.chunk",
+                created: Math.floor(Date.now() / 1000),
+                model: "",
+                provider: BEDROCK,
+                choices: [
+                    {
+                        index: parsedChunk.index ?? 0,
+                        delta: {},
+                        finish_reason: parsedChunk.finish_reason,
+                    },
+                ],
+                usage: {
+                    prompt_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount,
+                    completion_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                    total_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount +
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                },
+            })}\n\n`,
+            `data: [DONE]\n\n`,
+        ];
+    }
+
+    return `data: ${JSON.stringify({
+        id: fallbackId,
+        object: "chat.completion.chunk",
+        created: Math.floor(Date.now() / 1000),
+        model: "",
+        provider: BEDROCK,
+        choices: [
+            {
+                index: parsedChunk.index ?? 0,
+                delta: {
+                    role: "assistant",
+                    content: parsedChunk.text,
+                },
+                finish_reason: null,
+            },
+        ],
+    })}\n\n`;
+};

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -252,7 +252,7 @@ export const BedrockTitanChatompleteConfig: ProviderConfig = {
 
 export const BedrockAI21ChatCompleteConfig: ProviderConfig = {
     messages: {
-        param: "inputText",
+        param: "prompt",
         required: true,
         transform: (params: Params) => {
             let prompt: string = "";

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -29,9 +29,9 @@ export const BedrockAnthropicChatCompleteConfig: ProviderConfig = {
                 let messages: Message[] = params.messages;
                 messages.forEach((msg, index) => {
                     if (index === 0 && msg.role === "system") {
-                        prompt += `System: ${messages}\n`;
+                        prompt += `System: ${msg.content}\n`;
                     } else if (msg.role == "user") {
-                        prompt += `Human: ${msg.content}\n`;
+                        prompt += `\n\nHuman: ${msg.content}\n`;
                     } else if (msg.role == "assistant") {
                         prompt += `Assistant: ${msg.content}\n`;
                     } else {

--- a/src/providers/bedrock/complete.ts
+++ b/src/providers/bedrock/complete.ts
@@ -1,0 +1,853 @@
+import { BEDROCK } from "../../globals";
+import { Params } from "../../types/requestBody";
+import { CompletionResponse, ErrorResponse, ProviderConfig } from "../types";
+import { BedrockErrorResponse } from "./embed";
+
+export const BedrockAnthropicCompleteConfig: ProviderConfig = {
+    prompt: {
+        param: "prompt",
+        transform: (params: Params) =>
+            `\n\nHuman: ${params.prompt}\n\nAssistant:`,
+        required: true,
+    },
+    max_tokens: {
+        param: "max_tokens_to_sample",
+        required: true,
+    },
+    temperature: {
+        param: "temperature",
+        default: 1,
+        min: 0,
+        max: 1,
+    },
+    top_p: {
+        param: "top_p",
+        default: -1,
+        min: -1,
+    },
+    top_k: {
+        param: "top_k",
+        default: -1,
+    },
+    stop: {
+        param: "stop_sequences",
+        transform: (params: Params) => {
+            if (params.stop === null) {
+                return [];
+            }
+            return params.stop;
+        },
+    },
+    user: {
+        param: "metadata.user_id",
+    },
+};
+
+export const BedrockCohereCompleteConfig: ProviderConfig = {
+    prompt: {
+        param: "prompt",
+        required: true,
+    },
+    max_tokens: {
+        param: "max_tokens",
+        default: 20,
+        min: 1,
+    },
+    temperature: {
+        param: "temperature",
+        default: 0.75,
+        min: 0,
+        max: 5,
+    },
+    top_p: {
+        param: "p",
+        default: 0.75,
+        min: 0,
+        max: 1,
+    },
+    top_k: {
+        param: "k",
+        default: 0,
+        max: 500,
+    },
+    frequency_penalty: {
+        param: "frequency_penalty",
+        default: 0,
+        min: 0,
+        max: 1,
+    },
+    presence_penalty: {
+        param: "presence_penalty",
+        default: 0,
+        min: 0,
+        max: 1,
+    },
+    logit_bias: {
+        param: "logit_bias",
+    },
+    n: {
+        param: "num_generations",
+        default: 1,
+        min: 1,
+        max: 5,
+    },
+    stop: {
+        param: "end_sequences",
+    },
+    stream: {
+        param: "stream",
+    },
+};
+
+export const BedrockLLamaCompleteConfig: ProviderConfig = {
+    prompt: {
+        param: "prompt",
+        required: true,
+    },
+    max_tokens: {
+        param: "max_gen_len",
+        default: 512,
+        min: 1,
+        max: 2048,
+    },
+    temperature: {
+        param: "temperature",
+        default: 0.5,
+        min: 0,
+        max: 1,
+    },
+    top_p: {
+        param: "top_p",
+        default: 0.9,
+        min: 0,
+        max: 1,
+    },
+};
+
+const transformTitanGenerationConfig = (params: Params) => {
+    const generationConfig: Record<string, any> = {};
+    if (params["temperature"]) {
+        generationConfig["temperature"] = params["temperature"];
+    }
+    if (params["top_p"]) {
+        generationConfig["topP"] = params["top_p"];
+    }
+    if (params["max_tokens"]) {
+        generationConfig["maxTokenCount"] = params["max_tokens"];
+    }
+    if (params["stop"]) {
+        generationConfig["stopSequences"] = params["stop"];
+    }
+    return generationConfig;
+};
+
+export const BedrockTitanCompleteConfig: ProviderConfig = {
+    prompt: {
+        param: "inputText",
+        required: true,
+    },
+    temperature: {
+        param: "textGenerationConfig",
+        transform: (params: Params) => transformTitanGenerationConfig(params),
+    },
+    max_tokens: {
+        param: "textGenerationConfig",
+        transform: (params: Params) => transformTitanGenerationConfig(params),
+    },
+    top_p: {
+        param: "textGenerationConfig",
+        transform: (params: Params) => transformTitanGenerationConfig(params),
+    },
+};
+
+export const BedrockAI21CompleteConfig: ProviderConfig = {
+    prompt: {
+        param: "prompt",
+        required: true,
+    },
+    max_tokens: {
+        param: "maxTokens",
+        default: 200,
+    },
+    temperature: {
+        param: "temperature",
+        default: 0.7,
+        min: 0,
+        max: 1,
+    },
+    top_p: {
+        param: "topP",
+        default: 1,
+    },
+    stop: {
+        param: "stopSequences",
+    },
+    presence_penalty: {
+        param: "presencePenalty",
+        transform: (params: Params) => {
+            return {
+                scale: params.presence_penalty,
+            };
+        },
+    },
+    frequency_penalty: {
+        param: "frequencyPenalty",
+        transform: (params: Params) => {
+            return {
+                scale: params.frequency_penalty,
+            };
+        },
+    },
+    countPenalty: {
+        param: "countPenalty",
+    },
+    frequencyPenalty: {
+        param: "frequencyPenalty",
+    },
+    presencePenalty: {
+        param: "presencePenalty",
+    },
+};
+
+export interface BedrockLlamaCompleteResponse {
+    generation: string;
+    prompt_token_count: number;
+    generation_token_count: number;
+    stop_reason: string;
+}
+
+export const BedrockLlamaCompleteResponseTransform: (
+    response: BedrockLlamaCompleteResponse | BedrockErrorResponse,
+    responseStatus: number
+) => CompletionResponse | ErrorResponse = (response, responseStatus) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("generation" in response) {
+        return {
+            id: Date.now().toString(),
+            object: "text_completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: [
+                {
+                    text: response.generation,
+                    index: 0,
+                    logprobs: null,
+                    finish_reason: response.stop_reason,
+                },
+            ],
+            usage: {
+                prompt_tokens: response.prompt_token_count,
+                completion_tokens: response.generation_token_count,
+                total_tokens:
+                    response.prompt_token_count +
+                    response.generation_token_count,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export interface BedrockLlamaStreamChunk {
+    generation: string;
+    prompt_token_count: number;
+    generation_token_count: number;
+    stop_reason: string | null;
+    "amazon-bedrock-invocationMetrics": {
+        inputTokenCount: number;
+        outputTokenCount: number;
+        invocationLatency: number;
+        firstByteLatency: number;
+    };
+}
+
+export const BedrockLlamaCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string
+) => string | string[] = (responseChunk, fallbackId) => {
+    let chunk = responseChunk.trim();
+    chunk = chunk.trim();
+    const parsedChunk: BedrockLlamaStreamChunk = JSON.parse(chunk);
+
+    if (parsedChunk.stop_reason) {
+        return [
+            `data: ${JSON.stringify({
+                id: fallbackId,
+                object: "text_completion",
+                created: Math.floor(Date.now() / 1000),
+                model: "",
+                provider: BEDROCK,
+                choices: [
+                    {
+                        text: "",
+                        index: 0,
+                        logprobs: null,
+                        finish_reason: parsedChunk.stop_reason,
+                    },
+                ],
+                usage: {
+                    prompt_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount,
+                    completion_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                    total_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount +
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                },
+            })}\n\n`,
+            `data: [DONE]\n\n`,
+        ];
+    }
+
+    return `data: ${JSON.stringify({
+        id: fallbackId,
+        object: "text_completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "",
+        provider: BEDROCK,
+        choices: [
+            {
+                text: parsedChunk.generation,
+                index: 0,
+                logprobs: null,
+                finish_reason: null,
+            },
+        ],
+    })}\n\n`;
+};
+
+export interface BedrockTitanCompleteResponse {
+    inputTextTokenCount: number;
+    results: {
+        tokenCount: number;
+        outputText: string;
+        completionReason: string;
+    }[];
+}
+
+export const BedrockTitanCompleteResponseTransform: (
+    response: BedrockTitanCompleteResponse | BedrockErrorResponse,
+    responseStatus: number
+) => CompletionResponse | ErrorResponse = (response, responseStatus) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("results" in response) {
+        const completionTokens = response.results
+            .map((r) => r.tokenCount)
+            .reduce((partialSum, a) => partialSum + a, 0);
+        return {
+            id: Date.now().toString(),
+            object: "text_completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: response.results.map((generation, index) => ({
+                text: generation.outputText,
+                index: index,
+                logprobs: null,
+                finish_reason: generation.completionReason,
+            })),
+            usage: {
+                prompt_tokens: response.inputTextTokenCount,
+                completion_tokens: completionTokens,
+                total_tokens: response.inputTextTokenCount + completionTokens,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export interface BedrockTitanStreamChunk {
+    outputText: string;
+    index: number;
+    totalOutputTextTokenCount: number;
+    completionReason: string | null;
+    "amazon-bedrock-invocationMetrics": {
+        inputTokenCount: number;
+        outputTokenCount: number;
+        invocationLatency: number;
+        firstByteLatency: number;
+    };
+}
+
+export const BedrockTitanCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string
+) => string | string[] = (responseChunk, fallbackId) => {
+    let chunk = responseChunk.trim();
+    chunk = chunk.trim();
+    const parsedChunk: BedrockTitanStreamChunk = JSON.parse(chunk);
+
+    return [
+        `data: ${JSON.stringify({
+            id: fallbackId,
+            object: "text_completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: [
+                {
+                    text: parsedChunk.outputText,
+                    index: 0,
+                    logprobs: null,
+                    finish_reason: null,
+                },
+            ],
+        })}\n\n`,
+        `data: ${JSON.stringify({
+            id: fallbackId,
+            object: "text_completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: [
+                {
+                    text: "",
+                    index: 0,
+                    logprobs: null,
+                    finish_reason: parsedChunk.completionReason,
+                },
+            ],
+            usage: {
+                prompt_tokens:
+                    parsedChunk["amazon-bedrock-invocationMetrics"]
+                        .inputTokenCount,
+                completion_tokens:
+                    parsedChunk["amazon-bedrock-invocationMetrics"]
+                        .outputTokenCount,
+                total_tokens:
+                    parsedChunk["amazon-bedrock-invocationMetrics"]
+                        .inputTokenCount +
+                    parsedChunk["amazon-bedrock-invocationMetrics"]
+                        .outputTokenCount,
+            },
+        })}\n\n`,
+        `data: [DONE]\n\n`,
+    ];
+};
+
+export interface BedrockAI21CompleteResponse {
+    id: number;
+    prompt: {
+        text: string;
+        tokens: Record<string, any>[];
+    };
+    completions: [
+        {
+            data: {
+                text: string;
+                tokens: Record<string, any>[];
+            };
+            finishReason: {
+                reason: string;
+                length: number;
+            };
+        },
+    ];
+}
+
+export const BedrockAI21CompleteResponseTransform: (
+    response: BedrockAI21CompleteResponse | BedrockErrorResponse,
+    responseStatus: number,
+    responseHeaders: Headers
+) => CompletionResponse | ErrorResponse = (
+    response,
+    responseStatus,
+    responseHeaders
+) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("completions" in response) {
+        const prompt_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Input-Token-Count")) ||
+            0;
+        const completion_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Output-Token-Count")) ||
+            0;
+        return {
+            id: response.id.toString(),
+            object: "text_completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: response.completions.map((completion, index) => ({
+                text: completion.data.text,
+                index: index,
+                logprobs: null,
+                finish_reason: completion.finishReason?.reason,
+            })),
+            usage: {
+                prompt_tokens: prompt_tokens,
+                completion_tokens: completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export interface BedrockAnthropicCompleteResponse {
+    completion: string;
+    stop_reason: string;
+    stop: null | string;
+}
+
+export const BedrockAnthropicCompleteResponseTransform: (
+    response: BedrockAnthropicCompleteResponse | BedrockErrorResponse,
+    responseStatus: number,
+    responseHeaders: Headers
+) => CompletionResponse | ErrorResponse = (
+    response,
+    responseStatus,
+    responseHeaders
+) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: "",
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("completion" in response) {
+        const prompt_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Input-Token-Count")) ||
+            0;
+        const completion_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Output-Token-Count")) ||
+            0;
+        return {
+            id: Date.now().toString(),
+            object: "text_completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: [
+                {
+                    text: response.completion,
+                    index: 0,
+                    logprobs: null,
+                    finish_reason: response.stop_reason,
+                },
+            ],
+            usage: {
+                prompt_tokens: prompt_tokens,
+                completion_tokens: completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export interface BedrockAnthropicStreamChunk {
+    completion: string;
+    stop_reason: string | null;
+    stop: string | null;
+    "amazon-bedrock-invocationMetrics": {
+        inputTokenCount: number;
+        outputTokenCount: number;
+        invocationLatency: number;
+        firstByteLatency: number;
+    };
+}
+
+export const BedrockAnthropicCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string
+) => string | string[] = (responseChunk, fallbackId) => {
+    let chunk = responseChunk.trim();
+
+    const parsedChunk: BedrockAnthropicStreamChunk = JSON.parse(chunk);
+    if (parsedChunk.stop_reason) {
+        return [
+            `data: ${JSON.stringify({
+                id: fallbackId,
+                object: "text_completion",
+                created: Math.floor(Date.now() / 1000),
+                model: "",
+                provider: BEDROCK,
+                choices: [
+                    {
+                        text: parsedChunk.completion,
+                        index: 0,
+                        logprobs: null,
+                        finish_reason: null,
+                    },
+                ],
+            })}\n\n`,
+            `data: ${JSON.stringify({
+                id: fallbackId,
+                object: "text_completion",
+                created: Math.floor(Date.now() / 1000),
+                model: "",
+                provider: BEDROCK,
+                choices: [
+                    {
+                        text: "",
+                        index: 0,
+                        logprobs: null,
+                        finish_reason: parsedChunk.stop_reason,
+                    },
+                ],
+                usage: {
+                    prompt_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount,
+                    completion_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                    total_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount +
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                },
+            })}\n\n`,
+            `data: [DONE]\n\n`,
+        ];
+    }
+    return `data: ${JSON.stringify({
+        id: fallbackId,
+        object: "text_completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "",
+        provider: BEDROCK,
+        choices: [
+            {
+                text: parsedChunk.completion,
+                index: 0,
+                logprobs: null,
+                finish_reason: null,
+            },
+        ],
+    })}\n\n`;
+};
+
+export interface BedrockCohereCompleteResponse {
+    id: string;
+    generations: {
+        id: string;
+        text: string;
+        finish_reason: string;
+    }[];
+    prompt: string;
+}
+
+export const BedrockCohereCompleteResponseTransform: (
+    response: BedrockCohereCompleteResponse | BedrockErrorResponse,
+    responseStatus: number,
+    responseHeaders: Headers
+) => CompletionResponse | ErrorResponse = (
+    response,
+    responseStatus,
+    responseHeaders
+) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("generations" in response) {
+        const prompt_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Input-Token-Count")) ||
+            0;
+        const completion_tokens =
+            Number(responseHeaders.get("X-Amzn-Bedrock-Output-Token-Count")) ||
+            0;
+        return {
+            id: response.id,
+            object: "text_completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "",
+            provider: BEDROCK,
+            choices: response.generations.map((generation, index) => ({
+                text: generation.text,
+                index: index,
+                logprobs: null,
+                finish_reason: generation.finish_reason,
+            })),
+            usage: {
+                prompt_tokens: prompt_tokens,
+                completion_tokens: completion_tokens,
+                total_tokens: prompt_tokens + completion_tokens,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+export interface BedrockCohereStreamChunk {
+    text: string;
+    is_finished: boolean;
+    index?: number;
+    finish_reason?: string;
+    "amazon-bedrock-invocationMetrics": {
+        inputTokenCount: number;
+        outputTokenCount: number;
+        invocationLatency: number;
+        firstByteLatency: number;
+    };
+}
+
+export const BedrockCohereCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string
+) => string | string[] = (responseChunk, fallbackId) => {
+    let chunk = responseChunk.trim();
+    chunk = chunk.replace(/^data: /, "");
+    chunk = chunk.trim();
+    const parsedChunk: BedrockCohereStreamChunk = JSON.parse(chunk);
+
+    // discard the last cohere chunk as it sends the whole response combined.
+    if (parsedChunk.is_finished) {
+        return [
+            `data: ${JSON.stringify({
+                id: fallbackId,
+                object: "text_completion",
+                created: Math.floor(Date.now() / 1000),
+                model: "",
+                provider: BEDROCK,
+                choices: [
+                    {
+                        text: "",
+                        index: 0,
+                        logprobs: null,
+                        finish_reason: parsedChunk.finish_reason,
+                    },
+                ],
+                usage: {
+                    prompt_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount,
+                    completion_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                    total_tokens:
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .inputTokenCount +
+                        parsedChunk["amazon-bedrock-invocationMetrics"]
+                            .outputTokenCount,
+                },
+            })}\n\n`,
+            `data: [DONE]\n\n`,
+        ];
+    }
+
+    return `data: ${JSON.stringify({
+        id: fallbackId,
+        object: "text_completion",
+        created: Math.floor(Date.now() / 1000),
+        model: "",
+        provider: BEDROCK,
+        choices: [
+            {
+                text: parsedChunk.text,
+                index: parsedChunk.index ?? 0,
+                logprobs: null,
+                finish_reason: null,
+            },
+        ],
+    })}\n\n`;
+};

--- a/src/providers/bedrock/embed.ts
+++ b/src/providers/bedrock/embed.ts
@@ -16,6 +16,7 @@ export const BedrockCohereEmbedConfig: ProviderConfig = {
     },
     input_type: {
         param: "input_type",
+        required: true
     },
     truncate: {
         param: "truncate",

--- a/src/providers/bedrock/embed.ts
+++ b/src/providers/bedrock/embed.ts
@@ -1,0 +1,140 @@
+import { BEDROCK } from "../../globals";
+import { EmbedResponse } from "../../types/embedRequestBody";
+import { ErrorResponse, ProviderConfig } from "../types";
+
+export const BedrockCohereEmbedConfig: ProviderConfig = {
+    input: {
+        param: "texts",
+        required: true,
+        transform: (params: any): string[] => {
+            if (Array.isArray(params.input)) {
+                return params.input;
+            } else {
+                return [params.input];
+            }
+        },
+    },
+    input_type: {
+        param: "input_type",
+    },
+    truncate: {
+        param: "truncate",
+    },
+};
+
+export const BedrockTitanEmbedConfig: ProviderConfig = {
+    input: {
+        param: "inputText",
+        required: true,
+    },
+};
+
+interface BedrockTitanEmbedResponse {
+    embedding: number[];
+    inputTextTokenCount: number;
+}
+
+export interface BedrockErrorResponse {
+    message: string;
+}
+
+export const BedrockTitanEmbedResponseTransform: (
+    response: BedrockTitanEmbedResponse | BedrockErrorResponse,
+    responseStatus: number
+) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+    if ("message" in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ("embedding" in response) {
+        return {
+            object: "list",
+            data: [
+                {
+                    object: "embedding",
+                    embedding: response.embedding,
+                    index: 0,
+                },
+            ],
+            provider: BEDROCK,
+            model: "",
+            usage: {
+                prompt_tokens: response.inputTextTokenCount,
+                total_tokens: response.inputTextTokenCount,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};
+
+interface BedrockCohereEmbedResponse {
+    embeddings: number[][];
+    id: string;
+    texts: string[];
+}
+
+export const BedrockCohereEmbedResponseTransform: (
+    response: BedrockCohereEmbedResponse | BedrockErrorResponse,
+    responseStatus: number,
+    responseHeaders: Headers
+) => EmbedResponse | ErrorResponse = (response, responseStatus, responseHeaders) => {
+    if ('message' in response && responseStatus !== 200) {
+        return {
+            error: {
+                message: response.message,
+                type: null,
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        } as ErrorResponse;
+    }
+
+    if ('embeddings' in response) {
+        return {
+            object: "list",
+            data: response.embeddings.map((embedding, index) => ({
+                object: "embedding",
+                embedding: embedding,
+                index: index,
+            })),
+            provider: BEDROCK,
+            model: "",
+            usage: {
+                prompt_tokens: Number(responseHeaders.get("X-Amzn-Bedrock-Input-Token-Count")) || -1,
+                total_tokens: Number(responseHeaders.get("X-Amzn-Bedrock-Input-Token-Count")) || -1,
+            },
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};

--- a/src/providers/bedrock/imageGenerate.ts
+++ b/src/providers/bedrock/imageGenerate.ts
@@ -1,4 +1,4 @@
-import { BEDROCK, STABILITY_AI } from "../../globals";
+import { BEDROCK } from "../../globals";
 import { ErrorResponse, ImageGenerateResponse, ProviderConfig } from "../types";
 import { BedrockErrorResponse } from "./embed";
 

--- a/src/providers/bedrock/imageGenerate.ts
+++ b/src/providers/bedrock/imageGenerate.ts
@@ -1,0 +1,88 @@
+import { BEDROCK, STABILITY_AI } from "../../globals";
+import { ErrorResponse, ImageGenerateResponse, ProviderConfig } from "../types";
+import { BedrockErrorResponse } from "./embed";
+
+export const BedrockStabilityAIImageGenerateConfig: ProviderConfig = {
+    prompt: {
+        param: "text_prompts",
+        required: true,
+        transform: (params: any) => {
+            return [
+                {
+                    text: params.prompt,
+                    weight: 1,
+                },
+            ];
+        },
+    },
+    n: {
+        param: "samples",
+        min: 1,
+        max: 10,
+    },
+    size: [
+        {
+            param: "height",
+            transform: (params: any) =>
+                parseInt(params.size.toLowerCase().split("x")[1]),
+            min: 320,
+        },
+        {
+            param: "width",
+            transform: (params: any) =>
+                parseInt(params.size.toLowerCase().split("x")[0]),
+            min: 320,
+        },
+    ],
+    style: {
+        param: "style_preset",
+    },
+};
+
+interface ImageArtifact {
+    base64: string;
+    finishReason: "CONTENT_FILTERED" | "ERROR" | "SUCCESS";
+    seed: number;
+}
+
+interface BedrockStabilityAIImageGenerateResponse {
+    result: string;
+    artifacts: ImageArtifact[];
+}
+
+export const BedrockStabilityAIImageGenerateResponseTransform: (
+    response: BedrockStabilityAIImageGenerateResponse | BedrockErrorResponse,
+    responseStatus: number
+) => ImageGenerateResponse | ErrorResponse = (response, responseStatus) => {
+    if (responseStatus !== 200 && "message" in response) {
+        return {
+            error: {
+                message: response.message,
+                type: "",
+                param: null,
+                code: null,
+            },
+            provider: BEDROCK,
+        };
+    }
+
+    if ("artifacts" in response) {
+        return {
+            created: `${new Date().getTime()}`,
+            data: response.artifacts.map((art) => ({ b64_json: art.base64 })),
+            provider: BEDROCK,
+        };
+    }
+
+    return {
+        error: {
+            message: `Invalid response recieved from ${BEDROCK}: ${JSON.stringify(
+                response
+            )}`,
+            type: null,
+            param: null,
+            code: null,
+        },
+        provider: BEDROCK,
+    } as ErrorResponse;
+};

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -1,0 +1,139 @@
+import { AI21, ANTHROPIC, COHERE } from "../../globals";
+import { Params } from "../../types/requestBody";
+import { ProviderConfigs } from "../types";
+import BedrockAPIConfig from "./api";
+import {
+    BedrockAI21ChatCompleteConfig,
+    BedrockAI21ChatCompleteResponseTransform,
+    BedrockAnthropicChatCompleteConfig,
+    BedrockAnthropicChatCompleteResponseTransform,
+    BedrockAnthropicChatCompleteStreamChunkTransform,
+    BedrockCohereChatCompleteConfig,
+    BedrockCohereChatCompleteResponseTransform,
+    BedrockCohereChatCompleteStreamChunkTransform,
+    BedrockLLamaChatCompleteConfig,
+    BedrockLlamaChatCompleteResponseTransform,
+    BedrockLlamaChatCompleteStreamChunkTransform,
+    BedrockTitanChatCompleteResponseTransform,
+    BedrockTitanChatCompleteStreamChunkTransform,
+    BedrockTitanChatompleteConfig,
+} from "./chatComplete";
+import {
+    BedrockAI21CompleteConfig,
+    BedrockAI21CompleteResponseTransform,
+    BedrockAnthropicCompleteConfig,
+    BedrockAnthropicCompleteResponseTransform,
+    BedrockAnthropicCompleteStreamChunkTransform,
+    BedrockCohereCompleteConfig,
+    BedrockCohereCompleteResponseTransform,
+    BedrockCohereCompleteStreamChunkTransform,
+    BedrockLLamaCompleteConfig,
+    BedrockLlamaCompleteResponseTransform,
+    BedrockLlamaCompleteStreamChunkTransform,
+    BedrockTitanCompleteConfig,
+    BedrockTitanCompleteResponseTransform,
+    BedrockTitanCompleteStreamChunkTransform,
+} from "./complete";
+import {
+    BedrockCohereEmbedConfig,
+    BedrockCohereEmbedResponseTransform,
+    BedrockTitanEmbedConfig,
+    BedrockTitanEmbedResponseTransform,
+} from "./embed";
+import {
+    BedrockStabilityAIImageGenerateConfig,
+    BedrockStabilityAIImageGenerateResponseTransform,
+} from "./imageGenerate";
+
+const BedrockConfig: ProviderConfigs = {
+    api: BedrockAPIConfig,
+    getConfig: (params: Params) => {
+        const providerModel = params.model;
+        const provider = providerModel?.split(".")[0];
+        switch (provider) {
+            case ANTHROPIC:
+                return {
+                    complete: BedrockAnthropicCompleteConfig,
+                    chatComplete: BedrockAnthropicChatCompleteConfig,
+                    api: BedrockAPIConfig,
+                    responseTransforms: {
+                        "stream-complete":
+                            BedrockAnthropicCompleteStreamChunkTransform,
+                        complete: BedrockAnthropicCompleteResponseTransform,
+                        "stream-chatComplete":
+                            BedrockAnthropicChatCompleteStreamChunkTransform,
+                        chatComplete:
+                            BedrockAnthropicChatCompleteResponseTransform,
+                    },
+                };
+            case COHERE:
+                return {
+                    complete: BedrockCohereCompleteConfig,
+                    chatComplete: BedrockCohereChatCompleteConfig,
+                    embed: BedrockCohereEmbedConfig,
+                    api: BedrockAPIConfig,
+                    responseTransforms: {
+                        "stream-complete":
+                            BedrockCohereCompleteStreamChunkTransform,
+                        complete: BedrockCohereCompleteResponseTransform,
+                        "stream-chatComplete":
+                            BedrockCohereChatCompleteStreamChunkTransform,
+                        chatComplete:
+                            BedrockCohereChatCompleteResponseTransform,
+                        embed: BedrockCohereEmbedResponseTransform,
+                    },
+                };
+            case "meta":
+                return {
+                    complete: BedrockLLamaCompleteConfig,
+                    chatComplete: BedrockLLamaChatCompleteConfig,
+                    api: BedrockAPIConfig,
+                    responseTransforms: {
+                        "stream-complete":
+                            BedrockLlamaCompleteStreamChunkTransform,
+                        complete: BedrockLlamaCompleteResponseTransform,
+                        "stream-chatComplete":
+                            BedrockLlamaChatCompleteStreamChunkTransform,
+                        chatComplete: BedrockLlamaChatCompleteResponseTransform,
+                    },
+                };
+            case "amazon":
+                return {
+                    complete: BedrockTitanCompleteConfig,
+                    chatComplete: BedrockTitanChatompleteConfig,
+                    embed: BedrockTitanEmbedConfig,
+                    api: BedrockAPIConfig,
+                    responseTransforms: {
+                        "stream-complete":
+                            BedrockTitanCompleteStreamChunkTransform,
+                        complete: BedrockTitanCompleteResponseTransform,
+                        "stream-chatComplete":
+                            BedrockTitanChatCompleteStreamChunkTransform,
+                        chatComplete: BedrockTitanChatCompleteResponseTransform,
+                        embed: BedrockTitanEmbedResponseTransform,
+                    },
+                };
+            case AI21:
+                return {
+                    complete: BedrockAI21CompleteConfig,
+                    chatComplete: BedrockAI21ChatCompleteConfig,
+                    api: BedrockAPIConfig,
+                    responseTransforms: {
+                        complete: BedrockAI21CompleteResponseTransform,
+                        chatComplete: BedrockAI21ChatCompleteResponseTransform,
+                    },
+                };
+            case "stability":
+                return {
+                    imageGenerate: BedrockStabilityAIImageGenerateConfig,
+                    api: BedrockAPIConfig,
+                    responseTransforms: {
+                        imageGenerate:
+                            BedrockStabilityAIImageGenerateResponseTransform,
+                    },
+                };
+        }
+    },
+};
+
+export default BedrockConfig;

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -1,0 +1,40 @@
+import { SignatureV4 } from "@smithy/signature-v4";
+import { Sha256 } from "@aws-crypto/sha256-js";
+
+export const generateAWSHeaders = async (
+    body: Record<string, any>,
+    headers: Record<string, string>,
+    url: string,
+    method: string,
+    awsService: string,
+    awsRegion: string,
+    awsAccessKeyID: string,
+    awsSecretAccessKey: string,
+    awsSessionToken: string | undefined
+): Promise<Record<string, string>> => {
+    const signer = new SignatureV4({
+        service: awsService,
+        region: awsRegion || "us-east-1",
+        credentials: {
+            accessKeyId: awsAccessKeyID,
+            secretAccessKey: awsSecretAccessKey,
+            ...(awsSessionToken && {sessionToken: awsSessionToken})
+        },
+        sha256: Sha256
+      });
+    
+    const urlObj = new URL(url);
+    const hostname = urlObj.hostname;
+    headers['host'] = hostname; 
+    const request = {
+        method: method,
+        path: urlObj.pathname,
+        protocol: "https",
+        hostname: urlObj.hostname,
+        headers: headers,
+        body: JSON.stringify(body),
+    };
+    
+    const signed = await signer.sign(request);
+    return signed.headers;
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,6 +2,7 @@ import AI21Config from "./ai21";
 import AnthropicConfig from "./anthropic";
 import AnyscaleConfig from "./anyscale";
 import AzureOpenAIConfig from "./azure-openai";
+import BedrockConfig from "./bedrock";
 import CohereConfig from "./cohere";
 import DeepInfraConfig from "./deepinfra";
 import GoogleConfig from "./google";
@@ -30,7 +31,8 @@ const Providers: { [key: string]: ProviderConfigs } = {
   'stability-ai': StabilityAIConfig,
   nomic: NomicConfig,
   'ollama': OllamaAPIConfig,
-  ai21: AI21Config
+  ai21: AI21Config,
+  bedrock: BedrockConfig
 };
 
 export default Providers;

--- a/src/providers/openai/chatComplete.ts
+++ b/src/providers/openai/chatComplete.ts
@@ -99,19 +99,23 @@ export const OpenAIChatCompleteResponseTransform: (response: OpenAIChatCompleteR
 export const OpenAIChatCompleteJSONToStreamResponseTransform: (response: OpenAIChatCompleteResponse, provider: string) => Array<string> = (response, provider) => {
   const streamChunkArray: Array<string> = [];
   const { id, model, system_fingerprint, choices } = response;
-  const streamChunkTemplate = {
+
+  const { prompt_tokens, completion_tokens } = response.usage || {};
+
+  let total_tokens;
+  if (prompt_tokens && completion_tokens) total_tokens = prompt_tokens + completion_tokens;
+
+  const streamChunkTemplate: Record<string, any> = {
     id,
     object: "chat.completion.chunk",
     created: Date.now(),
     model: model || "",
     system_fingerprint: system_fingerprint || null,
     provider,
-    usage: {}
-  }
-
-  if (response.usage?.completion_tokens) {
-    streamChunkTemplate.usage = {
-      completion_tokens: response.usage?.completion_tokens
+    usage: {
+      ...(completion_tokens && {completion_tokens}),
+      ...(prompt_tokens && {prompt_tokens}),
+      ...(total_tokens && {total_tokens})
     }
   }
 

--- a/src/providers/openai/complete.ts
+++ b/src/providers/openai/complete.ts
@@ -91,18 +91,21 @@ export const OpenAICompleteResponseTransform: (response: OpenAICompleteResponse)
 export const OpenAICompleteJSONToStreamResponseTransform: (response: OpenAICompleteResponse, provider: string) => Array<string> = (response, provider) => {
   const streamChunkArray: Array<string> = [];
   const { id, model, choices } = response;
+  const { prompt_tokens, completion_tokens } = response.usage || {};
+
+  let total_tokens;
+  if (prompt_tokens && completion_tokens) total_tokens = prompt_tokens + completion_tokens;
+
   const streamChunkTemplate = {
     id: id,
     object: "text_completion",
     created: Date.now(),
     model: model ?? "",
     provider,
-    usage: {}
-  }
-
-  if (response.usage?.completion_tokens) {
-    streamChunkTemplate.usage = {
-      completion_tokens: response.usage?.completion_tokens
+    usage: {
+      ...(completion_tokens && {completion_tokens}),
+      ...(prompt_tokens && {prompt_tokens}),
+      ...(total_tokens && {total_tokens})
     }
   }
 

--- a/src/services/transformToProviderRequest.ts
+++ b/src/services/transformToProviderRequest.ts
@@ -46,7 +46,12 @@ function setArrayNestedProperties(obj: any, path: Array<string>, value: Array<an
  */
 const transformToProviderRequest = (provider: string, params: Params, fn: string): { [key: string]: any } => {
   // Get the configuration for the specified provider
-  const providerConfig = ProviderConfigs[provider][fn];
+  let providerConfig = ProviderConfigs[provider];
+  if (providerConfig.getConfig) {
+    providerConfig = providerConfig.getConfig(params)[fn];
+  } else {
+    providerConfig = providerConfig[fn]
+  }
 
   // If the provider is not supported, throw an error
   if (!providerConfig) {

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -52,6 +52,11 @@ export interface Options {
   cache?: CacheSettings | string;
   metadata?: Record<string, string>;
   requestTimeout?: number;
+  /** AWS Bedrock specific */
+  awsSecretAccessKey?: string;
+  awsAccessKeyId?: string;
+  awsSessionToken?: string;
+  awsRegion?: string;
 }
 
 /**


### PR DESCRIPTION
**Title:** 
- AWS Bedrock integration for text, chat, embed and image generation models

**Description:** (optional)
- Add @aws-crypto/sha256-js and @smithy/signature-v4 to calculate the aws auth signature from incoming access key id, secret access key, region and session token (if sent).
- Add a new stream parser to support `application/vnd.amazon.eventstream` response type sent by bedrock
- Add support for `x-portkey-aws-access-key-id`, `x-portkey-aws-secret-access-key`, `x-portkey-aws-region`, `x-portkey-session-token` headers.
- Add support for `aws_access_key_id`, `aws_secret_access_key`, `aws_region` and `aws_session_token` config params.
- Support bedrock completions, chat completions, embeddings and image generation models. For chat, gateway will do the message to prompt transformation and make the call and then convert the response into chat response as well.
- Update core functions `responseHandler` and `transformToProviderRequest` to allow multiple configs for single provider. For bedrock, each provider that it supports has different request/response structure. So a single transformer config would not work for bedrock.

**Motivation:** (optional)
- New integration

**Related Issues:** (optional)
- Closes #39 
