### PR TITLE
Fix: allow loadbalance zero weight

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -645,7 +645,7 @@ export async function tryTargetsRecursively(
 
         case "loadbalance":
             currentTarget.targets.forEach((t: Options) => {
-                if (!t.weight) {
+                if (t.weight === undefined) {
                     t.weight = 1;
                 }
             });


### PR DESCRIPTION
**Title:** 
- allow loadbalance zero weight

**Description:** (optional)
- Allow 0 as a valid loadbalance target weight value.

**Motivation:** (optional)
- To allow stopping traffic to one of the loadbalance traffic

**Related Issues:** (optional)
- #228 
