### PR TITLE
Added stability parameters

### DIFF
--- a/src/providers/stability-ai/imageGenerate.ts
+++ b/src/providers/stability-ai/imageGenerate.ts
@@ -28,6 +28,24 @@ export const StabilityAIImageGenerateConfig: ProviderConfig = {
   }],
   style: {
     param: "style_preset"
+  },
+  cfg_scale: {
+    param: "cfg_scale"
+  },
+  clip_guidance_preset: {
+    param: "clip_guidance_preset"
+  },
+  sampler: {
+    param: "sampler"
+  },
+  seed: {
+    param: "seed"
+  },
+  steps: {
+    param: "steps"
+  },
+  extras: {
+    param: "extras"
   }
 }
 


### PR DESCRIPTION
**Title:** 
- Stability's API supports more parameters in the body than OpenAI (`cfg_scale `, `clip_guidance_preset `, `sampler `,`seed `,  `steps`,  `extras `). We're supporting them here.

#237 
