### PR TITLE
provide `usage` of tokens for anthropic models

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -168,6 +168,8 @@ export const AnthropicChatCompleteResponseTransform: (response: AnthropicChatCom
   } 
 
   if ('content' in response) {
+    const { input_tokens = 0, output_tokens = 0 } = response?.usage;
+
     return {
       id: response.id,
       object: "chat_completion",
@@ -181,7 +183,12 @@ export const AnthropicChatCompleteResponseTransform: (response: AnthropicChatCom
           logprobs: null,
           finish_reason: response.stop_reason,
         },
-      ]
+      ],
+      usage: {
+        prompt_tokens: input_tokens,
+        completion_tokens: output_tokens,
+        total_tokens: input_tokens + output_tokens,
+      },
     }
   }
 


### PR DESCRIPTION
**Title:** 
Pass token count from Anthropic response.

Docs: https://docs.anthropic.com/claude/reference/messages_post

**Motivation:** (optional)
- I've faced issues for `usage` being undefined when using PHP OpenAI client.
- I believe it's also very nice to have this. :)
