### PR TITLE
feat: add portkey-default value check to set default param values

### DIFF
--- a/src/services/transformToProviderRequest.ts
+++ b/src/services/transformToProviderRequest.ts
@@ -85,11 +85,7 @@ const transformToProviderRequest = (provider: string, params: Params, fn: string
           paramConfig.default !== undefined
         ) {
           // Set the transformed parameter to the default value
-          setNestedProperty(
-            transformedRequest,
-            paramConfig.param,
-            paramConfig.default
-          );
+          value = paramConfig.default;
         }
 
         // If a minimum is defined for this parameter and the value is less than this, set the value to the minimum

--- a/src/services/transformToProviderRequest.ts
+++ b/src/services/transformToProviderRequest.ts
@@ -79,6 +79,19 @@ const transformToProviderRequest = (provider: string, params: Params, fn: string
           value = paramConfig.transform(params);
         }
 
+        if (
+          value === "portkey-default" &&
+          paramConfig &&
+          paramConfig.default !== undefined
+        ) {
+          // Set the transformed parameter to the default value
+          setNestedProperty(
+            transformedRequest,
+            paramConfig.param,
+            paramConfig.default
+          );
+        }
+
         // If a minimum is defined for this parameter and the value is less than this, set the value to the minimum
         // Also, we should only do this comparison if value is of type 'number'
         if (


### PR DESCRIPTION
**Title:** 
- add portkey-default value check to set default param values

**Description:** (optional)
- Add a `portkey-default` value check in request transformer function which can be used to pick up gateway's default param value. This allows users to mention portkey-default in SDK calls so that it bypasses empty/null value check on the SDKs. 

**Motivation:** (optional)
- Enhancement

**Related Issues:** (optional)
- Closes #263 
