### PR TITLE
[Provider] Added Support for Workers AI Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -135,4 +135,7 @@ build
 .DS_Store
 
 # Wrangler temp directory
-.wrangler 
+.wrangler
+
+# IntelliJ Idea
+.idea

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -42,6 +42,7 @@ export const GROQ: string = 'groq';
 export const SEGMIND: string = 'segmind';
 export const JINA: string = 'jina';
 export const FIREWORKS_AI: string = 'fireworks-ai';
+export const WORKERS_AI: string = 'workers-ai';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -64,6 +65,7 @@ export const VALID_PROVIDERS = [
   SEGMIND,
   JINA,
   FIREWORKS_AI,
+  WORKERS_AI,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -191,8 +191,8 @@ export const fetchProviderOptionsFromConfig = (
       providerOptions[0].deploymentId = camelCaseConfig.deploymentId;
     if (camelCaseConfig.apiVersion)
       providerOptions[0].apiVersion = camelCaseConfig.apiVersion;
-    if (camelCaseConfig.accountId)
-      providerOptions[0].accountId = camelCaseConfig.accountId;
+    if (camelCaseConfig.workersAiAccountId)
+      providerOptions[0].workersAiAccountId = camelCaseConfig.workersAiAccountId;
     mode = 'single';
   } else {
     if (camelCaseConfig.strategy && camelCaseConfig.strategy.mode) {
@@ -955,7 +955,7 @@ export function constructConfigFromRequestHeaders(
   };
 
   const workersAiConfig = {
-    accountId: requestHeaders[`x-${POWERED_BY}-workers-ai-account-id`],
+    workersAiAccountId: requestHeaders[`x-${POWERED_BY}-workers-ai-account-id`],
   };
 
   if (requestHeaders[`x-${POWERED_BY}-config`]) {

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -2,6 +2,7 @@ import { Context } from 'hono';
 import {
   AZURE_OPEN_AI,
   BEDROCK,
+  WORKERS_AI,
   CONTENT_TYPES,
   HEADER_KEYS,
   POWERED_BY,
@@ -190,6 +191,8 @@ export const fetchProviderOptionsFromConfig = (
       providerOptions[0].deploymentId = camelCaseConfig.deploymentId;
     if (camelCaseConfig.apiVersion)
       providerOptions[0].apiVersion = camelCaseConfig.apiVersion;
+    if (camelCaseConfig.accountId)
+      providerOptions[0].apiVersion = camelCaseConfig.accountId;
     mode = 'single';
   } else {
     if (camelCaseConfig.strategy && camelCaseConfig.strategy.mode) {
@@ -951,6 +954,10 @@ export function constructConfigFromRequestHeaders(
     awsRegion: requestHeaders[`x-${POWERED_BY}-aws-region`],
   };
 
+  const workersAiConfig = {
+    accountId: requestHeaders[`x-${POWERED_BY}-workers-ai-account-id`],
+  };
+
   if (requestHeaders[`x-${POWERED_BY}-config`]) {
     let parsedConfigJson = JSON.parse(requestHeaders[`x-${POWERED_BY}-config`]);
 
@@ -974,6 +981,13 @@ export function constructConfigFromRequestHeaders(
           ...bedrockConfig,
         };
       }
+
+      if (parsedConfigJson.provider === WORKERS_AI) {
+        parsedConfigJson = {
+          ...parsedConfigJson,
+          ...workersAiConfig,
+        };
+      }
     }
     return convertKeysToCamelCase(parsedConfigJson, [
       'override_params',
@@ -988,5 +1002,7 @@ export function constructConfigFromRequestHeaders(
       azureConfig),
     ...(requestHeaders[`x-${POWERED_BY}-provider`] === BEDROCK &&
       bedrockConfig),
+    ...(requestHeaders[`x-${POWERED_BY}-provider`] === WORKERS_AI &&
+      workersAiConfig),
   };
 }

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -192,7 +192,8 @@ export const fetchProviderOptionsFromConfig = (
     if (camelCaseConfig.apiVersion)
       providerOptions[0].apiVersion = camelCaseConfig.apiVersion;
     if (camelCaseConfig.workersAiAccountId)
-      providerOptions[0].workersAiAccountId = camelCaseConfig.workersAiAccountId;
+      providerOptions[0].workersAiAccountId =
+        camelCaseConfig.workersAiAccountId;
     mode = 'single';
   } else {
     if (camelCaseConfig.strategy && camelCaseConfig.strategy.mode) {

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -192,7 +192,7 @@ export const fetchProviderOptionsFromConfig = (
     if (camelCaseConfig.apiVersion)
       providerOptions[0].apiVersion = camelCaseConfig.apiVersion;
     if (camelCaseConfig.accountId)
-      providerOptions[0].apiVersion = camelCaseConfig.accountId;
+      providerOptions[0].accountId = camelCaseConfig.accountId;
     mode = 'single';
   } else {
     if (camelCaseConfig.strategy && camelCaseConfig.strategy.mode) {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -19,6 +19,7 @@ import GroqConfig from './groq';
 import SegmindConfig from './segmind';
 import JinaConfig from './jina';
 import FireworksAIConfig from './fireworks-ai';
+import WorkersAiConfig from './workers-ai';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -41,6 +42,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   segmind: SegmindConfig,
   jina: JinaConfig,
   'fireworks-ai': FireworksAIConfig,
+  'workers-ai': WorkersAiConfig,
 };
 
 export default Providers;

--- a/src/providers/workers-ai/api.ts
+++ b/src/providers/workers-ai/api.ts
@@ -18,6 +18,8 @@ const WorkersAiAPIConfig: ProviderAPIConfig = {
       case 'chatComplete': {
         return `/${model}`;
       }
+      case 'embed':
+        return `/${model}`;
       default:
         return '';
     }

--- a/src/providers/workers-ai/api.ts
+++ b/src/providers/workers-ai/api.ts
@@ -1,0 +1,27 @@
+import { ProviderAPIConfig } from '../types';
+
+const WorkersAiAPIConfig: ProviderAPIConfig = {
+  getBaseURL: ({ providerOptions }) => {
+    const { accountId } = providerOptions;
+    return `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run`;
+  },
+  headers: ({ providerOptions }) => {
+    const { apiKey } = providerOptions;
+    return { Authorization: `Bearer ${apiKey}` };
+  },
+  getEndpoint: ({ providerOptions, fn, gatewayRequestBody: params }) => {
+    const { model } = params;
+    switch (fn) {
+      case 'complete': {
+        return `/${model}`;
+      }
+      case 'chatComplete': {
+        return `/${model}`;
+      }
+      default:
+        return '';
+    }
+  },
+};
+
+export default WorkersAiAPIConfig;

--- a/src/providers/workers-ai/api.ts
+++ b/src/providers/workers-ai/api.ts
@@ -2,8 +2,8 @@ import { ProviderAPIConfig } from '../types';
 
 const WorkersAiAPIConfig: ProviderAPIConfig = {
   getBaseURL: ({ providerOptions }) => {
-    const { accountId } = providerOptions;
-    return `https://api.cloudflare.com/client/v4/accounts/${accountId}/ai/run`;
+    const { workersAiAccountId } = providerOptions;
+    return `https://api.cloudflare.com/client/v4/accounts/${workersAiAccountId}/ai/run`;
   },
   headers: ({ providerOptions }) => {
     const { apiKey } = providerOptions;

--- a/src/providers/workers-ai/chatComplete.ts
+++ b/src/providers/workers-ai/chatComplete.ts
@@ -8,68 +8,10 @@ import {
 import { generateErrorResponse, generateInvalidProviderResponseError } from '../utils';
 
 export const WorkersAiChatCompleteConfig: ProviderConfig = {
-  messages: [
-    {
-      param: 'messages',
-      required: true,
-      transform: (params: Params) => {
-        let messages: Message[] = [];
-        // Transform the chat messages into a simple prompt
-        if (!!params.messages) {
-          params.messages.forEach((msg) => {
-            if (
-              msg.content &&
-              typeof msg.content === 'object' &&
-              msg.content.length
-            ) {
-              const transformedMessage: Record<string, any> = {
-                role: msg.role,
-                content: [],
-              };
-              msg.content.forEach((item) => {
-                if (item.type === 'text') {
-                  transformedMessage.content.push({
-                    type: item.type,
-                    text: item.text,
-                  });
-                } else if (
-                  item.type === 'image_url' &&
-                  item.image_url &&
-                  item.image_url.url
-                ) {
-                  const parts = item.image_url.url.split(';');
-                  if (parts.length === 2) {
-                    const base64ImageParts = parts[1].split(',');
-                    const base64Image = base64ImageParts[1];
-                    const mediaTypeParts = parts[0].split(':');
-                    if (mediaTypeParts.length === 2 && base64Image) {
-                      const mediaType = mediaTypeParts[1];
-                      transformedMessage.content.push({
-                        type: 'image',
-                        source: {
-                          type: 'base64',
-                          media_type: mediaType,
-                          data: base64Image,
-                        },
-                      });
-                    }
-                  }
-                }
-              });
-              messages.push(transformedMessage as Message);
-            } else {
-              messages.push({
-                role: msg.role,
-                content: msg.content,
-              });
-            }
-          });
-        }
-
-        return messages;
-      },
-    },
-  ],
+  messages: {
+    param: 'messages',
+    default: '',
+  },
   stream: {
     param: 'stream',
     default: false,

--- a/src/providers/workers-ai/chatComplete.ts
+++ b/src/providers/workers-ai/chatComplete.ts
@@ -16,6 +16,12 @@ export const WorkersAiChatCompleteConfig: ProviderConfig = {
     param: 'stream',
     default: false,
   },
+  raw: {
+    param: 'raw'
+  },
+  max_tokens: {
+    param: "max_tokens"
+  }
 };
 
 export interface WorkersAiErrorObject {

--- a/src/providers/workers-ai/chatComplete.ts
+++ b/src/providers/workers-ai/chatComplete.ts
@@ -1,0 +1,189 @@
+import { WORKERS_AI } from '../../globals';
+import { Params, Message } from '../../types/requestBody';
+import {
+  ChatCompletionResponse,
+  ErrorResponse,
+  ProviderConfig,
+} from '../types';
+
+export const WorkersAiChatCompleteConfig: ProviderConfig = {
+  messages: [
+    {
+      param: 'messages',
+      required: true,
+      transform: (params: Params) => {
+        let messages: Message[] = [];
+        // Transform the chat messages into a simple prompt
+        if (!!params.messages) {
+          params.messages.forEach((msg) => {
+            if (
+              msg.content &&
+              typeof msg.content === 'object' &&
+              msg.content.length
+            ) {
+              const transformedMessage: Record<string, any> = {
+                role: msg.role,
+                content: [],
+              };
+              msg.content.forEach((item) => {
+                if (item.type === 'text') {
+                  transformedMessage.content.push({
+                    type: item.type,
+                    text: item.text,
+                  });
+                } else if (
+                  item.type === 'image_url' &&
+                  item.image_url &&
+                  item.image_url.url
+                ) {
+                  const parts = item.image_url.url.split(';');
+                  if (parts.length === 2) {
+                    const base64ImageParts = parts[1].split(',');
+                    const base64Image = base64ImageParts[1];
+                    const mediaTypeParts = parts[0].split(':');
+                    if (mediaTypeParts.length === 2 && base64Image) {
+                      const mediaType = mediaTypeParts[1];
+                      transformedMessage.content.push({
+                        type: 'image',
+                        source: {
+                          type: 'base64',
+                          media_type: mediaType,
+                          data: base64Image,
+                        },
+                      });
+                    }
+                  }
+                }
+              });
+              messages.push(transformedMessage as Message);
+            } else {
+              messages.push({
+                role: msg.role,
+                content: msg.content,
+              });
+            }
+          });
+        }
+
+        return messages;
+      },
+    },
+  ],
+  stream: {
+    param: 'stream',
+    default: false,
+  },
+};
+
+export interface WorkersAiErrorObject {
+  type: string;
+  message: string;
+}
+
+interface WorkersAiErrorResponse {
+  type: string;
+  error: WorkersAiErrorObject;
+}
+
+interface WorkersAiChatCompleteResponse {
+  result: {
+    response: string;
+  };
+  success: boolean;
+  errors: string[];
+  messages: string[];
+}
+
+interface WorkersAiChatCompleteStreamResponse {
+  response: string;
+  p?: string;
+}
+
+// TODO: cloudflare do not return the usage
+// TODO: return the model
+export const WorkersAiChatCompleteResponseTransform: (
+  response: WorkersAiChatCompleteResponse | WorkersAiErrorResponse,
+  responseStatus: number
+) => ChatCompletionResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'errors' in response) {
+    return {
+      error: {
+        message: response.errors?.join(','),
+        type: null,
+        param: null,
+        code: null,
+      },
+      provider: WORKERS_AI,
+    } as ErrorResponse;
+  }
+
+  if ('result' in response) {
+    // const { input_tokens = 0, output_tokens = 0 } = {};
+
+    return {
+      id: Date.now().toString(),
+      object: 'chat_completion',
+      created: Math.floor(Date.now() / 1000),
+      model: '',
+      provider: WORKERS_AI,
+      choices: [
+        {
+          message: { role: 'assistant', content: response.result.response },
+          index: 0,
+          logprobs: null,
+          finish_reason: '',
+        },
+      ],
+      // usage: {
+      //   prompt_tokens: input_tokens,
+      //   completion_tokens: output_tokens,
+      //   total_tokens: input_tokens + output_tokens,
+      // },
+    };
+  }
+
+  return {
+    error: {
+      message: `Invalid response received from WorkersAi: ${JSON.stringify(response)}`,
+      type: null,
+      param: null,
+      code: null,
+    },
+    provider: WORKERS_AI,
+  } as ErrorResponse;
+};
+
+export const WorkersAiChatCompleteStreamChunkTransform: (
+  response: string,
+  fallbackId: string
+) => string | undefined = (responseChunk, fallbackId) => {
+  let chunk = responseChunk.trim();
+
+  if (chunk.startsWith('data: [DONE]')) {
+    return 'data: [DONE]\n\n';
+  }
+
+  chunk = chunk.replace(/^data: /, '');
+  chunk = chunk.trim();
+
+  const parsedChunk: WorkersAiChatCompleteStreamResponse = JSON.parse(chunk);
+  return (
+    `data: ${JSON.stringify({
+      id: fallbackId,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model: '',
+      provider: WORKERS_AI,
+      choices: [
+        {
+          delta: {
+            content: parsedChunk.response,
+          },
+          index: 0,
+          logprobs: null,
+          finish_reason: null,
+        },
+      ],
+    })}` + '\n\n'
+  );
+};

--- a/src/providers/workers-ai/chatComplete.ts
+++ b/src/providers/workers-ai/chatComplete.ts
@@ -119,7 +119,6 @@ export const WorkersAiErrorResponseTransform: (
 };
 
 // TODO: cloudflare do not return the usage
-// TODO: return the model
 export const WorkersAiChatCompleteResponseTransform: (
   response: WorkersAiChatCompleteResponse | WorkersAiErrorResponse,
   responseStatus: number
@@ -136,7 +135,7 @@ export const WorkersAiChatCompleteResponseTransform: (
       id: Date.now().toString(),
       object: 'chat_completion',
       created: Math.floor(Date.now() / 1000),
-      model: '',
+      model: '',  // TODO: find a way to send the cohere embedding model name back
       provider: WORKERS_AI,
       choices: [
         {

--- a/src/providers/workers-ai/chatComplete.ts
+++ b/src/providers/workers-ai/chatComplete.ts
@@ -5,7 +5,10 @@ import {
   ErrorResponse,
   ProviderConfig,
 } from '../types';
-import { generateErrorResponse, generateInvalidProviderResponseError } from '../utils';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+} from '../utils';
 
 export const WorkersAiChatCompleteConfig: ProviderConfig = {
   messages: {
@@ -17,11 +20,11 @@ export const WorkersAiChatCompleteConfig: ProviderConfig = {
     default: false,
   },
   raw: {
-    param: 'raw'
+    param: 'raw',
   },
   max_tokens: {
-    param: "max_tokens"
-  }
+    param: 'max_tokens',
+  },
 };
 
 export interface WorkersAiErrorObject {
@@ -54,7 +57,9 @@ export const WorkersAiErrorResponseTransform: (
   if ('errors' in response) {
     return generateErrorResponse(
       {
-        message: response.errors?.map((error) => `Error ${error.code}:${error.message}`).join(', '),
+        message: response.errors
+          ?.map((error) => `Error ${error.code}:${error.message}`)
+          .join(', '),
         type: null,
         param: null,
         code: null,
@@ -83,7 +88,7 @@ export const WorkersAiChatCompleteResponseTransform: (
       id: Date.now().toString(),
       object: 'chat_completion',
       created: Math.floor(Date.now() / 1000),
-      model: '',  // TODO: find a way to send the cohere embedding model name back
+      model: '', // TODO: find a way to send the cohere embedding model name back
       provider: WORKERS_AI,
       choices: [
         {

--- a/src/providers/workers-ai/chatComplete.ts
+++ b/src/providers/workers-ai/chatComplete.ts
@@ -118,8 +118,6 @@ export const WorkersAiChatCompleteResponseTransform: (
   }
 
   if ('result' in response) {
-    // const { input_tokens = 0, output_tokens = 0 } = {};
-
     return {
       id: Date.now().toString(),
       object: 'chat_completion',
@@ -134,11 +132,6 @@ export const WorkersAiChatCompleteResponseTransform: (
           finish_reason: '',
         },
       ],
-      // usage: {
-      //   prompt_tokens: input_tokens,
-      //   completion_tokens: output_tokens,
-      //   total_tokens: input_tokens + output_tokens,
-      // },
     };
   }
 

--- a/src/providers/workers-ai/complete.ts
+++ b/src/providers/workers-ai/complete.ts
@@ -1,0 +1,95 @@
+import { Params } from '../../types/requestBody';
+import { CompletionResponse, ErrorResponse, ProviderConfig } from '../types';
+import { WorkersAiErrorObject } from './chatComplete';
+import { WORKERS_AI } from '../../globals';
+
+export const WorkersAiCompleteConfig: ProviderConfig = {
+  prompt: {
+    param: 'prompt',
+    transform: (params: Params) => `\n\nHuman: ${params.prompt}\n\nAssistant:`,
+    required: true,
+  },
+  stream: {
+    param: 'stream',
+    default: false,
+  },
+};
+
+interface WorkersAiCompleteResponse {
+  result: {
+    response: string;
+  };
+  success: boolean;
+  errors: string[];
+  messages: string[];
+}
+
+interface WorkersAiCompleteStreamResponse {
+  response: string;
+  p?: string;
+}
+
+export const WorkersAiCompleteResponseTransform: (
+  response: WorkersAiCompleteResponse,
+  responseStatus: number
+) => CompletionResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'errors' in response) {
+    return {
+      error: {
+        message: response.errors?.join(','),
+        type: null,
+        param: null,
+        code: null,
+      },
+      provider: WORKERS_AI,
+    } as ErrorResponse;
+  }
+
+  return {
+    id: Date.now().toString(),
+    object: 'text_completion',
+    created: Math.floor(Date.now() / 1000),
+    model: '',
+    provider: WORKERS_AI,
+    choices: [
+      {
+        text: response.result.response,
+        index: 0,
+        logprobs: null,
+        finish_reason: '',
+      },
+    ],
+  };
+};
+
+export const WorkersAiCompleteStreamChunkTransform: (
+  response: string
+) => string | undefined = (responseChunk) => {
+  let chunk = responseChunk.trim();
+
+  if (chunk.startsWith('data: [DONE]')) {
+    return 'data: [DONE]\n\n';
+  }
+
+  chunk = chunk.replace(/^data: /, '');
+  chunk = chunk.trim();
+
+  const parsedChunk: WorkersAiCompleteStreamResponse = JSON.parse(chunk);
+  return (
+    `data: ${JSON.stringify({
+      id: '',
+      object: 'text_completion',
+      created: Math.floor(Date.now() / 1000),
+      model: '',
+      provider: WORKERS_AI,
+      choices: [
+        {
+          text: parsedChunk.response,
+          index: 0,
+          logprobs: null,
+          finish_reason: '',
+        },
+      ],
+    })}` + '\n\n'
+  );
+};

--- a/src/providers/workers-ai/complete.ts
+++ b/src/providers/workers-ai/complete.ts
@@ -1,7 +1,10 @@
 import { Params } from '../../types/requestBody';
 import { CompletionResponse, ErrorResponse, ProviderConfig } from '../types';
 import { WORKERS_AI } from '../../globals';
-import { generateErrorResponse, generateInvalidProviderResponseError } from '../utils';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+} from '../utils';
 
 export const WorkersAiCompleteConfig: ProviderConfig = {
   prompt: {
@@ -14,10 +17,10 @@ export const WorkersAiCompleteConfig: ProviderConfig = {
     default: false,
   },
   raw: {
-    param: 'raw'
+    param: 'raw',
   },
   max_tokens: {
-    param: "max_tokens"
+    param: 'max_tokens',
   },
 };
 
@@ -51,7 +54,9 @@ export const WorkersAiErrorResponseTransform: (
   if ('errors' in response) {
     return generateErrorResponse(
       {
-        message: response.errors?.map((error) => `Error ${error.code}:${error.message}`).join(', '),
+        message: response.errors
+          ?.map((error) => `Error ${error.code}:${error.message}`)
+          .join(', '),
         type: null,
         param: null,
         code: null,
@@ -113,7 +118,7 @@ export const WorkersAiCompleteStreamChunkTransform: (
       id: '',
       object: 'text_completion',
       created: Math.floor(Date.now() / 1000),
-      model: '',  // TODO: find a way to send the cohere embedding model name back
+      model: '', // TODO: find a way to send the cohere embedding model name back
       provider: WORKERS_AI,
       choices: [
         {

--- a/src/providers/workers-ai/complete.ts
+++ b/src/providers/workers-ai/complete.ts
@@ -107,7 +107,7 @@ export const WorkersAiCompleteStreamChunkTransform: (
       id: '',
       object: 'text_completion',
       created: Math.floor(Date.now() / 1000),
-      model: '',
+      model: '',  // TODO: find a way to send the cohere embedding model name back
       provider: WORKERS_AI,
       choices: [
         {

--- a/src/providers/workers-ai/complete.ts
+++ b/src/providers/workers-ai/complete.ts
@@ -13,6 +13,12 @@ export const WorkersAiCompleteConfig: ProviderConfig = {
     param: 'stream',
     default: false,
   },
+  raw: {
+    param: 'raw'
+  },
+  max_tokens: {
+    param: "max_tokens"
+  },
 };
 
 export interface WorkersAiErrorObject {

--- a/src/providers/workers-ai/embed.ts
+++ b/src/providers/workers-ai/embed.ts
@@ -1,0 +1,90 @@
+import { WORKERS_AI } from '../../globals';
+import { EmbedParams, EmbedResponse } from '../../types/embedRequestBody';
+import { ErrorResponse, ProviderConfig } from '../types';
+import { generateErrorResponse, generateInvalidProviderResponseError } from '../utils';
+
+export const WorkersAiEmbedConfig: ProviderConfig = {
+  input: {
+    param: 'text',
+    required: true,
+    transform: (params: EmbedParams): string[] => {
+      if (Array.isArray(params.input)) {
+        return params.input;
+      } else {
+        return [params.input];
+      }
+    },
+  },
+};
+
+export interface WorkersAiErrorObject {
+  code: string;
+  message: string;
+}
+
+interface WorkersAiErrorResponse {
+  success: boolean;
+  errors: WorkersAiErrorObject[];
+}
+
+export const WorkersAiErrorResponseTransform: (
+  response: WorkersAiErrorResponse
+) => ErrorResponse | undefined = (response) => {
+  if ('errors' in response) {
+    return generateErrorResponse(
+      {
+        message: response.errors?.map((error) => `Error ${error.code}:${error.message}`).join(', '),
+        type: null,
+        param: null,
+        code: null,
+      },
+      WORKERS_AI
+    );
+  }
+
+  return undefined;
+};
+
+/**
+ * The structure of the CohereEmbedResponse.
+ * @interface
+ */
+export interface WorkersAiEmbedResponse {
+  result: {
+    /** An array of strings which were the input texts to be embedded. */
+    shape: number[];
+
+    /** A 2D array of floating point numbers representing the embeddings. */
+    data: number[][];
+  }
+}
+
+export const WorkersAiEmbedResponseTransform: (
+  response: WorkersAiEmbedResponse | WorkersAiErrorResponse,
+  responseStatus: number
+) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200) {
+    const errorResponse = WorkersAiErrorResponseTransform(
+      response as WorkersAiErrorResponse
+    );
+    if (errorResponse) return errorResponse;
+  }
+
+  if ('result' in response) {
+    return {
+      object: 'list',
+      data: response.result.data.map((embedding, index) => ({
+        object: 'embedding',
+        embedding: embedding,
+        index: index,
+      })),
+      model: '', // TODO: find a way to send the cohere embedding model name back
+      usage: {
+        prompt_tokens: -1,
+        total_tokens: -1,
+      },
+    };
+  }
+
+  return generateInvalidProviderResponseError(response, WORKERS_AI);
+};

--- a/src/providers/workers-ai/embed.ts
+++ b/src/providers/workers-ai/embed.ts
@@ -1,7 +1,10 @@
 import { WORKERS_AI } from '../../globals';
 import { EmbedParams, EmbedResponse } from '../../types/embedRequestBody';
 import { ErrorResponse, ProviderConfig } from '../types';
-import { generateErrorResponse, generateInvalidProviderResponseError } from '../utils';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+} from '../utils';
 
 export const WorkersAiEmbedConfig: ProviderConfig = {
   input: {
@@ -33,7 +36,9 @@ export const WorkersAiErrorResponseTransform: (
   if ('errors' in response) {
     return generateErrorResponse(
       {
-        message: response.errors?.map((error) => `Error ${error.code}:${error.message}`).join(', '),
+        message: response.errors
+          ?.map((error) => `Error ${error.code}:${error.message}`)
+          .join(', '),
         type: null,
         param: null,
         code: null,
@@ -56,7 +61,7 @@ export interface WorkersAiEmbedResponse {
 
     /** A 2D array of floating point numbers representing the embeddings. */
     data: number[][];
-  }
+  };
 }
 
 export const WorkersAiEmbedResponseTransform: (

--- a/src/providers/workers-ai/index.ts
+++ b/src/providers/workers-ai/index.ts
@@ -10,16 +10,19 @@ import {
   WorkersAiCompleteResponseTransform,
   WorkersAiCompleteStreamChunkTransform,
 } from './complete';
+import { WorkersAiEmbedConfig, WorkersAiEmbedResponseTransform } from './embed';
 
 const WorkersAiConfig: ProviderConfigs = {
   complete: WorkersAiCompleteConfig,
   chatComplete: WorkersAiChatCompleteConfig,
   api: WorkersAiAPIConfig,
+  embed: WorkersAiEmbedConfig,
   responseTransforms: {
     'stream-complete': WorkersAiCompleteStreamChunkTransform,
     complete: WorkersAiCompleteResponseTransform,
     chatComplete: WorkersAiChatCompleteResponseTransform,
     'stream-chatComplete': WorkersAiChatCompleteStreamChunkTransform,
+    embed: WorkersAiEmbedResponseTransform,
   },
 };
 

--- a/src/providers/workers-ai/index.ts
+++ b/src/providers/workers-ai/index.ts
@@ -1,0 +1,26 @@
+import { ProviderConfigs } from '../types';
+import WorkersAiAPIConfig from './api';
+import {
+  WorkersAiChatCompleteConfig,
+  WorkersAiChatCompleteResponseTransform,
+  WorkersAiChatCompleteStreamChunkTransform,
+} from './chatComplete';
+import {
+  WorkersAiCompleteConfig,
+  WorkersAiCompleteResponseTransform,
+  WorkersAiCompleteStreamChunkTransform,
+} from './complete';
+
+const WorkersAiConfig: ProviderConfigs = {
+  complete: WorkersAiCompleteConfig,
+  chatComplete: WorkersAiChatCompleteConfig,
+  api: WorkersAiAPIConfig,
+  responseTransforms: {
+    'stream-complete': WorkersAiCompleteStreamChunkTransform,
+    complete: WorkersAiCompleteResponseTransform,
+    chatComplete: WorkersAiChatCompleteResponseTransform,
+    'stream-chatComplete': WorkersAiChatCompleteStreamChunkTransform,
+  },
+};
+
+export default WorkersAiConfig;

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -43,6 +43,8 @@ export interface Options {
   deploymentId?: string;
   apiVersion?: string;
   adAuth?: string;
+  /** Workers AI specific */
+  accountId?: string;
   /** The parameter to set custom base url */
   customHost?: string;
   /** The parameter to set list of headers to be forwarded as-is to the provider */
@@ -239,6 +241,7 @@ export interface ShortConfig {
   retry?: RetrySettings;
   resourceName?: string;
   deploymentId?: string;
+  accountId?: string;
   apiVersion?: string;
   customHost?: string;
 }

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -44,7 +44,7 @@ export interface Options {
   apiVersion?: string;
   adAuth?: string;
   /** Workers AI specific */
-  accountId?: string;
+  workersAiAccountId?: string;
   /** The parameter to set custom base url */
   customHost?: string;
   /** The parameter to set list of headers to be forwarded as-is to the provider */
@@ -241,7 +241,7 @@ export interface ShortConfig {
   retry?: RetrySettings;
   resourceName?: string;
   deploymentId?: string;
-  accountId?: string;
+  workersAiAccountId?: string;
   apiVersion?: string;
   customHost?: string;
 }


### PR DESCRIPTION
**Title:** 
This PR is a first draft to support Cloudflare Workers AI.

One new required header is added : 

```
'x-portkey-workers-ai-account-id': 'your cloudflare account id'
```

Chat requests are compatible with portkey, with streaming:

```
{
    "model": "@cf/meta/llama-2-7b-chat-int8",
    "messages": [
        {
            "role": "system",
            "content": "you are a helpful assistant"
        },
        {
            "role": "user",
            "content": "hi"
        }
    ],
    "stream": true
}
```

**Motivation:**
I needed this integration for a side project, since the api is fairly simple i added this support for the completion api.

⚠️ Cloudflare Workers AI api supports lots of models (tex, image, embeddings), so i guess a more broader support could be handled. 

This is only what i needed so far, but if there is wider interest in this integration i'm welcoming help and feedback.

