### PR TITLE
fix: map headers to lower case to avoid conflicts with forward headers

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -54,14 +54,19 @@ export function constructRequest(
     'content-type': 'application/json',
   };
 
-  let headers: Record<string, string> = {
-    ...providerConfigMappedHeaders,
-  };
+  let headers: Record<string, string> = {};
+
+  Object.keys(providerConfigMappedHeaders).forEach((h: string) => {
+    headers[h.toLowerCase()] = providerConfigMappedHeaders[h];
+  });
 
   const forwardHeadersMap: Record<string, string> = {};
 
   forwardHeaders.forEach((h: string) => {
-    if (requestHeaders[h]) forwardHeadersMap[h] = requestHeaders[h];
+    const lowerCaseHeaderKey = h.toLowerCase();
+    if (requestHeaders[lowerCaseHeaderKey])
+      forwardHeadersMap[lowerCaseHeaderKey] =
+        requestHeaders[lowerCaseHeaderKey];
   });
 
   // Add any headers that the model might need


### PR DESCRIPTION
**Title:** 
- fix: map headers to lower case to avoid conflicts with forward headers

**Description:** (optional)
- Convert forward_headers keys to lower casing before mapping the final headers object

**Motivation:** (optional)
- To resolve conflicts in header names while creating final request header object for a provider

**Related Issues:** (optional)
- Fixes #336 
