### PR TITLE
chore: update docker publish action with docker org name variable

### DIFF
--- a/.github/workflows/docker_publish.yml
+++ b/.github/workflows/docker_publish.yml
@@ -28,7 +28,7 @@ jobs:
         id: meta
         uses: docker/metadata-action@v5
         with:
-          images: ${{ secrets.DOCKER_USERNAME }}/gateway
+          images: ${{ secrets.DOCKER_ORGANISATION }}/gateway
           tags: |
             type=raw,value=latest
             type=pep440,pattern={{version}},value=${{ github.event.release.tag_name }}


### PR DESCRIPTION
**Title:** 
- chore: update docker publish action with docker org name variable

**Description:** (optional)
- Use new actions secret DOCKER_ORGANISATION in docker-publish workflow

**Motivation:** (optional)
- Update Github workflow

**Related Issues:** (optional)
- Closes #338 
