### PR TITLE
fix: add bearer to zhipu-ai authorization header

### DIFF
--- a/src/providers/zhipu/api.ts
+++ b/src/providers/zhipu/api.ts
@@ -3,7 +3,7 @@ import { ProviderAPIConfig } from '../types';
 const ZhipuAPIConfig: ProviderAPIConfig = {
   getBaseURL: () => 'https://open.bigmodel.cn/api/paas/v4',
   headers: ({ providerOptions }) => {
-    return { Authorization: `${providerOptions.apiKey}` }; // https://open.bigmodel.cn/usercenter/apikeys
+    return { Authorization: `Bearer ${providerOptions.apiKey}` }; // https://open.bigmodel.cn/usercenter/apikeys
   },
   getEndpoint: ({ fn }) => {
     switch (fn) {


### PR DESCRIPTION
**Title:** 
- add bearer to zhipu-ai authorization header

**Description:** (optional)
- add `Bearer ` before auth token for zhipu-ai authorization header

**Motivation:** (optional)
- Send auth header as per zhipu ai API docs

**Related Issues:** (optional)
- Fixes #349 
