### PR TITLE
feat: map usage tokens for anthropic messages stream

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -269,7 +269,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
 
   const parsedChunk: AnthropicChatCompleteStreamResponse = JSON.parse(chunk);
 
-  if (parsedChunk.type === 'message_start') {
+  if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
     return (
       `data: ${JSON.stringify({
         id: fallbackId,
@@ -294,7 +294,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
     );
   }
 
-  if (parsedChunk.type === 'message_delta') {
+  if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
     return (
       `data: ${JSON.stringify({
         id: fallbackId,

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -174,6 +174,16 @@ interface AnthropicChatCompleteStreamResponse {
     text: string;
     stop_reason?: string;
   };
+  usage?: {
+    output_tokens?: number;
+    input_tokens?: number;
+  };
+  message?: {
+    usage?: {
+      output_tokens?: number;
+      input_tokens?: number;
+    };
+  };
 }
 
 export const AnthropicErrorResponseTransform: (
@@ -241,7 +251,6 @@ export const AnthropicChatCompleteStreamChunkTransform: (
   let chunk = responseChunk.trim();
   if (
     chunk.startsWith('event: ping') ||
-    chunk.startsWith('event: message_start') ||
     chunk.startsWith('event: content_block_start') ||
     chunk.startsWith('event: content_block_stop')
   ) {
@@ -254,10 +263,59 @@ export const AnthropicChatCompleteStreamChunkTransform: (
 
   chunk = chunk.replace(/^event: content_block_delta[\r\n]*/, '');
   chunk = chunk.replace(/^event: message_delta[\r\n]*/, '');
+  chunk = chunk.replace(/^event: message_start[\r\n]*/, '');
   chunk = chunk.replace(/^data: /, '');
   chunk = chunk.trim();
 
   const parsedChunk: AnthropicChatCompleteStreamResponse = JSON.parse(chunk);
+
+  if (parsedChunk.type === 'message_start') {
+    return (
+      `data: ${JSON.stringify({
+        id: fallbackId,
+        object: 'chat.completion.chunk',
+        created: Math.floor(Date.now() / 1000),
+        model: '',
+        provider: ANTHROPIC,
+        choices: [
+          {
+            delta: {
+              content: '',
+            },
+            index: 0,
+            logprobs: null,
+            finish_reason: null,
+          },
+        ],
+        usage: {
+          prompt_tokens: parsedChunk.message?.usage?.input_tokens,
+        },
+      })}` + '\n\n'
+    );
+  }
+
+  if (parsedChunk.type === 'message_delta') {
+    return (
+      `data: ${JSON.stringify({
+        id: fallbackId,
+        object: 'chat.completion.chunk',
+        created: Math.floor(Date.now() / 1000),
+        model: '',
+        provider: ANTHROPIC,
+        choices: [
+          {
+            index: 0,
+            delta: {},
+            finish_reason: parsedChunk.delta?.stop_reason,
+          },
+        ],
+        usage: {
+          completion_tokens: parsedChunk.usage?.output_tokens,
+        },
+      })}` + '\n\n'
+    );
+  }
+
   return (
     `data: ${JSON.stringify({
       id: fallbackId,


### PR DESCRIPTION
**Title:** 
- map usage tokens for anthropic messages stream

**Description:** (optional)
- Update anthropic chat complete stream transform to extract usage from chunks. More details in attached issue

**Motivation:** (optional)
- To send accurate tokens for anthropic messages

**Related Issues:** (optional)
- Closes #350 
