### PR TITLE
fix: pick up stream chunk index from response for novita-ai

### DIFF
--- a/src/providers/novita-ai/chatComplete.ts
+++ b/src/providers/novita-ai/chatComplete.ts
@@ -211,7 +211,7 @@ export const NovitaAIChatCompleteStreamChunkTransform: (
           delta: {
             content: parsedChunk.choices[0]?.delta.content,
           },
-          index: 0,
+          index: parsedChunk.choices[0]?.index || 0,
           finish_reason: '',
         },
       ],


### PR DESCRIPTION
**Title:** 
- pick up stream chunk index from response for novita-ai

**Description:** (optional)
- Get chunk index from actual chunk instead of harcoding it to 0 for NovitaAI

**Motivation:** (optional)
- Fix streaming bug for novita-ai

**Related Issues:** (optional)
- Fixes #354 
