### PR TITLE
[FEATURE] Support predibase LLM serving a base model with optional fine-tuned adapter.

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -52,6 +52,7 @@ export const LINGYI: string = 'lingyi';
 export const ZHIPU: string = 'zhipu';
 export const NOVITA_AI: string = 'novita-ai';
 export const MONSTERAPI: string = 'monsterapi';
+export const PREDIBASE: string = 'predibase';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -83,6 +84,7 @@ export const VALID_PROVIDERS = [
   ZHIPU,
   NOVITA_AI,
   MONSTERAPI,
+  PREDIBASE,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -28,6 +28,7 @@ import LingYiConfig from './lingyi';
 import ZhipuConfig from './zhipu';
 import NovitaAIConfig from './novita-ai';
 import MonsterAPIConfig from './monsterapi';
+import PredibaseConfig from './predibase';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -59,6 +60,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   zhipu: ZhipuConfig,
   'novita-ai': NovitaAIConfig,
   monsterapi: MonsterAPIConfig,
+  predibase: PredibaseConfig,
 };
 
 export default Providers;

--- a/src/providers/predibase/api.ts
+++ b/src/providers/predibase/api.ts
@@ -2,7 +2,6 @@ import { ProviderAPIConfig } from '../types';
 
 const PredibaseAPIConfig: ProviderAPIConfig = {
   getBaseURL: () => 'https://serving.app.predibase.com',
-  // getBaseURL: () => 'https://serving.staging.predibase.com',
   headers: ({ providerOptions }) => {
     return {
       'Authorization': `Bearer ${providerOptions.apiKey}`,

--- a/src/providers/predibase/api.ts
+++ b/src/providers/predibase/api.ts
@@ -4,8 +4,8 @@ const PredibaseAPIConfig: ProviderAPIConfig = {
   getBaseURL: () => 'https://serving.app.predibase.com',
   headers: ({ providerOptions }) => {
     return {
-      'Authorization': `Bearer ${providerOptions.apiKey}`,
-      'Accept': 'application/json',
+      Authorization: `Bearer ${providerOptions.apiKey}`,
+      Accept: 'application/json',
     };
   },
   getEndpoint: ({ fn, gatewayRequestBody }) => {

--- a/src/providers/predibase/api.ts
+++ b/src/providers/predibase/api.ts
@@ -1,4 +1,5 @@
 import { ProviderAPIConfig } from '../types';
+import { splitString } from '../utils';
 
 const PredibaseAPIConfig: ProviderAPIConfig = {
   getBaseURL: () => 'https://serving.app.predibase.com',
@@ -11,9 +12,11 @@ const PredibaseAPIConfig: ProviderAPIConfig = {
   getEndpoint: ({ fn, gatewayRequestBody }) => {
     const user = gatewayRequestBody?.user;
     const model = gatewayRequestBody?.model;
+    const base_model = splitString(`${model}`, ":").before
     switch (fn) {
       case 'chatComplete':
-        return `/${user}/deployments/v2/llms/${model}/v1/chat/completions`;
+        // The Predibase model format is "<base_model>[:adapter_id]".
+        return `/${user}/deployments/v2/llms/${base_model}/v1/chat/completions`;
       default:
         return '';
     }

--- a/src/providers/predibase/api.ts
+++ b/src/providers/predibase/api.ts
@@ -1,8 +1,8 @@
 import { ProviderAPIConfig } from '../types';
 
 const PredibaseAPIConfig: ProviderAPIConfig = {
-  // getBaseURL: () => 'https://serving.app.predibase.com/',
-  getBaseURL: () => 'https://serving.staging.predibase.com',
+  getBaseURL: () => 'https://serving.app.predibase.com',
+  // getBaseURL: () => 'https://serving.staging.predibase.com',
   headers: ({ providerOptions }) => {
     return {
       'Authorization': `Bearer ${providerOptions.apiKey}`,
@@ -12,8 +12,6 @@ const PredibaseAPIConfig: ProviderAPIConfig = {
   getEndpoint: ({ fn, gatewayRequestBody }) => {
     const user = gatewayRequestBody?.user;
     const model = gatewayRequestBody?.model;
-    console.log(fn)
-    console.log(gatewayRequestBody)
     switch (fn) {
       case 'chatComplete':
         return `/${user}/deployments/v2/llms/${model}/v1/chat/completions`;

--- a/src/providers/predibase/api.ts
+++ b/src/providers/predibase/api.ts
@@ -6,7 +6,6 @@ const PredibaseAPIConfig: ProviderAPIConfig = {
   headers: ({ providerOptions }) => {
     return {
       'Authorization': `Bearer ${providerOptions.apiKey}`,
-      // 'Content-Type': 'application/json',
       'Accept': 'application/json',
     };
   },
@@ -17,9 +16,7 @@ const PredibaseAPIConfig: ProviderAPIConfig = {
     console.log(gatewayRequestBody)
     switch (fn) {
       case 'chatComplete':
-        return `${user}/deployments/v2/llms/${model}/generate`;
-      // case 'chat/completions':
-      //   return `${user}/deployments/v2/llms/${model}/generate`;
+        return `/${user}/deployments/v2/llms/${model}/v1/chat/completions`;
       default:
         return '';
     }

--- a/src/providers/predibase/api.ts
+++ b/src/providers/predibase/api.ts
@@ -1,0 +1,29 @@
+import { ProviderAPIConfig } from '../types';
+
+const PredibaseAPIConfig: ProviderAPIConfig = {
+  // getBaseURL: () => 'https://serving.app.predibase.com/',
+  getBaseURL: () => 'https://serving.staging.predibase.com',
+  headers: ({ providerOptions }) => {
+    return {
+      'Authorization': `Bearer ${providerOptions.apiKey}`,
+      // 'Content-Type': 'application/json',
+      'Accept': 'application/json',
+    };
+  },
+  getEndpoint: ({ fn, gatewayRequestBody }) => {
+    const user = gatewayRequestBody?.user;
+    const model = gatewayRequestBody?.model;
+    console.log(fn)
+    console.log(gatewayRequestBody)
+    switch (fn) {
+      case 'chatComplete':
+        return `${user}/deployments/v2/llms/${model}/generate`;
+      // case 'chat/completions':
+      //   return `${user}/deployments/v2/llms/${model}/generate`;
+      default:
+        return '';
+    }
+  },
+};
+
+export default PredibaseAPIConfig;

--- a/src/providers/predibase/api.ts
+++ b/src/providers/predibase/api.ts
@@ -15,7 +15,11 @@ const PredibaseAPIConfig: ProviderAPIConfig = {
     const base_model = splitString(`${model}`, ':').before;
     switch (fn) {
       case 'chatComplete':
-        // The Predibase model format is "<base_model>[:adapter_id]".
+        /*
+        The Predibase model format is "<base_model>[:adapter_id]",
+        where adapter_id format is "<adapter_repository_reference/version_number"
+        (version_number is required).
+        */
         return `/${user}/deployments/v2/llms/${base_model}/v1/chat/completions`;
       default:
         return '';

--- a/src/providers/predibase/api.ts
+++ b/src/providers/predibase/api.ts
@@ -12,7 +12,7 @@ const PredibaseAPIConfig: ProviderAPIConfig = {
   getEndpoint: ({ fn, gatewayRequestBody }) => {
     const user = gatewayRequestBody?.user;
     const model = gatewayRequestBody?.model;
-    const base_model = splitString(`${model}`, ":").before
+    const base_model = splitString(`${model}`, ':').before;
     switch (fn) {
       case 'chatComplete':
         // The Predibase model format is "<base_model>[:adapter_id]".

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -1,0 +1,118 @@
+import { PREDIBASE } from '../../globals';
+import {
+  ChatCompletionResponse,
+  ErrorResponse,
+  ProviderConfig,
+} from '../types';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+} from '../utils';
+
+export const PredibaseChatCompleteConfig: ProviderConfig = {
+  user: {
+    param: 'user',
+    required: true,
+  },
+  model: {
+    param: 'model',
+    required: true,
+    default: 'mistral-7b-instruct-v0-2',
+  },
+  messages: {
+    param: 'messages',
+    required: true,
+    default: [],
+  },
+  max_tokens: {
+    param: 'max_tokens',
+    default: 2048,
+    min: 0,
+  },
+  temperature: {
+    param: 'temperature',
+    default: 0.1,
+    min: 0,
+    max: 1,
+  },
+  //Add more parameters once prototype with basics works.
+  /*
+  ignore_eos_token: {
+    param: 'ignore_eos_token',
+    default: false,
+  },
+  top_p: {
+    param: 'top_k',
+    default: 1,
+    min: 0,
+    max: 1,
+  },
+  */
+  /*
+  ignore_eos_token: bool = False,
+  best_of: Optional[int] = None,
+  repetition_penalty: Optional[float] = None,
+  return_full_text: bool = False,
+  seed: Optional[int] = None,
+  stop_sequences: Optional[List[str]] = None,
+  temperature: Optional[float] = None,
+  top_k: Optional[int] = None,
+  top_p: Optional[float] = None,
+  truncate: Optional[int] = None,
+  typical_p: Optional[float] = None,
+  */
+};
+
+interface PredibaseChatCompleteResponse extends ChatCompletionResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export interface PredibaseErrorResponse extends ErrorResponse {}
+
+export const PredibaseChatCompleteResponseTransform: (
+  response: PredibaseChatCompleteResponse | PredibaseErrorResponse,
+  responseStatus: number
+) => ChatCompletionResponse | ErrorResponse = (response, responseStatus) => {
+  if ('error' in response && responseStatus !== 200) {
+    return generateErrorResponse(
+      {
+        message: response.error.message,
+        type: response.error.type,
+        param: null,
+        code: response.error.code?.toString() || null,
+      },
+      PREDIBASE
+    );
+  }
+
+  if ('choices' in response) {
+    return {
+      id: response.id,
+      object: response.object,
+      created: response.created,
+      model: response.model,
+      provider: PREDIBASE,
+      choices: response.choices.map((c) => ({
+        index: c.index,
+        message: c.message,
+        logprobs: c.logprobs,
+        finish_reason: c.finish_reason,
+      })),
+      usage: {
+        prompt_tokens: response.usage?.prompt_tokens || 0,
+        completion_tokens: response.usage?.completion_tokens || 0,
+        total_tokens: response.usage?.total_tokens || 0,
+      },
+    };
+  }
+
+  return generateInvalidProviderResponseError(response, PREDIBASE);
+};

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -7,15 +7,16 @@ import {
 import {
   generateErrorResponse,
   generateInvalidProviderResponseError,
+  splitString,
 } from '../utils';
 
 export const PredibaseChatCompleteConfig: ProviderConfig = {
-  //Add more parameters once prototype with basics works.
   model: {
     param: 'model',
     required: false,
-    transform: (value: string) => {
-      return value;
+    // The Predibase model format is "<base_model>[:adapter_id]".
+    transform: (value: PredibaseChatCompleteResponse) => {
+      return splitString(value.model, ":").after;
     },
   },
   messages: {
@@ -35,6 +36,28 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
     default: 0.1,
     min: 0,
     max: 1,
+  },
+  top_p: {
+    param: 'top_p',
+    required: false,
+    default: 1,
+    min: 0,
+    max: 1,
+  },
+  stream: {
+    param: 'stream',
+    default: false,
+  },
+  n: {
+    param: 'n',
+    required: false,
+    default: 1,
+    max: 1,
+    min: 1,
+  },
+  stop: {
+    param: 'stop',
+    required: false,
   },
 };
 

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -16,7 +16,7 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
     required: false,
     // The Predibase model format is "<base_model>[:adapter_id]".
     transform: (value: PredibaseChatCompleteResponse) => {
-      return splitString(value.model, ":").after;
+      return splitString(value.model, ':').after;
     },
   },
   messages: {

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -14,7 +14,12 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
   model: {
     param: 'model',
     required: false,
-    // The Predibase model format is "<base_model>[:adapter_id]".
+    default: '',
+    /*
+    The Predibase model format is "<base_model>[:adapter_id]",
+    where adapter_id format is "<adapter_repository_reference/version_number"
+    (version_number is required).
+    */
     transform: (value: PredibaseChatCompleteResponse) => {
       return splitString(value.model, ':').after;
     },

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -67,8 +67,8 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
   top_k: {
     param: 'top_k',
     required: false,
-    default: -1, 
-  }, 
+    default: -1,
+  },
   best_of: {
     param: 'best_of',
     required: false,

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -14,7 +14,9 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
   model: {
     param: 'model',
     required: false,
-    transform: (value: string) => {return ""},
+    transform: (value: string) => {
+      return value;
+    },
   },
   messages: {
     param: 'messages',

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -10,6 +10,7 @@ import {
 } from '../utils';
 
 export const PredibaseChatCompleteConfig: ProviderConfig = {
+  //Add more parameters once prototype with basics works.
   model: {
     param: 'model',
     required: false,
@@ -33,32 +34,6 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
     min: 0,
     max: 1,
   },
-  //Add more parameters once prototype with basics works.
-  /*
-  ignore_eos_token: {
-    param: 'ignore_eos_token',
-    default: false,
-  },
-  top_p: {
-    param: 'top_k',
-    default: 1,
-    min: 0,
-    max: 1,
-  },
-  */
-  /*
-  ignore_eos_token: bool = False,
-  best_of: Optional[int] = None,
-  repetition_penalty: Optional[float] = None,
-  return_full_text: bool = False,
-  seed: Optional[int] = None,
-  stop_sequences: Optional[List[str]] = None,
-  temperature: Optional[float] = None,
-  top_k: Optional[int] = None,
-  top_p: Optional[float] = None,
-  truncate: Optional[int] = None,
-  typical_p: Optional[float] = None,
-  */
 };
 
 interface PredibaseChatCompleteResponse extends ChatCompletionResponse {

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -10,14 +10,10 @@ import {
 } from '../utils';
 
 export const PredibaseChatCompleteConfig: ProviderConfig = {
-  user: {
-    param: 'user',
-    required: true,
-  },
   model: {
     param: 'model',
-    required: true,
-    default: 'mistral-7b-instruct-v0-2',
+    required: false,
+    transform: (value: string) => {return ""},
   },
   messages: {
     param: 'messages',
@@ -26,11 +22,13 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
   },
   max_tokens: {
     param: 'max_tokens',
-    default: 2048,
+    required: false,
+    default: 4096,
     min: 0,
   },
   temperature: {
     param: 'temperature',
+    required: false,
     default: 0.1,
     min: 0,
     max: 1,

--- a/src/providers/predibase/chatComplete.ts
+++ b/src/providers/predibase/chatComplete.ts
@@ -44,8 +44,13 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
     min: 0,
     max: 1,
   },
+  response_format: {
+    param: 'response_format',
+    required: false,
+  },
   stream: {
     param: 'stream',
+    required: false,
     default: false,
   },
   n: {
@@ -57,6 +62,15 @@ export const PredibaseChatCompleteConfig: ProviderConfig = {
   },
   stop: {
     param: 'stop',
+    required: false,
+  },
+  top_k: {
+    param: 'top_k',
+    required: false,
+    default: -1, 
+  }, 
+  best_of: {
+    param: 'best_of',
     required: false,
   },
 };

--- a/src/providers/predibase/index.ts
+++ b/src/providers/predibase/index.ts
@@ -1,0 +1,16 @@
+import { ProviderConfigs } from '../types';
+import PredibaseAPIConfig from './api';
+import {
+  PredibaseChatCompleteConfig,
+  PredibaseChatCompleteResponseTransform,
+} from './chatComplete';
+
+const PredibaseConfig: ProviderConfigs = {
+  chatComplete: PredibaseChatCompleteConfig,
+  api: PredibaseAPIConfig,
+  responseTransforms: {
+    chatComplete: PredibaseChatCompleteResponseTransform,
+  },
+};
+
+export default PredibaseConfig;

--- a/src/providers/predibase/index.ts
+++ b/src/providers/predibase/index.ts
@@ -3,6 +3,7 @@ import PredibaseAPIConfig from './api';
 import {
   PredibaseChatCompleteConfig,
   PredibaseChatCompleteResponseTransform,
+  PredibaseChatCompleteStreamChunkTransform,
 } from './chatComplete';
 
 const PredibaseConfig: ProviderConfigs = {
@@ -10,6 +11,7 @@ const PredibaseConfig: ProviderConfigs = {
   api: PredibaseAPIConfig,
   responseTransforms: {
     chatComplete: PredibaseChatCompleteResponseTransform,
+    'stream-chatComplete': PredibaseChatCompleteStreamChunkTransform,
   },
 };
 

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -36,3 +36,24 @@ export const generateErrorResponse: (
     provider: provider,
   } as ErrorResponse;
 };
+
+type SplitResult = {
+  before: string;
+  after: string;
+};
+
+export function splitString(input: string, separator: string): SplitResult {
+  const sepIndex = input.indexOf(separator);
+  
+  if (sepIndex === -1) {
+    return {
+      before: input,
+      after: ''
+    };
+  }
+  
+  return {
+    before: input.substring(0, sepIndex),
+    after: input.substring(sepIndex + 1)
+  };
+}

--- a/src/providers/utils.ts
+++ b/src/providers/utils.ts
@@ -44,16 +44,16 @@ type SplitResult = {
 
 export function splitString(input: string, separator: string): SplitResult {
   const sepIndex = input.indexOf(separator);
-  
+
   if (sepIndex === -1) {
     return {
       before: input,
-      after: ''
+      after: '',
     };
   }
-  
+
   return {
     before: input.substring(0, sepIndex),
-    after: input.substring(sepIndex + 1)
+    after: input.substring(sepIndex + 1),
   };
 }


### PR DESCRIPTION
**Title: Support predibase LLM serving a base model with an optional fine-tuned adapter.** 
- Brief Description of Changes
* We add "predibase" as the provider using the OpenAI-compliant API that Predibase has.
* Format for supplying a fine-tuned adapter is "<base_model>[:adapter_id]", where adapter_id format is 
 "<adapter_repository_reference/version_number" (version_number is required).

```
client = OpenAI(
    api_key=os.environ["PREDIBASE_API_TOKEN"],
    base_url=PORTKEY_GATEWAY_URL,
    default_headers=createHeaders(
        provider="predibase",
    )
)

chat_complete = client.chat.completions.create(
    user=os.environ["PREDIBASE_TENANT_ID"],
    # model=os.environ["PREDIBASE_DEPLOYMENT"],
    model=f'{os.environ["PREDIBASE_DEPLOYMENT"]}:test-phi-3/4',
    stream=False,  # True is also supported.
    max_tokens=128,
    temperature=0.2,
    messages=[
        {
            "role": "user",
            "content": "How fast can a horse run?",
        },
    ],
)

if isinstance(chat_complete, Stream):
    completion_stream: Stream = chat_complete
    text: list[str] = []
    for message in completion_stream:
        print(message)
        delta_content: str | None = message.choices[0].delta.content
        if delta_content:
            text.append(delta_content)
    print("".join(text))
else:
    print(chat_complete.choices[0])
    print(chat_complete.choices[0].message)
    print(chat_complete.choices[0].message.content)


Supported body parameters:

  model,
  messages,
  max_tokens,
  temperature,
  top_p,
  stream,
  n,
  stop,

```

**Description:** (optional)
- Detailed change 1
- Detailed change 2

**Motivation:** (optional)
- Predibase becomes an option as an LLM provider for the users of Gateway.  Predibase is the most robust platform for LLM fine-tuning and serving for a wide variety of pre-trained models, including the open-source ones.

**Related Issues:** (optional)
- #issue-number
