### PR TITLE
Adding requestExecTime to requestOptions in the context

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -503,6 +503,7 @@ export async function tryPost(
 
   let response: Response;
   let retryCount: number | undefined;
+  let requestExecTime: number | undefined;
 
   providerOption.retry = {
     attempts: providerOption.retry?.attempts ?? 0,
@@ -532,6 +533,7 @@ export async function tryPost(
   }
 
   if (getFromCacheFunction && cacheMode) {
+    requestExecTime = Date.now();
     [cacheResponse, cacheStatus, cacheKey] = await getFromCacheFunction(
       env(c),
       { ...requestHeaders, ...fetchOptions.headers },
@@ -562,6 +564,7 @@ export async function tryPost(
             rubeusURL: fn,
           },
           requestParams: transformedRequestBody,
+          requestExecTime: requestExecTime,
           response: response.clone(),
           cacheStatus: cacheStatus,
           lastUsedOptionIndex: currentIndex,
@@ -587,7 +590,7 @@ export async function tryPost(
     : undefined;
 
   if (!response) {
-    [response, retryCount] = await retryRequest(
+    [response, retryCount, requestExecTime] = await retryRequest(
       url,
       fetchOptions,
       providerOption.retry.attempts,
@@ -622,6 +625,7 @@ export async function tryPost(
         rubeusURL: fn,
       },
       requestParams: transformedRequestBody,
+      requestExecTime: requestExecTime,
       response: mappedResponse.clone(),
       cacheStatus: cacheStatus,
       lastUsedOptionIndex: currentIndex,


### PR DESCRIPTION
This improves response time metrics for streaming and cache use cases, without retries.