### PR TITLE
feat: support x-portkey-request-timeout header

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -8,6 +8,7 @@ export const HEADER_KEYS: Record<string, string> = {
   CACHE: `x-${POWERED_BY}-cache`,
   FORWARD_HEADERS: `x-${POWERED_BY}-forward-headers`,
   CUSTOM_HOST: `x-${POWERED_BY}-custom-host`,
+  REQUEST_TIMEOUT: `x-${POWERED_BY}-request-timeout`,
 };
 
 export const RESPONSE_HEADER_KEYS: Record<string, string> = {

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -474,6 +474,11 @@ export async function tryPost(
   const customHost =
     requestHeaders[HEADER_KEYS.CUSTOM_HOST] || providerOption.customHost || '';
 
+  const requestTimeout =
+    Number(requestHeaders[HEADER_KEYS.REQUEST_TIMEOUT]) ||
+    providerOption.requestTimeout ||
+    null;
+
   const baseUrl =
     customHost || apiConfig.getBaseURL({ providerOptions: providerOption });
   const endpoint = apiConfig.getEndpoint({
@@ -592,7 +597,7 @@ export async function tryPost(
       fetchOptions,
       providerOption.retry.attempts,
       providerOption.retry.onStatusCodes,
-      providerOption.requestTimeout || null
+      requestTimeout
     );
   }
 


### PR DESCRIPTION
**Title:** 
- support x-portkey-request-timeout header

**Description:** (optional)
- Support x-portkey-request-timeout header which will be given preference over timeout set in configs.

**Motivation:** (optional)
- To allow sending timeout header on a request level

**Related Issues:** (optional)
- Closes #404 
