### PR TITLE
Fix tool calling for gemini

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -18,7 +18,7 @@ import {
   GoogleMessageRole,
   SYSTEM_INSTRUCTION_DISABLED_MODELS,
   transformOpenAIRoleToGoogleRole,
-  transformToolChoice,
+  transformToolChoiceForGemini,
 } from '../google/chatComplete';
 import {
   ChatCompletionResponse,
@@ -260,7 +260,7 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
         }
         return {
           functionCallingConfig: {
-            mode: transformToolChoice(params.tool_choice),
+            mode: transformToolChoiceForGemini(params.tool_choice),
             allowedFunctionNames,
           },
         };

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -88,7 +88,7 @@ export const transformOpenAIRoleToGoogleRole = (
 
 type GoogleToolChoiceType = 'AUTO' | 'ANY' | 'NONE';
 
-export const transformToolChoice = (
+export const transformToolChoiceForGemini = (
   tool_choice: ToolChoice
 ): GoogleToolChoiceType | undefined => {
   if (typeof tool_choice === 'object' && tool_choice.type === 'function')
@@ -287,7 +287,7 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
         }
         return {
           functionCallingConfig: {
-            mode: transformToolChoice(params.tool_choice),
+            mode: transformToolChoiceForGemini(params.tool_choice),
             allowedFunctionNames,
           },
         };

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -1,5 +1,12 @@
 import { GOOGLE } from '../../globals';
-import { ContentType, Message, Params } from '../../types/requestBody';
+import {
+  ContentType,
+  Message,
+  OpenAIMessageRole,
+  Params,
+  ToolCall,
+  ToolChoice,
+} from '../../types/requestBody';
 import {
   ChatCompletionResponse,
   ErrorResponse,
@@ -31,7 +38,7 @@ const transformGenerationConfig = (params: Params) => {
 };
 
 // models for which systemInstruction is not supported
-const SYSTEM_INSTRUCTION_DISABLED_MODELS = [
+export const SYSTEM_INSTRUCTION_DISABLED_MODELS = [
   'gemini-1.0-pro',
   'gemini-1.0-pro-001',
   'gemini-1.0-pro-latest',
@@ -39,6 +46,65 @@ const SYSTEM_INSTRUCTION_DISABLED_MODELS = [
   'gemini-pro',
   'gemini-pro-vision',
 ];
+
+export type GoogleMessageRole = 'user' | 'model' | 'system' | 'function';
+
+interface GoogleFunctionCallMessagePart {
+  functionCall: GoogleGenerateFunctionCall;
+}
+
+interface GoogleFunctionResponseMessagePart {
+  functionResponse: {
+    name: string;
+    response: {
+      name?: string;
+      content: string;
+    };
+  };
+}
+
+type GoogleMessagePart =
+  | GoogleFunctionCallMessagePart
+  | GoogleFunctionResponseMessagePart
+  | { text: string };
+
+export interface GoogleMessage {
+  role: GoogleMessageRole;
+  parts: GoogleMessagePart[];
+}
+
+export const transformOpenAIRoleToGoogleRole = (
+  role: OpenAIMessageRole
+): GoogleMessageRole => {
+  switch (role) {
+    case 'assistant':
+      return 'model';
+    case 'tool':
+      return 'function';
+    default:
+      return role;
+  }
+};
+
+type GoogleToolChoiceType = 'AUTO' | 'ANY' | 'NONE';
+
+export const transformToolChoice = (
+  tool_choice: ToolChoice
+): GoogleToolChoiceType | undefined => {
+  if (typeof tool_choice === 'object' && tool_choice.type === 'function')
+    return 'ANY';
+  if (typeof tool_choice === 'string') {
+    switch (tool_choice) {
+      case 'auto':
+        return 'AUTO';
+      case 'none':
+        return 'NONE';
+      case 'required':
+        return 'ANY';
+    }
+  }
+  return undefined;
+};
 
 // TODOS: this configuration does not enforce the maximum token limit for the input parameter. If you want to enforce this, you might need to add a custom validation function or a max property to the ParameterConfig interface, and then use it in the input configuration. However, this might be complex because the token count is not a simple length check, but depends on the specific tokenization method used by the model.
 
@@ -53,8 +119,8 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
       param: 'contents',
       default: '',
       transform: (params: Params) => {
-        let lastRole: 'user' | 'model' | 'system' | undefined;
-        const messages: { role: string; parts: { text: string }[] }[] = [];
+        let lastRole: GoogleMessageRole | undefined;
+        const messages: GoogleMessage[] = [];
 
         params.messages?.forEach((message: Message) => {
           // From gemini-1.5 onwards, systemInstruction is supported
@@ -65,15 +131,31 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
           )
             return;
 
-          const role = message.role === 'assistant' ? 'model' : 'user';
+          const role = transformOpenAIRoleToGoogleRole(message.role);
           let parts = [];
-          if (typeof message.content === 'string') {
-            parts.push({
-              text: message.content,
-            });
-          }
 
-          if (message.content && typeof message.content === 'object') {
+          if (message.role === 'assistant' && message.tool_calls) {
+            message.tool_calls.forEach((tool_call: ToolCall) => {
+              parts.push({
+                functionCall: {
+                  name: tool_call.function.name,
+                  args: JSON.parse(tool_call.function.arguments),
+                },
+              });
+            });
+          } else if (
+            message.role === 'tool' &&
+            typeof message.content === 'string'
+          ) {
+            parts.push({
+              functionResponse: {
+                name: message.name ?? 'gateway-tool-filler-name',
+                response: {
+                  content: message.content,
+                },
+              },
+            });
+          } else if (message.content && typeof message.content === 'object') {
             message.content.forEach((c: ContentType) => {
               if (c.type === 'text') {
                 parts.push({
@@ -88,6 +170,10 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
                   },
                 });
               }
+            });
+          } else if (typeof message.content === 'string') {
+            parts.push({
+              text: message.content,
             });
           }
 
@@ -184,7 +270,28 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
           functionDeclarations.push(tool.function);
         }
       });
-      return [{ functionDeclarations }];
+      return { functionDeclarations };
+    },
+  },
+  tool_choice: {
+    param: 'tool_config',
+    default: '',
+    transform: (params: Params) => {
+      if (params.tool_choice) {
+        const allowedFunctionNames: string[] = [];
+        if (
+          typeof params.tool_choice === 'object' &&
+          params.tool_choice.type === 'function'
+        ) {
+          allowedFunctionNames.push(params.tool_choice.function.name);
+        }
+        return {
+          functionCallingConfig: {
+            mode: transformToolChoice(params.tool_choice),
+            allowedFunctionNames,
+          },
+        };
+      }
     },
   },
 };
@@ -224,6 +331,11 @@ interface GoogleGenerateContentResponse {
       probability: string;
     }[];
   };
+  usageMetadata: {
+    promptTokenCount: number;
+    candidatesTokenCount: number;
+    totalTokenCount: number;
+  };
 }
 
 export const GoogleErrorResponseTransform: (
@@ -258,7 +370,7 @@ export const GoogleChatCompleteResponseTransform: (
 
   if ('candidates' in response) {
     return {
-      id: crypto.randomUUID(),
+      id: 'portkey-' + crypto.randomUUID(),
       object: 'chat_completion',
       created: Math.floor(Date.now() / 1000),
       model: 'Unknown',
@@ -274,18 +386,18 @@ export const GoogleChatCompleteResponseTransform: (
           } else if (generation.content.parts[0]?.functionCall) {
             message = {
               role: 'assistant',
-              tool_calls: [
-                {
-                  id: crypto.randomUUID(),
-                  type: 'function',
-                  function: {
-                    name: generation.content.parts[0]?.functionCall.name,
-                    arguments: JSON.stringify(
-                      generation.content.parts[0]?.functionCall.args
-                    ),
-                  },
-                },
-              ],
+              tool_calls: generation.content.parts.map((part) => {
+                if (part.functionCall) {
+                  return {
+                    id: 'portkey-' + crypto.randomUUID(),
+                    type: 'function',
+                    function: {
+                      name: part.functionCall.name,
+                      arguments: JSON.stringify(part.functionCall.args),
+                    },
+                  };
+                }
+              }),
             };
           }
           return {
@@ -294,6 +406,11 @@ export const GoogleChatCompleteResponseTransform: (
             finish_reason: generation.finishReason,
           };
         }) ?? [],
+      usage: {
+        prompt_tokens: response.usageMetadata.promptTokenCount,
+        completion_tokens: response.usageMetadata.candidatesTokenCount,
+        total_tokens: response.usageMetadata.totalTokenCount,
+      },
     };
   }
 
@@ -341,19 +458,19 @@ export const GoogleChatCompleteStreamChunkTransform: (
           } else if (generation.content.parts[0]?.functionCall) {
             message = {
               role: 'assistant',
-              tool_calls: [
-                {
-                  id: crypto.randomUUID(),
-                  type: 'function',
-                  index: 0,
-                  function: {
-                    name: generation.content.parts[0]?.functionCall.name,
-                    arguments: JSON.stringify(
-                      generation.content.parts[0]?.functionCall.args
-                    ),
-                  },
-                },
-              ],
+              tool_calls: generation.content.parts.map((part, idx) => {
+                if (part.functionCall) {
+                  return {
+                    index: idx,
+                    id: 'portkey-' + crypto.randomUUID(),
+                    type: 'function',
+                    function: {
+                      name: part.functionCall.name,
+                      arguments: JSON.stringify(part.functionCall.args),
+                    },
+                  };
+                }
+              }),
             };
           }
           return {
@@ -362,6 +479,11 @@ export const GoogleChatCompleteStreamChunkTransform: (
             finish_reason: generation.finishReason,
           };
         }) ?? [],
+      usage: {
+        prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
+        completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
+        total_tokens: parsedChunk.usageMetadata.totalTokenCount,
+      },
     })}` + '\n\n'
   );
 };

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -129,13 +129,29 @@ export interface ContentType {
   };
 }
 
+export interface ToolCall {
+  id: string;
+  type: string;
+  function: {
+    name: string;
+    arguments: string;
+  };
+}
+
+export type OpenAIMessageRole =
+  | 'system'
+  | 'user'
+  | 'assistant'
+  | 'function'
+  | 'tool';
+
 /**
  * A message in the conversation.
  * @interface
  */
 export interface Message {
   /** The role of the message sender. It can be 'system', 'user', 'assistant', or 'function'. */
-  role: 'system' | 'user' | 'assistant' | 'function' | 'tool';
+  role: OpenAIMessageRole;
   /** The content of the message. */
   content?: string | ContentType[];
   /** The name of the function to call, if any. */
@@ -180,6 +196,15 @@ export interface Function {
   parameters?: JsonSchema;
 }
 
+export interface ToolChoiceObject {
+  type: string;
+  function: {
+    name: string;
+  };
+}
+
+export type ToolChoice = ToolChoiceObject | 'none' | 'auto' | 'required';
+
 /**
  * A tool in the conversation.
  * @interface
@@ -189,13 +214,6 @@ export interface Tool {
   type: string;
   /** A description of the function. */
   function?: Function;
-}
-
-export interface ToolChoice {
-  type: string;
-  function: {
-    name: string;
-  };
 }
 
 /**
@@ -225,7 +243,7 @@ export interface Params {
   examples?: Examples[];
   top_k?: number;
   tools?: Tool[];
-  tool_choice?: ToolChoice | 'none' | 'auto' | 'required';
+  tool_choice?: ToolChoice;
   response_format?: { type: 'json_object' | 'text' };
   // Google Vertex AI specific
   safety_settings?: any;


### PR DESCRIPTION
**Title:** 
- Updated request and response transformers for gemini models

**Description:** (optional)

- Update response schema to handle multiple tools in response
- Update request schema for tools 

```const { GoogleGenerativeAI } = require("@google/generative-ai");

// Access your API key as an environment variable (see "Set up your API key" above)
const genAI = new GoogleGenerativeAI(process.env.API_KEY);

// ...

const generativeModel = genAI.getGenerativeModel({
  // Use a model that supports function calling, like a Gemini 1.5 model
  model: "gemini-1.5-flash",

  // Specify the function declaration.
  tools: {
    functionDeclarations: [controlLightFunctionDeclaration],
  },
});
```

Also added usage tokens while at it

Related Issue:
https://github.com/Portkey-AI/gateway/issues/335