### PR TITLE
Triton Support

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -55,6 +55,7 @@ export const ZHIPU: string = 'zhipu';
 export const NOVITA_AI: string = 'novita-ai';
 export const MONSTERAPI: string = 'monsterapi';
 export const PREDIBASE: string = 'predibase';
+export const TRITON: string = 'triton';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -87,6 +88,7 @@ export const VALID_PROVIDERS = [
   NOVITA_AI,
   MONSTERAPI,
   PREDIBASE,
+  TRITON,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/handlers/proxyHandler.ts
+++ b/src/handlers/proxyHandler.ts
@@ -9,6 +9,7 @@ import {
   OLLAMA,
   POWERED_BY,
   RETRY_STATUS_CODES,
+  TRITON,
 } from '../globals';
 import Providers from '../providers';
 import { Config, ShortConfig } from '../types/requestBody';
@@ -48,7 +49,7 @@ function getProxyPath(
     return `https:/${reqPath}${reqQuery}`;
   }
 
-  if (proxyProvider === OLLAMA) {
+  if (proxyProvider === OLLAMA || proxyProvider === TRITON) {
     return `https:/${reqPath}`;
   }
   let proxyPath = `${providerBasePath}${reqPath}${reqQuery}`;

--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -119,8 +119,7 @@ export const retryRequest = async (
       lastResponse = new Response(error.message, {
         status: 503,
       });
-    }
-    else {
+    } else {
       lastResponse = new Response(error.message, {
         status: error.status,
         headers: error.headers,

--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -112,10 +112,20 @@ export const retryRequest = async (
       }
     );
   } catch (error: any) {
-    lastResponse = new Response(error.message, {
-      status: error.status,
-      headers: error.headers,
-    });
+    if (error instanceof TypeError && error.message?.includes('fetch failed')) {
+      console.error('Fetch failed:', error);
+      // This error comes in case the host address is unreachable. Empty status code used to get returned
+      // from here hence no retry logic used to get called.
+      lastResponse = new Response(error.message, {
+        status: 503,
+      });
+    }
+    else {
+      lastResponse = new Response(error.message, {
+        status: error.status,
+        headers: error.headers,
+      });
+    }
     console.warn(
       `Tried ${lastAttempt ?? 1} time(s) but failed. Error: ${JSON.stringify(error)}`
     );

--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -112,8 +112,12 @@ export const retryRequest = async (
       }
     );
   } catch (error: any) {
-    if (error instanceof TypeError && error.message?.includes('fetch failed')) {
-      console.error('Fetch failed:', error);
+    if (
+      error instanceof TypeError &&
+      error.cause instanceof Error &&
+      error.cause?.name === 'ConnectTimeoutError'
+    ) {
+      console.error('ConnectTimeoutError: ', error.cause);
       // This error comes in case the host address is unreachable. Empty status code used to get returned
       // from here hence no retry logic used to get called.
       lastResponse = new Response(error.message, {

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -1,5 +1,10 @@
 import { z } from 'zod';
-import { OLLAMA, VALID_PROVIDERS, GOOGLE_VERTEX_AI } from '../../../globals';
+import {
+  OLLAMA,
+  VALID_PROVIDERS,
+  GOOGLE_VERTEX_AI,
+  TRITON,
+} from '../../../globals';
 
 export const configSchema: any = z
   .object({
@@ -79,6 +84,7 @@ export const configSchema: any = z
       const hasModeTargets =
         value.strategy !== undefined && value.targets !== undefined;
       const isOllamaProvider = value.provider === OLLAMA;
+      const isTritonProvider = value.provider === TRITON;
       const isVertexAIProvider =
         value.provider === GOOGLE_VERTEX_AI &&
         value.vertex_region &&
@@ -93,6 +99,7 @@ export const configSchema: any = z
         value.retry ||
         value.request_timeout ||
         isOllamaProvider ||
+        isTritonProvider ||
         hasAWSDetails ||
         isVertexAIProvider ||
         value.after_request_hooks ||

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -29,6 +29,7 @@ import ZhipuConfig from './zhipu';
 import NovitaAIConfig from './novita-ai';
 import MonsterAPIConfig from './monsterapi';
 import PredibaseConfig from './predibase';
+import TritonConfig from './triton/';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -61,6 +62,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   'novita-ai': NovitaAIConfig,
   monsterapi: MonsterAPIConfig,
   predibase: PredibaseConfig,
+  triton: TritonConfig,
 };
 
 export default Providers;

--- a/src/providers/triton/api.ts
+++ b/src/providers/triton/api.ts
@@ -1,0 +1,22 @@
+import { ProviderAPIConfig } from '../types';
+
+const TritonAPIConfig: ProviderAPIConfig = {
+  headers: () => {
+    return {};
+  },
+  getBaseURL: ({ providerOptions }) => {
+    return providerOptions.customHost ?? '';
+  },
+  getEndpoint: ({ fn, providerOptions }) => {
+    let mappedFn = fn;
+    switch (mappedFn) {
+      case 'complete': {
+        return `/generate`;
+      }
+      default:
+        return '';
+    }
+  },
+};
+
+export default TritonAPIConfig;

--- a/src/providers/triton/complete.ts
+++ b/src/providers/triton/complete.ts
@@ -1,0 +1,98 @@
+import { generateInvalidProviderResponseError } from '../utils';
+import { CompletionResponse, ErrorResponse, ProviderConfig } from '../types';
+import { TRITON } from '../../globals';
+import { generateErrorResponse } from '../utils';
+
+export const TritonCompleteConfig: ProviderConfig = {
+  prompt: {
+    param: 'text_input',
+    required: true,
+  },
+  max_tokens: {
+    param: 'max_tokens',
+    default: 100,
+  },
+  temperature: {
+    param: 'temperature',
+    default: 0.7,
+    min: 0,
+    max: 1,
+  },
+  top_p: {
+    param: 'top_p',
+    default: 1,
+  },
+  top_k: {
+    param: 'top_k',
+    default: 50,
+  },
+  stop: {
+    param: 'stop_words',
+  },
+  bad_words: {
+    param: 'bad_words',
+  },
+};
+
+interface TritonCompleteResponse extends CompletionResponse {
+  cum_log_probs: number;
+  model_name: string;
+  model_version: number;
+  output_log_probs: number[];
+  sequence_end: boolean;
+  sequence_id: number;
+  sequence_start: boolean;
+  text_output: string;
+}
+
+export interface TritonErrorResponse {
+  error: string;
+}
+
+const TritonErrorResponseTransform: (
+  response: TritonErrorResponse
+) => ErrorResponse | undefined = (response) => {
+  if ('error' in response) {
+    return generateErrorResponse(
+      { message: response.error, type: null, param: null, code: null },
+      TRITON
+    );
+  }
+  return undefined;
+};
+
+export const TritonCompleteResponseTransform: (
+  response: TritonCompleteResponse | TritonErrorResponse,
+  responseStatus: number
+) => CompletionResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200) {
+    const errorResponse = TritonErrorResponseTransform(
+      response as TritonErrorResponse
+    );
+    if (errorResponse) return errorResponse;
+  }
+
+  if ('text_output' in response) {
+    return {
+      id: crypto.randomUUID(),
+      object: 'text_completion',
+      created: Math.floor(Date.now() / 1000),
+      model: response.model_name,
+      provider: TRITON,
+      choices: [
+        {
+          text: response.text_output,
+          index: 0,
+          logprobs: null,
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: -1,
+        completion_tokens: -1,
+        total_tokens: -1,
+      },
+    };
+  }
+  return generateInvalidProviderResponseError(response, TRITON);
+};

--- a/src/providers/triton/complete.ts
+++ b/src/providers/triton/complete.ts
@@ -11,20 +11,24 @@ export const TritonCompleteConfig: ProviderConfig = {
   max_tokens: {
     param: 'max_tokens',
     default: 100,
+    required: true,
   },
   temperature: {
     param: 'temperature',
     default: 0.7,
     min: 0,
     max: 1,
+    required: true,
   },
   top_p: {
     param: 'top_p',
-    default: 1,
+    default: 0.7,
+    required: true,
   },
   top_k: {
     param: 'top_k',
     default: 50,
+    required: true,
   },
   stop: {
     param: 'stop_words',

--- a/src/providers/triton/index.ts
+++ b/src/providers/triton/index.ts
@@ -1,0 +1,16 @@
+import { ProviderConfigs } from '../types';
+import TritonAPIConfig from './api';
+import {
+  TritonCompleteConfig,
+  TritonCompleteResponseTransform,
+} from './complete';
+
+const TritonConfig: ProviderConfigs = {
+  api: TritonAPIConfig,
+  complete: TritonCompleteConfig,
+  responseTransforms: {
+    complete: TritonCompleteResponseTransform,
+  },
+};
+
+export default TritonConfig;


### PR DESCRIPTION
**Triton Support** 
- This branch contains the changes being done for Triton support. With these changes, portkey can now call Triton host. 

- The implementation is based on Ollama changes in the code.

**Description:**
Following is the sample configuration that we need to pass in order to call the Triton server running on `http://triton-host/v2/models/<model_name>`

```
{
  "strategy": {
      "mode": "fallback"
  },
  "targets": [
      {
        "provider": "triton",
        "custom_host": "http://triton-host/v2/models/<model_name>"
        "api_key": "empty"
      },
      {
        "provider": "together-ai",
        "model": "codellama/CodeLlama-34b-Instruct-hf",
         "api_key": "together_key"
      }
  ]
}
```
Sample Python code:

```
port_key = Portkey(
      api_key="empty", config=config, base_url="http://localhost:8787/v1"
)

completion: Union[
    TextCompletion, Iterator[TextCompletionChunk]
] = port_key.completions.create(prompt=prompt, **kwargs)

output = ""
if isinstance(completion, TextCompletion):
    output = completion.choices[0].text if completion.choices[0].text else ""
```

**Motivation:** 
- We wanted to have the fallback mechanism in place where we should connect to our own LLM hosted in our environment, `Triton` in our case. In case of failover, as a second option it should contact `TogetherAI`. Since Triton support was not there and we saw `Ollama` changes being recently pushed into PortKey, we thought of leveraging `custom_host` feature and made these changes.
- We have deployed TensorRT LLM on Triton server. With these changes we are able to achieve our requirements.

These changes do not have support for chatCompletions. We have tested our code with Text Completion use case where model repository of `TensorRT-LLM  backend `is hosted on `Triton`.

Thanks!
