### PR TITLE
fix: first retry logging

### DIFF
--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -114,7 +114,7 @@ export const retryRequest = async (
       headers: error.headers,
     });
     console.warn(
-      `Tried ${lastAttempt} time(s) but failed. Error: ${JSON.stringify(error)}`
+      `Tried ${lastAttempt ?? 1} time(s) but failed. Error: ${JSON.stringify(error)}`
     );
   }
   return [lastResponse as Response, lastAttempt];


### PR DESCRIPTION
**Title:** 
Handle the case where the first attempt fails and `lastAttempt` is undefined.
