### PR TITLE
Make create chat completion object strictly typed

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -1,10 +1,10 @@
 import { ANTHROPIC } from '../../globals';
 import {
-  Params,
-  Message,
-  ContentType,
-  ToolMessage,
   AssistantMessage,
+  ContentType,
+  Message,
+  Params,
+  ToolMessage,
 } from '../../types/requestBody';
 import {
   ChatCompletionResponse,
@@ -177,7 +177,17 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
         // Transform the chat messages into a simple prompt
         if (!!params.messages) {
           params.messages.forEach((msg) => {
-            if (msg.role === 'system' && typeof msg.content === 'string') {
+            if (
+              msg.role === 'system' &&
+              msg.content &&
+              typeof msg.content === 'object' &&
+              msg.content[0].text
+            ) {
+              systemMessage = msg.content[0].text;
+            } else if (
+              msg.role === 'system' &&
+              typeof msg.content === 'string'
+            ) {
               systemMessage = msg.content;
             }
           });

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -1,5 +1,11 @@
 import { ANTHROPIC } from '../../globals';
-import { Params, Message, ContentType, ToolMessage, AssistantMessage } from '../../types/requestBody';
+import {
+  Params,
+  Message,
+  ContentType,
+  ToolMessage,
+  AssistantMessage,
+} from '../../types/requestBody';
 import {
   ChatCompletionResponse,
   ErrorResponse,
@@ -171,9 +177,7 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
         // Transform the chat messages into a simple prompt
         if (!!params.messages) {
           params.messages.forEach((msg) => {
-            if (
-              msg.role === 'system' && typeof msg.content === 'string'
-            ) {
+            if (msg.role === 'system' && typeof msg.content === 'string') {
               systemMessage = msg.content;
             }
           });

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -173,15 +173,7 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
         if (!!params.messages) {
           params.messages.forEach((msg) => {
             if (
-              msg.role === 'system' &&
-              msg.content &&
-              typeof msg.content === 'object' &&
-              msg.content[0].text
-            ) {
-              systemMessage = msg.content[0].text;
-            } else if (
-              msg.role === 'system' &&
-              typeof msg.content === 'string'
+              msg.role === 'system'
             ) {
               systemMessage = msg.content;
             }

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -1,5 +1,5 @@
 import { BEDROCK } from '../../globals';
-import { ContentType, Message, Params } from '../../types/requestBody';
+import { AssistantMessage, ContentType, Message, Params, ToolMessage } from '../../types/requestBody';
 import {
   ChatCompletionResponse,
   ErrorResponse,
@@ -46,7 +46,7 @@ interface AnthropicToolResultContentItem {
 
 type AnthropicMessageContentItem = AnthropicToolResultContentItem | ContentType;
 
-interface AnthropicMessage extends Message {
+interface AnthropicMessage extends Omit<Message, 'content'> {
   content?: string | AnthropicMessageContentItem[];
 }
 
@@ -65,10 +65,9 @@ interface AnthropicToolContentItem {
 type AnthropicContentItem = AnthorpicTextContentItem | AnthropicToolContentItem;
 
 const transformAssistantMessageForAnthropic = (
-  msg: Message
+  msg: AssistantMessage
 ): AnthropicMessage => {
   let content: AnthropicContentItem[] = [];
-  const containsToolCalls = msg.tool_calls && msg.tool_calls.length;
 
   if (msg.content && typeof msg.content === 'string') {
     content.push({
@@ -87,7 +86,7 @@ const transformAssistantMessageForAnthropic = (
       });
     }
   }
-  if (containsToolCalls) {
+  if (msg.tool_calls) {
     msg.tool_calls.forEach((toolCall: any) => {
       content.push({
         type: 'tool_use',
@@ -103,7 +102,7 @@ const transformAssistantMessageForAnthropic = (
   };
 };
 
-const transformToolMessageForAnthropic = (msg: Message): AnthropicMessage => {
+const transformToolMessageForAnthropic = (msg: ToolMessage): AnthropicMessage => {
   return {
     role: 'user',
     content: [

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -1,5 +1,11 @@
 import { BEDROCK } from '../../globals';
-import { AssistantMessage, ContentType, Message, Params, ToolMessage } from '../../types/requestBody';
+import {
+  AssistantMessage,
+  ContentType,
+  Message,
+  Params,
+  ToolMessage,
+} from '../../types/requestBody';
 import {
   ChatCompletionResponse,
   ErrorResponse,
@@ -102,7 +108,9 @@ const transformAssistantMessageForAnthropic = (
   };
 };
 
-const transformToolMessageForAnthropic = (msg: ToolMessage): AnthropicMessage => {
+const transformToolMessageForAnthropic = (
+  msg: ToolMessage
+): AnthropicMessage => {
   return {
     role: 'user',
     content: [

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -357,7 +357,9 @@ const transformAssistantMessageForAnthropic = (
   };
 };
 
-const transformToolMessageForAnthropic = (msg: ToolMessage): AnthropicMessage => {
+const transformToolMessageForAnthropic = (
+  msg: ToolMessage
+): AnthropicMessage => {
   return {
     role: 'user',
     content: [

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -3,11 +3,14 @@
 
 import { GOOGLE_VERTEX_AI } from '../../globals';
 import {
+  AssistantMessage,
   ContentType,
   Message,
   Params,
   ToolCall,
+  ToolMessage,
 } from '../../types/requestBody';
+import { Message as ResponseMessage } from '../../types/responseBody';
 import {
   AnthropicChatCompleteResponse,
   AnthropicChatCompleteStreamResponse,
@@ -17,6 +20,7 @@ import {
   GoogleMessage,
   GoogleMessageRole,
   GoogleToolConfig,
+  PortkeyGeminiMessage,
   SYSTEM_INSTRUCTION_DISABLED_MODELS,
   transformOpenAIRoleToGoogleRole,
   transformToolChoiceForGemini,
@@ -51,7 +55,7 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
         let lastRole: GoogleMessageRole | undefined;
         const messages: GoogleMessage[] = [];
 
-        params.messages?.forEach((message: Message) => {
+        params.messages?.forEach((message: PortkeyGeminiMessage) => {
           // From gemini-1.5 onwards, systemInstruction is supported
           // Skipping system message and sending it in systemInstruction for gemini 1.5 models
           if (
@@ -297,7 +301,7 @@ interface AnthropicToolResultContentItem {
 
 type AnthropicMessageContentItem = AnthropicToolResultContentItem | ContentType;
 
-interface AnthropicMessage extends Message {
+interface AnthropicMessage extends Omit<Message, 'content'> {
   content?: string | AnthropicMessageContentItem[];
 }
 
@@ -316,10 +320,9 @@ interface AnthropicToolContentItem {
 type AnthropicContentItem = AnthorpicTextContentItem | AnthropicToolContentItem;
 
 const transformAssistantMessageForAnthropic = (
-  msg: Message
+  msg: AssistantMessage
 ): AnthropicMessage => {
   let content: AnthropicContentItem[] = [];
-  const containsToolCalls = msg.tool_calls && msg.tool_calls.length;
 
   if (msg.content && typeof msg.content === 'string') {
     content.push({
@@ -338,7 +341,7 @@ const transformAssistantMessageForAnthropic = (
       });
     }
   }
-  if (containsToolCalls) {
+  if (msg.tool_calls) {
     msg.tool_calls.forEach((toolCall: any) => {
       content.push({
         type: 'tool_use',
@@ -354,7 +357,7 @@ const transformAssistantMessageForAnthropic = (
   };
 };
 
-const transformToolMessageForAnthropic = (msg: Message): AnthropicMessage => {
+const transformToolMessageForAnthropic = (msg: ToolMessage): AnthropicMessage => {
   return {
     role: 'user',
     content: [
@@ -600,7 +603,7 @@ export const GoogleChatCompleteResponseTransform: (
       provider: GOOGLE_VERTEX_AI,
       choices:
         response.candidates?.map((generation, index) => {
-          let message: Message = { role: 'assistant', content: '' };
+          let message: ResponseMessage = { role: 'assistant', content: '' };
           if (generation.content.parts[0]?.text) {
             message = {
               role: 'assistant',
@@ -672,7 +675,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
     provider: GOOGLE_VERTEX_AI,
     choices:
       parsedChunk.candidates?.map((generation, index) => {
-        let message: Message = { role: 'assistant', content: '' };
+        let message: ResponseMessage = { role: 'assistant', content: '' };
         if (generation.content.parts[0]?.text) {
           message = {
             role: 'assistant',

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -238,6 +238,21 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
           };
         }
 
+        if (
+          firstMessage.role === 'system' &&
+          typeof firstMessage.content === 'object' &&
+          firstMessage.content?.[0]?.text
+        ) {
+          return {
+            parts: [
+              {
+                text: firstMessage.content?.[0].text,
+              },
+            ],
+            role: 'system',
+          };
+        }
+
         return;
       },
     },

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -86,7 +86,9 @@ interface PortkeyGoogleToolMessage extends ToolMessage {
   name?: string;
 }
 
-export type PortkeyGeminiMessage = Exclude<Message, ToolMessage> | PortkeyGoogleToolMessage;
+export type PortkeyGeminiMessage =
+  | Exclude<Message, ToolMessage>
+  | PortkeyGoogleToolMessage;
 
 export const transformOpenAIRoleToGoogleRole = (
   role: OpenAIMessageRole
@@ -489,5 +491,5 @@ export const GoogleChatCompleteStreamChunkTransform: (
         total_tokens: parsedChunk.usageMetadata.totalTokenCount,
       },
     })}` + '\n\n'
-  )
+  );
 };

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -6,7 +6,9 @@ import {
   Params,
   ToolCall,
   ToolChoice,
+  ToolMessage,
 } from '../../types/requestBody';
+import { Message as ResponseMessage } from '../../types/responseBody';
 import {
   ChatCompletionResponse,
   ErrorResponse,
@@ -80,6 +82,12 @@ export interface GoogleToolConfig {
   };
 }
 
+interface PortkeyGoogleToolMessage extends ToolMessage {
+  name?: string;
+}
+
+export type PortkeyGeminiMessage = Exclude<Message, ToolMessage> | PortkeyGoogleToolMessage;
+
 export const transformOpenAIRoleToGoogleRole = (
   role: OpenAIMessageRole
 ): GoogleMessageRole => {
@@ -129,7 +137,7 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
         let lastRole: GoogleMessageRole | undefined;
         const messages: GoogleMessage[] = [];
 
-        params.messages?.forEach((message: Message) => {
+        params.messages?.forEach((message: PortkeyGeminiMessage) => {
           // From gemini-1.5 onwards, systemInstruction is supported
           // Skipping system message and sending it in systemInstruction for gemini 1.5 models
           if (
@@ -373,7 +381,7 @@ export const GoogleChatCompleteResponseTransform: (
       provider: 'google',
       choices:
         response.candidates?.map((generation, index) => {
-          let message: Message = { role: 'assistant', content: '' };
+          let message: ResponseMessage = { role: 'assistant', content: '' };
           if (generation.content.parts[0]?.text) {
             message = {
               role: 'assistant',
@@ -445,7 +453,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
       provider: 'google',
       choices:
         parsedChunk.candidates?.map((generation, index) => {
-          let message: Message = { role: 'assistant', content: '' };
+          let message: ResponseMessage = { role: 'assistant', content: '' };
           if (generation.content.parts[0]?.text) {
             message = {
               role: 'assistant',

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -228,21 +228,6 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
           };
         }
 
-        if (
-          firstMessage.role === 'system' &&
-          typeof firstMessage.content === 'object' &&
-          firstMessage.content?.[0]?.text
-        ) {
-          return {
-            parts: [
-              {
-                text: firstMessage.content?.[0].text,
-              },
-            ],
-            role: 'system',
-          };
-        }
-
         return;
       },
     },
@@ -496,5 +481,5 @@ export const GoogleChatCompleteStreamChunkTransform: (
         total_tokens: parsedChunk.usageMetadata.totalTokenCount,
       },
     })}` + '\n\n'
-  );
+  )
 };

--- a/src/providers/reka-ai/chatComplete.ts
+++ b/src/providers/reka-ai/chatComplete.ts
@@ -73,7 +73,8 @@ export const RekaAIChatCompleteConfig: ProviderConfig = {
             } else if (item.type === 'text') {
               text = item.text;
             }
-            let media_url = item.type === 'image_url' ? item.image_url?.url : undefined;
+            let media_url =
+              item.type === 'image_url' ? item.image_url?.url : undefined;
             addMessage({
               type: currentType,
               text,

--- a/src/providers/reka-ai/chatComplete.ts
+++ b/src/providers/reka-ai/chatComplete.ts
@@ -1,5 +1,5 @@
 import { REKA_AI } from '../../globals';
-import { Message, Params } from '../../types/requestBody';
+import { Params } from '../../types/requestBody';
 import {
   ChatCompletionResponse,
   ErrorResponse,

--- a/src/providers/reka-ai/chatComplete.ts
+++ b/src/providers/reka-ai/chatComplete.ts
@@ -67,10 +67,17 @@ export const RekaAIChatCompleteConfig: ProviderConfig = {
           addMessage({ type: currentType, text: message.content || '' });
         } else {
           message.content.forEach((item) => {
+            let text = '';
+            if (typeof item === 'string') {
+              text = item;
+            } else if (item.type === 'text') {
+              text = item.text;
+            }
+            let media_url = item.type === 'image_url' ? item.image_url?.url : undefined;
             addMessage({
               type: currentType,
-              text: item.text || '',
-              media_url: item.image_url?.url,
+              text,
+              media_url,
             });
           });
         }

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -1,4 +1,5 @@
-import { Message, Options, Params } from '../types/requestBody';
+import { Options, Params } from '../types/requestBody';
+import { Message } from '../types/responseBody';
 
 /**
  * Configuration for a parameter.

--- a/src/providers/workers-ai/chatComplete.ts
+++ b/src/providers/workers-ai/chatComplete.ts
@@ -1,5 +1,4 @@
 import { WORKERS_AI } from '../../globals';
-import { Params, Message } from '../../types/requestBody';
 import {
   ChatCompletionResponse,
   ErrorResponse,

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -151,7 +151,7 @@ export interface TextMessageContentItem {
   text: string;
 }
 
-interface ImageMessageContentItem {
+export interface ImageMessageContentItem {
   type: 'image_url';
   image_url: {
     url: string;

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -145,7 +145,7 @@ export type OpenAIMessageRole =
   | 'assistant'
   | 'function'
   | 'tool';
-  
+
 export interface TextMessageContentItem {
   type: 'text';
   text: string;
@@ -161,7 +161,9 @@ export interface ImageMessageContentItem {
 
 type SystemMessageContent = string | TextMessageContentItem[];
 
-type UserMessageContent = string | (TextMessageContentItem | ImageMessageContentItem)[];
+type UserMessageContent =
+  | string
+  | (TextMessageContentItem | ImageMessageContentItem)[];
 
 export type AssistantMessageContent = string | TextMessageContentItem[];
 
@@ -200,7 +202,7 @@ export interface AssistantMessage {
  */
 export interface ToolMessage {
   content: ToolMessageContent;
-  role: 'tool',
+  role: 'tool';
   tool_call_id: string;
 }
 
@@ -208,7 +210,11 @@ export interface ToolMessage {
  * A message in the conversation.
  * @type
  */
-export type Message = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
+export type Message =
+  | SystemMessage
+  | UserMessage
+  | AssistantMessage
+  | ToolMessage;
 
 /**
  * A JSON schema.

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -132,6 +132,7 @@ export interface ContentType {
 export interface ToolCall {
   id: string;
   type: string;
+  index?: number;
   function: {
     name: string;
     arguments: string;
@@ -144,35 +145,73 @@ export type OpenAIMessageRole =
   | 'assistant'
   | 'function'
   | 'tool';
+export interface SystemMessage {
+  content: string;
+  role: 'system';
+  name?: string;
+}
+
+export type UserMessageContentPart = {
+  type: string;
+  text?: string;
+  image_url?: {
+    url: string;
+    detail?: string;
+  };
+};
+
+export interface UserMessage {
+  content: string | UserMessageContentPart[];
+  role: 'user';
+  name?: string;
+}
+
+export interface AssistantMessage {
+  content?: string;
+  role: 'assistant';
+  name?: string;
+  tool_calls?: ToolCall[]; // TODO: copy this from upstream branch once gemini changes are merged
+}
+
+export interface ToolMessage {
+  content: string;
+  role: 'tool',
+  tool_call_id: string;
+}
 
 /**
  * A message in the conversation.
- * @interface
+ * @type
  */
-export interface Message {
-  /** The role of the message sender. It can be 'system', 'user', 'assistant', or 'function'. */
-  role: OpenAIMessageRole;
-  /** The content of the message. */
-  content?: string | ContentType[];
-  /** The name of the function to call, if any. */
-  name?: string;
-  /** The function call to make, if any. */
-  function_call?: any;
-  tool_calls?: any;
-  tool_call_id?: string;
-  citationMetadata?: CitationMetadata;
-}
+export type Message = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
 
-export interface CitationMetadata {
-  citationSources?: CitationSource[];
-}
+// /**
+//  * A message in the conversation.
+//  * @interface
+//  */
+// export interface Message {
+//   /** The role of the message sender. It can be 'system', 'user', 'assistant', or 'function'. */
+//   role: 'system' | 'user' | 'assistant' | 'function';
+//   /** The content of the message. */
+//   content?: string | ContentType[];
+//   /** The name of the function to call, if any. */
+//   name?: string;
+//   /** The function call to make, if any. */
+//   function_call?: any;
+//   tool_calls?: any;
+//   citationMetadata?: CitationMetadata;
+// }
 
-export interface CitationSource {
-  startIndex?: number;
-  endIndex?: number;
-  uri?: string;
-  license?: string;
-}
+// export interface CitationMetadata {
+//   citationSources?: CitationSource[];
+// }
+
+// export interface CitationSource {
+//   startIndex?: number;
+//   endIndex?: number;
+//   uri?: string;
+//   license?: string;
+// }
 
 /**
  * A JSON schema.

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -145,36 +145,61 @@ export type OpenAIMessageRole =
   | 'assistant'
   | 'function'
   | 'tool';
+  
+export interface TextMessageContentItem {
+  type: 'text';
+  text: string;
+}
+
+interface ImageMessageContentItem {
+  type: 'image_url';
+  image_url: {
+    url: string;
+    detail?: string;
+  };
+}
+
+type SystemMessageContent = string | TextMessageContentItem[];
+
+type UserMessageContent = string | (TextMessageContentItem | ImageMessageContentItem)[];
+
+export type AssistantMessageContent = string | TextMessageContentItem[];
+
+type ToolMessageContent = string | TextMessageContentItem[];
+
 export interface SystemMessage {
-  content: string;
+  content: SystemMessageContent;
   role: 'system';
   name?: string;
 }
 
-export type UserMessageContentPart = {
-  type: string;
-  text?: string;
-  image_url?: {
-    url: string;
-    detail?: string;
-  };
-};
-
+/**
+ * A User message in the conversation.
+ * @interface
+ */
 export interface UserMessage {
-  content: string | UserMessageContentPart[];
+  content: UserMessageContent;
   role: 'user';
   name?: string;
 }
 
+/**
+ * An Assistant message in teh conversation.
+ * @interface
+ */
 export interface AssistantMessage {
-  content?: string;
+  content?: AssistantMessageContent;
   role: 'assistant';
   name?: string;
-  tool_calls?: ToolCall[]; // TODO: copy this from upstream branch once gemini changes are merged
+  tool_calls?: ToolCall[];
 }
 
+/**
+ * A Tool message.
+ * @interface
+ */
 export interface ToolMessage {
-  content: string;
+  content: ToolMessageContent;
   role: 'tool',
   tool_call_id: string;
 }
@@ -184,34 +209,6 @@ export interface ToolMessage {
  * @type
  */
 export type Message = SystemMessage | UserMessage | AssistantMessage | ToolMessage;
-
-// /**
-//  * A message in the conversation.
-//  * @interface
-//  */
-// export interface Message {
-//   /** The role of the message sender. It can be 'system', 'user', 'assistant', or 'function'. */
-//   role: 'system' | 'user' | 'assistant' | 'function';
-//   /** The content of the message. */
-//   content?: string | ContentType[];
-//   /** The name of the function to call, if any. */
-//   name?: string;
-//   /** The function call to make, if any. */
-//   function_call?: any;
-//   tool_calls?: any;
-//   citationMetadata?: CitationMetadata;
-// }
-
-// export interface CitationMetadata {
-//   citationSources?: CitationSource[];
-// }
-
-// export interface CitationSource {
-//   startIndex?: number;
-//   endIndex?: number;
-//   uri?: string;
-//   license?: string;
-// }
 
 /**
  * A JSON schema.
@@ -260,9 +257,9 @@ export interface Tool {
  * @interface
  */
 export interface Params {
-  model?: string;
+  model: string;
   prompt?: string | string[];
-  messages?: Message[];
+  messages: Message[];
   functions?: Function[];
   function_call?: 'none' | 'auto' | { name: string };
   max_tokens?: number;

--- a/src/types/responseBody.ts
+++ b/src/types/responseBody.ts
@@ -1,3 +1,32 @@
+export interface ContentType {
+  type: string;
+  text?: string;
+  image_url?: {
+    url: string;
+  };
+}
+
+export type OpenAIMessageRole =
+  | 'system'
+  | 'user'
+  | 'assistant'
+  | 'function'
+  | 'tool';
+
+export interface Message {
+  /** The role of the message sender. It can be 'system', 'user', 'assistant', or 'function'. */
+  role: OpenAIMessageRole;
+  /** The content of the message. */
+  content?: string | ContentType[];
+  /** The name of the function to call, if any. */
+  name?: string;
+  /** The function call to make, if any. */
+  function_call?: any;
+  tool_calls?: any;
+  tool_call_id?: string;
+  citationMetadata?: CitationMetadata;
+}
+
 interface CitationSource {
   startIndex?: number;
   endIndex?: number;


### PR DESCRIPTION
**Title:** 
- Make create chat completion object type strictly typed

**Description:** (optional)
- Replicated types by looking at both the nodejs sdk of openai and the openai docs
- Gateway allows for system message to be an object which is not allowed in the latest openai sdk, gateway should deprecate this as it ads unnecessary overhead in transforming providers where both the cases have to be handled

**Testing Done**
Ran tsc --noEmit, and basic sanity. Did not remove any code

Related issue: #466 