### PR TITLE
vertex-ai/gemini Combine messages with the same role in succession to handle multi turn messages

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -135,16 +135,16 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
 
           // @NOTE: This takes care of the "Please ensure that multiturn requests alternate between user and model."
           // error that occurs when we have multiple user messages in a row.
-          const shouldAppendEmptyModeChat =
-            lastRole === 'user' &&
-            role === 'user' &&
+          const shouldCombineMessages =
+            lastRole === role &&
             !params.model?.includes('vision');
 
-          if (shouldAppendEmptyModeChat) {
-            messages.push({ role: 'model', parts: [{ text: '' }] });
+          if (shouldCombineMessages) {
+            messages[messages.length - 1].parts.push(...parts);
+          } else {
+            messages.push({ role, parts });            
           }
 
-          messages.push({ role, parts });
           lastRole = role;
         });
 

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -136,13 +136,12 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
           // @NOTE: This takes care of the "Please ensure that multiturn requests alternate between user and model."
           // error that occurs when we have multiple user messages in a row.
           const shouldCombineMessages =
-            lastRole === role &&
-            !params.model?.includes('vision');
+            lastRole === role && !params.model?.includes('vision');
 
           if (shouldCombineMessages) {
             messages[messages.length - 1].parts.push(...parts);
           } else {
-            messages.push({ role, parts });            
+            messages.push({ role, parts });
           }
 
           lastRole = role;

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -16,6 +16,7 @@ import {
 import {
   GoogleMessage,
   GoogleMessageRole,
+  GoogleToolConfig,
   SYSTEM_INSTRUCTION_DISABLED_MODELS,
   transformOpenAIRoleToGoogleRole,
   transformToolChoiceForGemini,
@@ -257,12 +258,16 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
         ) {
           allowedFunctionNames.push(params.tool_choice.function.name);
         }
-        return {
-          functionCallingConfig: {
+        const toolConfig: GoogleToolConfig = {
+          function_calling_config: {
             mode: transformToolChoiceForGemini(params.tool_choice),
-            allowedFunctionNames,
           },
         };
+        if (allowedFunctionNames.length > 0) {
+          toolConfig.function_calling_config.allowed_function_names =
+            allowedFunctionNames;
+        }
+        return toolConfig;
       }
     },
   },

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -73,6 +73,13 @@ export interface GoogleMessage {
   parts: GoogleMessagePart[];
 }
 
+export interface GoogleToolConfig {
+  function_calling_config: {
+    mode: GoogleToolChoiceType | undefined;
+    allowed_function_names?: string[];
+  };
+}
+
 export const transformOpenAIRoleToGoogleRole = (
   role: OpenAIMessageRole
 ): GoogleMessageRole => {
@@ -285,12 +292,16 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
         ) {
           allowedFunctionNames.push(params.tool_choice.function.name);
         }
-        return {
-          functionCallingConfig: {
+        const toolConfig: GoogleToolConfig = {
+          function_calling_config: {
             mode: transformToolChoiceForGemini(params.tool_choice),
-            allowedFunctionNames,
           },
         };
+        if (allowedFunctionNames.length > 0) {
+          toolConfig.function_calling_config.allowed_function_names =
+            allowedFunctionNames;
+        }
+        return toolConfig;
       }
     },
   },


### PR DESCRIPTION
**Title:** 
- Gemini on Vertex AI throws an exception, when there is an message part with empty string
- Also updated tool_config keys to snake_case (it works with camelCase also, but official documentation is in snake_case)
```
{
    "error": {
        "message": "vertex-ai error: Unable to submit request because it has an empty text parameter. Add a value to the parameter and try again. Learn more: https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini",
        "type": "INVALID_ARGUMENT",
        "param": null,
        "code": "400"
    },
    "provider": "vertex-ai"
}
```
- Gateway appends a message with empty string part in between two messages of the same role and it's failing thus
- Handling this by merging the messages with the same role, as gemini supports multiple parts inside the same message
```
{
  "model": "gemini-1.5-flash-001",
  "contents": [
    {
      "role": "user",
      "parts": [
        {
          "text": "<|context_start|>\n(Context omitted for historical message)\n<|context_end|>\n\nhello what are the discounts?"
        },
        {
          "text": "I am hungry"
        }
      ]
    },
    {
      "role": "model",
      "parts": [
        {
          "text": "That's okay, all of us get hungry sometimes?"
        }
      ]
    }
  ],
  "systemInstruction": {
    "parts": [
      {
        "text": "You're Sidekick"
      }
    ],
    "role": "system"
  },
  "generationConfig": {
    "temperature": 0.1
  }
}
```

**Related Issues:** (optional)
- https://github.com/Portkey-AI/gateway/issues/462


**Testing Done:**
- Tested with user and model messages in succession
- Tested with assistant messages with tool responses and tool messages, verified correct exception is thrown