### PR TITLE
fix: request timeout behaviour for streaming request

### DIFF
--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -5,17 +5,20 @@ async function fetchWithTimeout(
   options: RequestInit,
   timeout: number
 ) {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
   const timeoutRequestOptions = {
     ...options,
-    signal: AbortSignal.timeout(timeout),
+    signal: controller.signal,
   };
 
   let response;
 
   try {
     response = await fetch(url, timeoutRequestOptions);
+    clearTimeout(timeoutId);
   } catch (err: any) {
-    if (err.name === 'TimeoutError') {
+    if (err.name === 'AbortError') {
       response = new Response(
         JSON.stringify({
           error: {


### PR DESCRIPTION
**Title:** 
- fix: request timeout behaviour for streaming request

**Description:** (optional)
- Handle clearTimeout manually instead of using AbortSignal.timeout() in fetch for request_timeout support

**Motivation:** (optional)
- To fix request_timeout behaviour with streaming calls

**Related Issues:** (optional)
- Fixes #471 
