### PR TITLE
fix: Make anthropic usage object in streaming mode compliant with openAI response

### DIFF
--- a/src/providers/anthropic/types.ts
+++ b/src/providers/anthropic/types.ts
@@ -1,0 +1,7 @@
+export type AnthropicStreamState = {
+  containsChainOfThoughtMessage?: boolean;
+  usage?: {
+    prompt_tokens?: number;
+    completion_tokens?: number;
+  };
+};


### PR DESCRIPTION
**Title:** 
- Make anthropic usage object in streaming mode compliant with openAI response

**Description:**
- Moved prompt_tokens to streamState object
- used the streamState object to access the prompt_tokens

**Related Issues:**
- https://github.com/Portkey-AI/gateway/issues/496
