### PR TITLE
fix: pass response transformer type for cached stream response handler

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -610,7 +610,7 @@ export async function tryPost(
     fn
   ));
   if (!!cacheResponse) {
-    return createResponse(cacheResponse, undefined, true);
+    return createResponse(cacheResponse, fn, true);
   }
 
   // Prerequest validator (For virtual key budgets)


### PR DESCRIPTION
**Title:** 
- fix: pass response transformer type for cached stream response handler

**Description:** (optional)
- For cached response handler, the request type should be passed so that responseHandler can map cached json response to valid text/event-stream response. This used to work earlier but it got removed in one of the recent releases

**Motivation:** (optional)
- Fix cache behaviour for streaming request

**Related Issues:** (optional)
- Closes #529 
