### PR TITLE
Add X-Title header for openrouter requests

### DIFF
--- a/src/providers/openrouter/api.ts
+++ b/src/providers/openrouter/api.ts
@@ -1,9 +1,13 @@
+import { POWERED_BY } from '../../globals';
 import { ProviderAPIConfig } from '../types';
 
 const OpenrouterAPIConfig: ProviderAPIConfig = {
   getBaseURL: () => 'https://openrouter.ai/api',
   headers: ({ providerOptions }) => {
-    return { Authorization: `Bearer ${providerOptions.apiKey}` }; // https://openrouter.ai/keys
+    return {
+      Authorization: `Bearer ${providerOptions.apiKey}`, // https://openrouter.ai/keys
+      'X-Title': POWERED_BY,
+    };
   },
   getEndpoint: ({ fn }) => {
     switch (fn) {

--- a/src/providers/openrouter/api.ts
+++ b/src/providers/openrouter/api.ts
@@ -6,6 +6,7 @@ const OpenrouterAPIConfig: ProviderAPIConfig = {
   headers: ({ providerOptions }) => {
     return {
       Authorization: `Bearer ${providerOptions.apiKey}`, // https://openrouter.ai/keys
+      'HTTP-Referer': 'https://portkey.ai/',
       'X-Title': POWERED_BY,
     };
   },


### PR DESCRIPTION
This will show portkey on the openrouter App showcase/rankings dashboard
https://openrouter.ai/
https://openrouter.ai/docs/api-keys

Linked issue: https://github.com/Portkey-AI/gateway/issues/531