### PR TITLE
Feat: Conditional Router

### DIFF
--- a/src/errors/RouterError.ts
+++ b/src/errors/RouterError.ts
@@ -1,0 +1,9 @@
+export class RouterError extends Error {
+  constructor(
+    message: string,
+    public cause?: Error
+  ) {
+    super(message);
+    this.name = 'RouterError';
+  }
+}

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -6,6 +6,7 @@ export const HEADER_KEYS: Record<string, string> = {
   PROVIDER: `x-${POWERED_BY}-provider`,
   TRACE_ID: `x-${POWERED_BY}-trace-id`,
   CACHE: `x-${POWERED_BY}-cache`,
+  METADATA: `x-${POWERED_BY}-metadata`,
   FORWARD_HEADERS: `x-${POWERED_BY}-forward-headers`,
   CUSTOM_HOST: `x-${POWERED_BY}-custom-host`,
   REQUEST_TIMEOUT: `x-${POWERED_BY}-request-timeout`,

--- a/src/handlers/chatCompletionsHandler.ts
+++ b/src/handlers/chatCompletionsHandler.ts
@@ -1,3 +1,4 @@
+import { RouterError } from '../errors/RouterError';
 import {
   constructConfigFromRequestHeaders,
   tryTargetsRecursively,
@@ -30,13 +31,21 @@ export async function chatCompletionsHandler(c: Context): Promise<Response> {
     return tryTargetsResponse;
   } catch (err: any) {
     console.log('chatCompletion error', err.message);
+    let statusCode = 500;
+    let errorMessage = 'Something went wrong';
+
+    if (err instanceof RouterError) {
+      statusCode = 400;
+      errorMessage = err.message;
+    }
+
     return new Response(
       JSON.stringify({
         status: 'failure',
-        message: 'Something went wrong',
+        message: errorMessage,
       }),
       {
-        status: 500,
+        status: statusCode,
         headers: {
           'content-type': 'application/json',
         },

--- a/src/handlers/completionsHandler.ts
+++ b/src/handlers/completionsHandler.ts
@@ -1,3 +1,4 @@
+import { RouterError } from '../errors/RouterError';
 import {
   constructConfigFromRequestHeaders,
   tryTargetsRecursively,
@@ -31,6 +32,14 @@ export async function completionsHandler(c: Context): Promise<Response> {
     return tryTargetsResponse;
   } catch (err: any) {
     console.log('completion error', err.message);
+    let statusCode = 500;
+    let errorMessage = 'Something went wrong';
+
+    if (err instanceof RouterError) {
+      statusCode = 400;
+      errorMessage = err.message;
+    }
+
     return new Response(
       JSON.stringify({
         status: 'failure',

--- a/src/handlers/embeddingsHandler.ts
+++ b/src/handlers/embeddingsHandler.ts
@@ -1,3 +1,4 @@
+import { RouterError } from '../errors/RouterError';
 import {
   constructConfigFromRequestHeaders,
   tryTargetsRecursively,
@@ -30,7 +31,15 @@ export async function embeddingsHandler(c: Context): Promise<Response> {
 
     return tryTargetsResponse;
   } catch (err: any) {
-    console.log('completion error', err.message);
+    console.log('embeddings error', err.message);
+    let statusCode = 500;
+    let errorMessage = 'Something went wrong';
+
+    if (err instanceof RouterError) {
+      statusCode = 400;
+      errorMessage = err.message;
+    }
+
     return new Response(
       JSON.stringify({
         status: 'failure',

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -26,7 +26,7 @@ import { retryRequest } from './retryHandler';
 import { env, getRuntimeKey } from 'hono/adapter';
 import { afterRequestHookHandler, responseHandler } from './responseHandlers';
 import { HookSpan, HooksManager } from '../middlewares/hooks';
-import { QueryRouter } from '../services/queryRouter';
+import { ConditionalRouter } from '../services/conditionalRouter';
 import { RouterError } from '../errors/RouterError';
 
 /**
@@ -849,20 +849,20 @@ export async function tryTargetsRecursively(
       }
       break;
 
-    case StrategyModes.QUERY:
+    case StrategyModes.CONDITIONAL:
       let metadata: Record<string, string>;
       try {
         metadata = JSON.parse(requestHeaders[HEADER_KEYS.METADATA]);
       } catch (err) {
         metadata = {};
       }
-      let queryRouter: QueryRouter;
+      let conditionalRouter: ConditionalRouter;
       let finalTarget: Targets;
       try {
-        queryRouter = new QueryRouter(currentTarget, { metadata });
-        finalTarget = queryRouter.resolveTarget();
-      } catch (queryRouterError: any) {
-        throw new RouterError(queryRouterError.message);
+        conditionalRouter = new ConditionalRouter(currentTarget, { metadata });
+        finalTarget = conditionalRouter.resolveTarget();
+      } catch (conditionalRouter: any) {
+        throw new RouterError(conditionalRouter.message);
       }
 
       response = await tryTargetsRecursively(

--- a/src/handlers/imageGenerationsHandler.ts
+++ b/src/handlers/imageGenerationsHandler.ts
@@ -1,3 +1,4 @@
+import { RouterError } from '../errors/RouterError';
 import {
   constructConfigFromRequestHeaders,
   tryTargetsRecursively,
@@ -31,6 +32,13 @@ export async function imageGenerationsHandler(c: Context): Promise<Response> {
     return tryTargetsResponse;
   } catch (err: any) {
     console.log('imageGenerate error', err.message);
+    let statusCode = 500;
+    let errorMessage = 'Something went wrong';
+
+    if (err instanceof RouterError) {
+      statusCode = 400;
+      errorMessage = err.message;
+    }
     return new Response(
       JSON.stringify({
         status: 'failure',

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -9,7 +9,9 @@ export const configSchema: any = z
           .string()
           .refine(
             (value) =>
-              ['single', 'loadbalance', 'fallback', 'conditional'].includes(value),
+              ['single', 'loadbalance', 'fallback', 'conditional'].includes(
+                value
+              ),
             {
               message:
                 "Invalid 'mode' value. Must be one of: single, loadbalance, fallback, conditional",

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -1,4 +1,4 @@
-import { z } from 'zod';
+import { any, z } from 'zod';
 import { OLLAMA, VALID_PROVIDERS, GOOGLE_VERTEX_AI } from '../../../globals';
 
 export const configSchema: any = z
@@ -8,13 +8,23 @@ export const configSchema: any = z
         mode: z
           .string()
           .refine(
-            (value) => ['single', 'loadbalance', 'fallback'].includes(value),
+            (value) =>
+              ['single', 'loadbalance', 'fallback', 'query'].includes(value),
             {
               message:
-                "Invalid 'mode' value. Must be one of: single, loadbalance, fallback",
+                "Invalid 'mode' value. Must be one of: single, loadbalance, fallback, single",
             }
           ),
         on_status_codes: z.array(z.number()).optional(),
+        conditions: z
+          .array(
+            z.object({
+              query: z.object({}),
+              then: z.string(),
+            })
+          )
+          .optional(),
+        default: z.string().optional(),
       })
       .optional(),
     provider: z

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -9,10 +9,10 @@ export const configSchema: any = z
           .string()
           .refine(
             (value) =>
-              ['single', 'loadbalance', 'fallback', 'query'].includes(value),
+              ['single', 'loadbalance', 'fallback', 'conditional'].includes(value),
             {
               message:
-                "Invalid 'mode' value. Must be one of: single, loadbalance, fallback, single",
+                "Invalid 'mode' value. Must be one of: single, loadbalance, fallback, conditional",
             }
           ),
         on_status_codes: z.array(z.number()).optional(),

--- a/src/services/conditionalRouter.ts
+++ b/src/services/conditionalRouter.ts
@@ -25,14 +25,14 @@ enum Operator {
   Or = '$or',
 }
 
-export class QueryRouter {
+export class ConditionalRouter {
   private config: Targets;
   private context: RouterContext;
 
   constructor(config: Targets, context: RouterContext) {
     this.config = config;
     this.context = context;
-    if (this.config.strategy?.mode !== StrategyModes.QUERY) {
+    if (this.config.strategy?.mode !== StrategyModes.CONDITIONAL) {
       throw new Error('Unsupported strategy mode');
     }
   }

--- a/src/services/conditionalRouter.ts
+++ b/src/services/conditionalRouter.ts
@@ -117,7 +117,7 @@ export class ConditionalRouter {
         case Operator.Regex:
           try {
             const regex = new RegExp(compareValue);
-            return value.test(regex);
+            return regex.test(value);
           } catch (e) {
             return false;
           }

--- a/src/services/queryRouter.ts
+++ b/src/services/queryRouter.ts
@@ -1,0 +1,152 @@
+import { StrategyModes, Targets } from '../types/requestBody';
+
+type Query = {
+  [key: string]: any;
+};
+
+interface RouterContext {
+  metadata?: Record<string, string>;
+}
+
+enum Operator {
+  // Comparison Operators
+  Equal = '$eq',
+  NotEqual = '$ne',
+  GreaterThan = '$gt',
+  GreaterThanOrEqual = '$gte',
+  LessThan = '$lt',
+  LessThanOrEqual = '$lte',
+  In = '$in',
+  NotIn = '$nin',
+  Regex = '$regex',
+
+  // Logical Operators
+  And = '$and',
+  Or = '$or',
+}
+
+export class QueryRouter {
+  private config: Targets;
+  private context: RouterContext;
+
+  constructor(config: Targets, context: RouterContext) {
+    this.config = config;
+    this.context = context;
+    if (this.config.strategy?.mode !== StrategyModes.QUERY) {
+      throw new Error('Unsupported strategy mode');
+    }
+  }
+
+  resolveTarget(): Targets {
+    if (!this.config.strategy?.conditions) {
+      throw new Error('No conditions passed in the query router');
+    }
+
+    for (const condition of this.config.strategy.conditions) {
+      if (this.evaluateQuery(condition.query)) {
+        const targetName = condition.then;
+        return this.findTarget(targetName);
+      }
+    }
+
+    // If no conditions matched and a default is specified, return the default target
+    if (this.config.strategy.default) {
+      return this.findTarget(this.config.strategy.default);
+    }
+
+    throw new Error('Query router did not resolve to any valid target');
+  }
+
+  private evaluateQuery(query: Query): boolean {
+    for (const [key, value] of Object.entries(query)) {
+      if (key === Operator.Or && Array.isArray(value)) {
+        return value.some((subCondition: Query) =>
+          this.evaluateQuery(subCondition)
+        );
+      }
+
+      if (key === Operator.And && Array.isArray(value)) {
+        return value.every((subCondition: Query) =>
+          this.evaluateQuery(subCondition)
+        );
+      }
+
+      const metadataValue = this.getContextValue(key);
+
+      if (typeof value === 'object' && value !== null) {
+        if (!this.evaluateOperator(value, metadataValue)) {
+          return false;
+        }
+      } else if (metadataValue !== value) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  private evaluateOperator(operator: string, value: any): boolean {
+    for (const [op, compareValue] of Object.entries(operator)) {
+      switch (op) {
+        case Operator.Equal:
+          if (value !== compareValue) return false;
+          break;
+        case Operator.NotEqual:
+          if (value === compareValue) return false;
+          break;
+        case Operator.GreaterThan:
+          if (!(parseFloat(value) > parseFloat(compareValue))) return false;
+          break;
+        case Operator.GreaterThanOrEqual:
+          if (!(parseFloat(value) >= parseFloat(compareValue))) return false;
+          break;
+        case Operator.LessThan:
+          if (!(parseFloat(value) < parseFloat(compareValue))) return false;
+          break;
+        case Operator.LessThanOrEqual:
+          if (!(parseFloat(value) <= parseFloat(compareValue))) return false;
+          break;
+        case Operator.In:
+          if (!Array.isArray(compareValue) || !compareValue.includes(value))
+            return false;
+          break;
+        case Operator.NotIn:
+          if (!Array.isArray(compareValue) || compareValue.includes(value))
+            return false;
+          break;
+        case Operator.Regex:
+          try {
+            const regex = new RegExp(compareValue);
+            return value.test(regex);
+          } catch (e) {
+            return false;
+          }
+        default:
+          throw new Error(
+            `Unsupported operator used in the query router: ${op}`
+          );
+      }
+    }
+    return true;
+  }
+
+  private findTarget(name: string): Targets {
+    const index =
+      this.config.targets?.findIndex((target) => target.name === name) ?? -1;
+    if (index === -1) {
+      throw new Error(`Invalid target name found in the query router: ${name}`);
+    }
+
+    return {
+      ...this.config.targets?.[index],
+      index,
+    };
+  }
+
+  private getContextValue(key: string): any {
+    const parts = key.split('.');
+    let value: any = this.context;
+    value = value[parts[0]]?.[parts[1]];
+    return value;
+  }
+}

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -20,7 +20,7 @@ export enum StrategyModes {
   LOADBALANCE = 'loadbalance',
   FALLBACK = 'fallback',
   SINGLE = 'single',
-  QUERY = 'query',
+  CONDITIONAL = 'conditional',
 }
 
 interface Strategy {

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -16,9 +16,23 @@ interface CacheSettings {
   maxAge?: number;
 }
 
+export enum StrategyModes {
+  LOADBALANCE = 'loadbalance',
+  FALLBACK = 'fallback',
+  SINGLE = 'single',
+  QUERY = 'query',
+}
+
 interface Strategy {
-  mode: string;
+  mode: StrategyModes;
   onStatusCodes?: Array<number>;
+  conditions?: {
+    query: {
+      [key: string]: any;
+    };
+    then: string;
+  }[];
+  default?: string;
 }
 
 /**
@@ -83,6 +97,7 @@ export interface Options {
  * @interface
  */
 export interface Targets {
+  name?: string;
   strategy?: Strategy;
   /** The name of the provider. */
   provider?: string | undefined;


### PR DESCRIPTION
The Conditional Routing Strategy allows you to define sophisticated routing rules using a MongoDB-like query syntax. These rules are currently limited to metadata but the implementation is done in a way that it can be used for headers (or anything else that is available in the request).

More details available here: #540 