### PR TITLE
docs: fix linking typo on README(.cn).md

### DIFF
--- a/.github/README.cn.md
+++ b/.github/README.cn.md
@@ -199,7 +199,7 @@ const client = new OpenAI({
 
 ## 贡献
 
-最简单的贡献方式是选择任何带有 `good first issue` 标签的问题 💪。在[这里](/CONTRIBUTING.cn.md.md)阅读贡献指南。
+最简单的贡献方式是选择任何带有 `good first issue` 标签的问题 💪。在[这里](./CONTRIBUTING.md)阅读贡献指南。
 
 发现 Bug？[在这里提交](https://github.com/Portkey-AI/gateway/issues) | 有功能请求？[在这里提交](https://github.com/Portkey-AI/gateway/issues)
 

--- a/README.md
+++ b/README.md
@@ -260,7 +260,7 @@ Make your AI app more <ins>reliable</ins> and <ins>forward compatible</ins>, whi
 
 ## Contributing
 
-The easiest way to contribute is to pick an issue with the `good first issue` tag 💪. Read the contribution guidelines [here](/CONTRIBUTING.md).
+The easiest way to contribute is to pick an issue with the `good first issue` tag 💪. Read the contribution guidelines [here](/.github/CONTRIBUTING.md).
 
 Bug Report? [File here](https://github.com/Portkey-AI/gateway/issues) | Feature Request? [File here](https://github.com/Portkey-AI/gateway/issues)
 


### PR DESCRIPTION
**Title:** 
- Fix trivial two READMEs(en, cn) being not redirected.