### PR TITLE
chore: support api endpoint configuration for aporia plugin to allow …

### DIFF
--- a/plugins/aporia/validateProject.ts
+++ b/plugins/aporia/validateProject.ts
@@ -18,7 +18,13 @@ export const validate = async (
       'X-APORIA-API-KEY': `${credentials.apiKey}`,
     },
   };
-  return post(`${APORIA_BASE_URL}/${projectID}/validate`, data, options);
+  let baseURL = APORIA_BASE_URL;
+  // Allow endpoint configuration to support aporia trial endpoint
+  // Aporia trial endpoint: https://gr-prd-trial.aporia.com
+  if (credentials.apiEndpoint) {
+    baseURL = credentials.apiEndpoint;
+  }
+  return post(`${baseURL}/${projectID}/validate`, data, options);
 };
 
 export const handler: PluginHandler = async (


### PR DESCRIPTION
…aporia trial endpoint

**Title:** 
- Make Aporia API endpoint configurable

**Description:** (optional)
- Aporia has 2 urls currently. `https://gr-prd.aporia.com` and `https://gr-prd-trial.aporia.com`. Allow configuring endpoint to trial if required. Defaults to `https://gr-prd.aporia.com`

**Motivation:** (optional)
- Support aporia trial endpoint

**Related Issues:** (optional)
- Closes #556 
