### PR TITLE
fix: skip husky prepare script for production environment

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:check": "prettier --check \"./**/*.{js,jsx,ts,tsx,json}\"",
     "test": "ts-jest",
     "pre-push": "npm run build && node start-test.js",
-    "prepare": "husky"
+    "prepare": "node -e \"if (process.env.NODE_ENV !== 'production'){process.exit(1)} \" || husky install"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",


### PR DESCRIPTION
**Title:** 
- fix: skip husky prepare script for production environment

Fixes #561 
