### PR TITLE
refactor code for minimal changes required for new open-ai compatible…

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -66,7 +66,7 @@ export const VOYAGE: string = 'voyage';
 export const GITHUB: string = 'github';
 export const DEEPBRICKS: string = 'deepbricks';
 export const SILICONFLOW: string = 'siliconflow';
-export const CREEBRAS: string = 'cerebras';
+export const CEREBRAS: string = 'cerebras';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -107,7 +107,7 @@ export const VALID_PROVIDERS = [
   DEEPBRICKS,
   SILICONFLOW,
   HUGGING_FACE,
-  CREEBRAS,
+  CEREBRAS,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -64,6 +64,7 @@ export const TRITON: string = 'triton';
 export const VOYAGE: string = 'voyage';
 export const DEEPBRICKS: string = 'deepbricks';
 export const SILICONFLOW: string = 'siliconflow';
+export const CREEBRAS: string = 'cerebras';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -102,6 +103,7 @@ export const VALID_PROVIDERS = [
   DEEPBRICKS,
   SILICONFLOW,
   HUGGING_FACE,
+  CREEBRAS,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/cerebras/api.ts
+++ b/src/providers/cerebras/api.ts
@@ -1,0 +1,16 @@
+import { ProviderAPIConfig } from '../types';
+
+export const cerebrasAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'http://localhost:8009/v1',
+  headers: ({ providerOptions }) => {
+    return { Authorization: `Bearer ${providerOptions.apiKey}` };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      default:
+        return '';
+    }
+  },
+};

--- a/src/providers/cerebras/api.ts
+++ b/src/providers/cerebras/api.ts
@@ -1,7 +1,7 @@
 import { ProviderAPIConfig } from '../types';
 
 export const cerebrasAPIConfig: ProviderAPIConfig = {
-  getBaseURL: () => 'http://localhost:8009/v1',
+  getBaseURL: () => 'https://api.cerebras.ai/v1',
   headers: ({ providerOptions }) => {
     return { Authorization: `Bearer ${providerOptions.apiKey}` };
   },

--- a/src/providers/cerebras/index.ts
+++ b/src/providers/cerebras/index.ts
@@ -1,4 +1,4 @@
-import { CREEBRAS } from '../../globals';
+import { CEREBRAS } from '../../globals';
 import { chatCompleteParams, responseTransformers } from '../open-ai-base';
 import { ProviderConfigs } from '../types';
 import { cerebrasAPIConfig } from './api';
@@ -13,7 +13,7 @@ export const cerebrasProviderAPIConfig: ProviderConfigs = {
     'service_tier',
   ]),
   api: cerebrasAPIConfig,
-  responseTransforms: responseTransformers(CREEBRAS, {
+  responseTransforms: responseTransformers(CEREBRAS, {
     chatComplete: true,
   }),
 };

--- a/src/providers/cerebras/index.ts
+++ b/src/providers/cerebras/index.ts
@@ -1,0 +1,19 @@
+import { CREEBRAS } from '../../globals';
+import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import { cerebrasAPIConfig } from './api';
+
+export const cerebrasProviderAPIConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams([
+    'frequency_penalty',
+    'logit_bias',
+    'logprobs',
+    'presence_penalty',
+    'parallel_tool_calls',
+    'service_tier',
+  ]),
+  api: cerebrasAPIConfig,
+  responseTransforms: responseTransformers(CREEBRAS, {
+    chatComplete: true,
+  }),
+};

--- a/src/providers/groq/index.ts
+++ b/src/providers/groq/index.ts
@@ -1,55 +1,16 @@
-import { GROQ } from '../../globals';
-import { chatCompleteParams, responseTransformers } from '../open-ai-base';
-import { OpenAIChatCompleteResponse } from '../openai/chatComplete';
-import { ErrorResponse, ProviderConfigs } from '../types';
+import { ProviderConfigs } from '../types';
 import GroqAPIConfig from './api';
-import { GroqChatCompleteStreamChunkTransform } from './chatComplete';
-
-type GroqChatCompleteResponse = (OpenAIChatCompleteResponse | ErrorResponse) & {
-  x_groq?: {
-    id: string;
-  };
-};
+import {
+  GroqChatCompleteConfig,
+  GroqChatCompleteResponseTransform,
+  GroqChatCompleteStreamChunkTransform,
+} from './chatComplete';
 
 const GroqConfig: ProviderConfigs = {
-  chatComplete: chatCompleteParams(
-    [
-      'functions',
-      'function_call',
-      'presence_penalty',
-      'frequency_penalty',
-      'logit_bias',
-      'user',
-      'seed',
-      'tools',
-      'tool_choice',
-      'response_format',
-      'logprobs',
-      'stream_options',
-    ],
-    { model: 'mixtral-8x7b-32768' }
-  ),
+  chatComplete: GroqChatCompleteConfig,
   api: GroqAPIConfig,
   responseTransforms: {
-    // chatComplete: GroqChatCompleteResponseTransform,
-    ...responseTransformers<any, any, GroqChatCompleteResponse>(GROQ, {
-      chatComplete: (response, isError) => {
-        if (isError) {
-          return response;
-        }
-        const newResponse = { ...response } as OpenAIChatCompleteResponse;
-
-        delete (newResponse as any)['x_groq'];
-
-        newResponse.usage = {
-          completion_tokens: newResponse.usage?.completion_tokens || 0,
-          prompt_tokens: newResponse.usage?.prompt_tokens || 0,
-          total_tokens: newResponse.usage?.total_tokens || 0,
-        };
-
-        return newResponse;
-      },
-    }),
+    chatComplete: GroqChatCompleteResponseTransform,
     'stream-chatComplete': GroqChatCompleteStreamChunkTransform,
   },
 };

--- a/src/providers/groq/index.ts
+++ b/src/providers/groq/index.ts
@@ -1,16 +1,55 @@
-import { ProviderConfigs } from '../types';
+import { GROQ } from '../../globals';
+import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import { OpenAIChatCompleteResponse } from '../openai/chatComplete';
+import { ErrorResponse, ProviderConfigs } from '../types';
 import GroqAPIConfig from './api';
-import {
-  GroqChatCompleteConfig,
-  GroqChatCompleteResponseTransform,
-  GroqChatCompleteStreamChunkTransform,
-} from './chatComplete';
+import { GroqChatCompleteStreamChunkTransform } from './chatComplete';
+
+type GroqChatCompleteResponse = (OpenAIChatCompleteResponse | ErrorResponse) & {
+  x_groq?: {
+    id: string;
+  };
+};
 
 const GroqConfig: ProviderConfigs = {
-  chatComplete: GroqChatCompleteConfig,
+  chatComplete: chatCompleteParams(
+    [
+      'functions',
+      'function_call',
+      'presence_penalty',
+      'frequency_penalty',
+      'logit_bias',
+      'user',
+      'seed',
+      'tools',
+      'tool_choice',
+      'response_format',
+      'logprobs',
+      'stream_options',
+    ],
+    { model: 'mixtral-8x7b-32768' }
+  ),
   api: GroqAPIConfig,
   responseTransforms: {
-    chatComplete: GroqChatCompleteResponseTransform,
+    // chatComplete: GroqChatCompleteResponseTransform,
+    ...responseTransformers<any, any, GroqChatCompleteResponse>(GROQ, {
+      chatComplete: (response, isError) => {
+        if (isError) {
+          return response;
+        }
+        const newResponse = { ...response } as OpenAIChatCompleteResponse;
+
+        delete (newResponse as any)['x_groq'];
+
+        newResponse.usage = {
+          completion_tokens: newResponse.usage?.completion_tokens || 0,
+          prompt_tokens: newResponse.usage?.prompt_tokens || 0,
+          total_tokens: newResponse.usage?.total_tokens || 0,
+        };
+
+        return newResponse;
+      },
+    }),
     'stream-chatComplete': GroqChatCompleteStreamChunkTransform,
   },
 };

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -35,6 +35,7 @@ import VoyageConfig from './voyage';
 import DeepbricksConfig from './deepbricks';
 import SiliconFlowConfig from './siliconflow';
 import HuggingfaceConfig from './huggingface';
+import { cerebrasProviderAPIConfig } from './cerebras';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -73,6 +74,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   voyage: VoyageConfig,
   deepbricks: DeepbricksConfig,
   siliconflow: SiliconFlowConfig,
+  cerebras: cerebrasProviderAPIConfig,
 };
 
 export default Providers;

--- a/src/providers/open-ai-base/index.ts
+++ b/src/providers/open-ai-base/index.ts
@@ -1,0 +1,378 @@
+import { OPEN_AI } from '../../globals';
+import { EmbedResponse } from '../../types/embedRequestBody';
+import { OpenAIChatCompleteResponse } from '../openai/chatComplete';
+import { OpenAICompleteResponse } from '../openai/complete';
+import { OpenAIErrorResponseTransform } from '../openai/utils';
+import { ErrorResponse, ProviderConfig } from '../types';
+
+type CustomTransformer<T extends any, U> = (
+  response: T | ErrorResponse,
+  isError?: boolean
+) => U;
+
+const excludeObjectKeys = (keyList: string[], object: Record<string, any>) => {
+  if (keyList) {
+    keyList.forEach((excludeKey) => {
+      if (Object.hasOwn(object, excludeKey)) {
+        delete object[excludeKey];
+      }
+    });
+  }
+};
+
+/**
+ *
+ * @param exclude List of string that we should exclude from open-ai default paramters
+ * @param defaultValues Default values specific to the provider for params
+ * @param extra Extra parameters type of ProviderConfig should extend to support the provider
+ * @returns {ProviderConfig}
+ */
+export const chatCompleteParams = (
+  exclude: string[],
+  defaultValues?: Record<string, string>,
+  extra?: ProviderConfig
+): ProviderConfig => {
+  const baseParams: ProviderConfig = {
+    model: {
+      param: 'model',
+      required: true,
+      ...(defaultValues?.model && { default: defaultValues.model }),
+    },
+    messages: {
+      param: 'messages',
+      default: '',
+    },
+    functions: {
+      param: 'functions',
+    },
+    function_call: {
+      param: 'function_call',
+    },
+    max_tokens: {
+      param: 'max_tokens',
+      ...(defaultValues?.max_tokens && { default: defaultValues.max_tokens }),
+      min: 0,
+    },
+    temperature: {
+      param: 'temperature',
+      ...(defaultValues?.temperature && { default: defaultValues.temperature }),
+      min: 0,
+      max: 2,
+    },
+    top_p: {
+      param: 'top_p',
+      ...(defaultValues?.top_p && { default: defaultValues.top_p }),
+      min: 0,
+      max: 1,
+    },
+    n: {
+      param: 'n',
+      default: 1,
+    },
+    stream: {
+      param: 'stream',
+      ...(defaultValues?.stream && { default: defaultValues.stream }),
+    },
+    presence_penalty: {
+      param: 'presence_penalty',
+      min: -2,
+      max: 2,
+    },
+    frequency_penalty: {
+      param: 'frequency_penalty',
+      min: -2,
+      max: 2,
+    },
+    logit_bias: {
+      param: 'logit_bias',
+    },
+    user: {
+      param: 'user',
+    },
+    seed: {
+      param: 'seed',
+    },
+    tools: {
+      param: 'tools',
+    },
+    tool_choice: {
+      param: 'tool_choice',
+    },
+    response_format: {
+      param: 'response_format',
+    },
+    logprobs: {
+      param: 'logprobs',
+      ...(defaultValues?.logprobs && { default: defaultValues?.logprobs }),
+    },
+    stream_options: {
+      param: 'stream_options',
+    },
+  };
+
+  // Exclude params that are not needed.
+  excludeObjectKeys(exclude, baseParams);
+
+  return { ...baseParams, ...(extra ?? {}) };
+};
+
+/**
+ *
+ * @param exclude List of string that we should exclude from open-ai default paramters
+ * @param defaultValues Default values specific to the provider for params
+ * @param extra Extra parameters type of ProviderConfig should extend to support the provider
+ * @returns {ProviderConfig}
+ */
+export const completeParams = (
+  exclude: string[],
+  defaultValues?: Record<string, string>,
+  extra?: ProviderConfig
+): ProviderConfig => {
+  const baseParams: ProviderConfig = {
+    model: {
+      param: 'model',
+      required: true,
+      ...(defaultValues?.model && { default: defaultValues.model }),
+    },
+    prompt: {
+      param: 'prompt',
+      default: '',
+    },
+    max_tokens: {
+      param: 'max_tokens',
+      ...(defaultValues?.max_tokens && { default: defaultValues.max_tokens }),
+      min: 0,
+    },
+    temperature: {
+      param: 'temperature',
+      ...(defaultValues?.temperature && { default: defaultValues.temperature }),
+      min: 0,
+      max: 2,
+    },
+    top_p: {
+      param: 'top_p',
+      ...(defaultValues?.top_p && { default: defaultValues.top_p }),
+      min: 0,
+      max: 1,
+    },
+    n: {
+      param: 'n',
+      default: 1,
+    },
+    stream: {
+      param: 'stream',
+      ...(defaultValues?.stream && { default: defaultValues.stream }),
+    },
+    logprobs: {
+      param: 'logprobs',
+      max: 5,
+    },
+    echo: {
+      param: 'echo',
+      default: false,
+    },
+    stop: {
+      param: 'stop',
+    },
+    presence_penalty: {
+      param: 'presence_penalty',
+      min: -2,
+      max: 2,
+    },
+    frequency_penalty: {
+      param: 'frequency_penalty',
+      min: -2,
+      max: 2,
+    },
+    best_of: {
+      param: 'best_of',
+    },
+    logit_bias: {
+      param: 'logit_bias',
+    },
+    user: {
+      param: 'user',
+    },
+    seed: {
+      param: 'seed',
+    },
+    suffix: {
+      param: 'suffix',
+    },
+  };
+
+  excludeObjectKeys(exclude, baseParams);
+
+  return { ...baseParams, ...(extra ?? {}) };
+};
+
+export const embedParams = (
+  exclude: string[],
+  defaultValues?: Record<string, string>,
+  extra?: ProviderConfig
+): ProviderConfig => {
+  const baseParams: ProviderConfig = {
+    model: {
+      param: 'model',
+      required: true,
+      ...(defaultValues?.model && { default: defaultValues.model }),
+    },
+    input: {
+      param: 'input',
+      required: true,
+    },
+    encoding_format: {
+      param: 'encoding_format',
+    },
+    dimensions: {
+      param: 'dimensions',
+    },
+    user: {
+      param: 'user',
+    },
+  };
+
+  excludeObjectKeys(exclude, baseParams);
+
+  return { ...baseParams, ...(extra ?? {}) };
+};
+
+const EmbedResponseTransformer = <T extends EmbedResponse | ErrorResponse>(
+  provider: string
+) => {
+  const transformer: (
+    response: T | ErrorResponse,
+    responseStatus: number
+  ) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+    if (responseStatus !== 200 && 'error' in response) {
+      return OpenAIErrorResponseTransform(response, provider ?? OPEN_AI);
+    }
+
+    Object.defineProperty(response, 'provider', {
+      value: provider,
+      enumerable: true,
+    });
+    return response;
+  };
+
+  return transformer;
+};
+
+const CompleteResponseTransformer = <
+  T extends OpenAICompleteResponse | ErrorResponse,
+>(
+  provider: string,
+  customTransformer?: CustomTransformer<OpenAICompleteResponse, T>
+) => {
+  const transformer: (
+    response: T | ErrorResponse,
+    responseStatus: number
+  ) => T | ErrorResponse = (response, responseStatus) => {
+    if (responseStatus !== 200 && 'error' in response) {
+      const errorResponse = OpenAIErrorResponseTransform(
+        response,
+        provider ?? OPEN_AI
+      );
+      if (customTransformer) {
+        return customTransformer(errorResponse, true);
+      }
+    }
+
+    if (customTransformer) {
+      return customTransformer(response as T);
+    }
+
+    Object.defineProperty(response, 'provider', {
+      value: provider,
+      enumerable: true,
+    });
+
+    return response;
+  };
+
+  return transformer;
+};
+
+const ChatCompleteResponseTransformer = <
+  T extends OpenAIChatCompleteResponse | ErrorResponse,
+>(
+  provider: string,
+  customTransformer?: CustomTransformer<OpenAIChatCompleteResponse, T>
+) => {
+  const transformer: (
+    response: T | ErrorResponse,
+    responseStatus: number
+  ) => T | ErrorResponse = (response, responseStatus) => {
+    if (responseStatus !== 200 && 'error' in response) {
+      const errorResponse = OpenAIErrorResponseTransform(
+        response,
+        provider ?? OPEN_AI
+      );
+      if (customTransformer) {
+        return customTransformer(response as ErrorResponse, true);
+      }
+
+      return errorResponse;
+    }
+
+    if (customTransformer) {
+      return customTransformer(response as T);
+    }
+
+    Object.defineProperty(response, 'provider', {
+      value: provider,
+      enumerable: true,
+    });
+    return response;
+  };
+
+  return transformer;
+};
+
+/**
+ *
+ * @param provider Provider value
+ * @param options Enable transformer functions to specific task (complete, chatComplete or embed)
+ * @returns
+ */
+export const responseTransformers = <
+  T extends EmbedResponse | ErrorResponse,
+  U extends OpenAICompleteResponse | ErrorResponse,
+  V extends OpenAIChatCompleteResponse | ErrorResponse,
+>(
+  provider: string,
+  options: {
+    embed?: boolean | CustomTransformer<EmbedResponse | ErrorResponse, T>;
+    complete?:
+      | boolean
+      | CustomTransformer<OpenAICompleteResponse | ErrorResponse, U>;
+    chatComplete?:
+      | boolean
+      | CustomTransformer<OpenAIChatCompleteResponse | ErrorResponse, V>;
+  }
+) => {
+  const transformers: Record<string, Function | null> = {
+    complete: null,
+    chatComplete: null,
+    embed: null,
+  };
+
+  if (options.embed) {
+    transformers.embed = EmbedResponseTransformer<T>(provider);
+  }
+
+  if (options.complete) {
+    transformers.complete = CompleteResponseTransformer<U>(provider);
+  }
+
+  if (options.chatComplete) {
+    transformers.chatComplete = ChatCompleteResponseTransformer<V>(
+      provider,
+      typeof options.chatComplete === 'function'
+        ? options.chatComplete
+        : undefined
+    );
+  }
+
+  return transformers;
+};

--- a/src/providers/open-ai-base/index.ts
+++ b/src/providers/open-ai-base/index.ts
@@ -238,7 +238,8 @@ export const embedParams = (
 };
 
 const EmbedResponseTransformer = <T extends EmbedResponse | ErrorResponse>(
-  provider: string
+  provider: string,
+  customTransformer?: CustomTransformer<EmbedResponse, T>
 ) => {
   const transformer: (
     response: T | ErrorResponse,
@@ -358,11 +359,17 @@ export const responseTransformers = <
   };
 
   if (options.embed) {
-    transformers.embed = EmbedResponseTransformer<T>(provider);
+    transformers.embed = EmbedResponseTransformer<T>(
+      provider,
+      typeof options.embed === 'function' ? options.embed : undefined
+    );
   }
 
   if (options.complete) {
-    transformers.complete = CompleteResponseTransformer<U>(provider);
+    transformers.complete = CompleteResponseTransformer<U>(
+      provider,
+      typeof options.complete === 'function' ? options.complete : undefined
+    );
   }
 
   if (options.chatComplete) {


### PR DESCRIPTION
Simplifying the creation of new openai compatible providers.

**API**
* `chatCompletetionParams` - Extendable function to support exclusion, default-values and extra config based on the requirement for `chat` functionality of provider.
* `completionParams` - Extendable function to support exclusion, default-values and extra config based on the requirement for `chat` functionality of provider.
* `embedParams` - Extendable function to support exclusion, default-values and extra config based on the requirement for `embed` functionality of provider.

**Response Handling**
`responseTransformers` function accepts two parameter
* `provider` as string
* `options` an object - `{chatComplete: Function | boolean, complete: Function | boolean, embed: Function | boolean}`

We can enable `openai` existing response transformers directly by passing `true` for each function or we can write a function that accepts `response` and `boolean` indicating weather the response is error response or not.

Extended function should return the response which is inclusive of `openai` response types (embed, complete and chatComplete). 
