### PR TITLE
perf: support type suggestions for hono context object

### DIFF
--- a/src/context.d.ts
+++ b/src/context.d.ts
@@ -1,0 +1,43 @@
+export * from 'hono';
+
+enum CACHE_STATUS {
+  HIT = 'HIT',
+  SEMANTIC_HIT = 'SEMANTIC HIT',
+  MISS = 'MISS',
+  SEMANTIC_MISS = 'SEMANTIC MISS',
+  REFRESH = 'REFRESH',
+  DISABLED = 'DISABLED',
+}
+
+declare module 'hono' {
+  interface ContextVariableMap {
+    hooksManager: import('./middlewares/hooks').HooksManager;
+    executeHooks: ContextVariableMap['hooksManager']['executeHooks'];
+    getFromCache: (
+      env: any,
+      requestHeaders: any,
+      requestBody: any,
+      url: string,
+      organisationId: string,
+      cacheMode: string,
+      cacheMaxAge?: string | number | null
+    ) => Promise<[any, CACHE_STATUS, any]>;
+    requestOptions: [
+      {
+        providerOptions: {
+          provider: string;
+          requestURL: string;
+          rubeusURL: string;
+          [key: string]: any;
+        };
+        requestParams: any;
+        response: Response;
+        cacheStatus: CACHE_STATUS;
+        cacheKey: string;
+        cacheMode: string;
+        // intentionally undefined
+        cacheMaxAge: string | number | null | undefined;
+      },
+    ];
+  }
+}

--- a/src/middlewares/cache/index.ts
+++ b/src/middlewares/cache/index.ts
@@ -100,14 +100,14 @@ export const memoryCache = () => {
       Array.isArray(requestOptions) &&
       requestOptions.length > 0
     ) {
-      requestOptions = requestOptions[0];
-      if (requestOptions.cacheMode === 'simple') {
+      const _requestOptions = requestOptions[0];
+      if (_requestOptions.cacheMode === 'simple') {
         await putInCache(
           null,
           null,
-          requestOptions.requestParams,
-          await requestOptions.response.json(),
-          requestOptions.providerOptions.rubeusURL,
+          _requestOptions.requestParams,
+          await _requestOptions.response.json(),
+          _requestOptions.providerOptions.rubeusURL,
           '',
           null,
           null


### PR DESCRIPTION
**Title:** 
Adds typescript support for `context` object which we use at multiple places
`c.get` and `c.set` functions.

