### PR TITLE
fix: move sambanova fastapi to cloud

### DIFF
--- a/src/providers/sambanova/api.ts
+++ b/src/providers/sambanova/api.ts
@@ -2,7 +2,7 @@ import { ProviderAPIConfig } from '../types';
 
 const SambaNovaAPIConfig: ProviderAPIConfig = {
   getBaseURL: ({ providerOptions }) =>
-    providerOptions.customHost || 'https://fast-api.snova.ai',
+    providerOptions.customHost || 'https://api.sambanova.ai',
   headers: ({ providerOptions }) => {
     return { Authorization: `Bearer ${providerOptions.apiKey}` };
   },


### PR DESCRIPTION
I received an email 6 hours ago informing to move from fastapi to own cloud. The old API URL has been deprecated and available for next 30 days. Users can get a new API KEY from https://cloud.sambanova.ai/.