### PR TITLE
feat/plugin-ends-with

### DIFF
--- a/plugins/default/default.test.ts
+++ b/plugins/default/default.test.ts
@@ -7,6 +7,7 @@ import { handler as wordCountHandler } from './wordCount';
 import { handler as sentenceCountHandler } from './sentenceCount';
 import { handler as webhookHandler } from './webhook';
 import { handler as logHandler } from './log';
+import {handler as endsWithHandler} from './endsWith';
 
 import { z } from 'zod';
 import { PluginContext, PluginParameters } from '../types';
@@ -520,5 +521,52 @@ describe('log handler', () => {
 
     expect(result.error).toBe(null);
     expect(result.verdict).toBe(true);
+  });
+});
+
+describe('endsWith handler', () => {
+  it('should return true verdict if response ends with provided suffix', async () => {
+    const eventType = 'afterRequestHook';
+    const context: PluginContext = {
+      response: {
+        text: 'This is a sentence that ends with the expect word i.e. HarryPortkey',
+      },
+    };
+    const parameters: PluginParameters = {
+      suffix: 'HarryPortkey',
+    };
+    const result = await endsWithHandler(context, parameters, eventType);
+    expect(result.error).toBe(null);
+    expect(result.verdict).toBe(true);
+  });
+  it('should return false verdict if response not ending with provided suffix', async () => {
+    const context: PluginContext = {
+      response: { text: 'This is a sentence ending with wrong word i.e. MalfoyPortkey.' },
+    };
+    const eventType = 'afterRequestHook';
+
+    const parameters: PluginParameters = {
+      suffix: 'HarryPortkey',
+    };
+
+    const result = await endsWithHandler(context, parameters, eventType);
+
+    expect(result.error).toBe(null);
+    expect(result.verdict).toBe(false);
+  });
+  it('should return error for missing suffix in parameters', async () => {
+    const context: PluginContext = {
+      response: { text: 'This is a sentence which ends with Portkey.' },
+    };
+    const eventType = 'afterRequestHook';
+
+    const parameters: PluginParameters = {};
+
+    const result = await endsWithHandler(context, parameters, eventType);
+
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Missing suffix or text');
+    expect(result.verdict).toBe(false);
+    expect(result.data).toBe(null);
   });
 });

--- a/plugins/default/endsWith.ts
+++ b/plugins/default/endsWith.ts
@@ -1,0 +1,37 @@
+import {
+    HookEventType,
+    PluginContext,
+    PluginHandler,
+    PluginParameters,
+  } from '../types';
+  import { getText } from '../utils';
+
+  export const handler: PluginHandler = async (
+    context: PluginContext,
+    parameters: PluginParameters,
+    eventType: HookEventType
+  ) => {
+    let error = null;
+    let verdict = false;
+    let data = null;
+  
+    try {
+      const suffix = parameters.suffix;
+      let text = getText(context, eventType);
+  
+      if (
+        suffix!==undefined && 
+        "" !== suffix &&
+        text.length >= 0
+      ) {
+        verdict = text.endsWith(suffix) || text.endsWith(`${suffix}.`);
+      } else {
+        error = error || new Error('Missing suffix or text');
+      } 
+    } catch (e) {
+      error = e as Error;
+    }
+  
+    return { error, verdict, data };
+  };
+  


### PR DESCRIPTION
**ENDS WITH PLUGIN** 
- Default Guardrail check to see whether the response ends with a specific substring or not.

**Description:** 
- Added endsWith.ts in the default plugin.
- Wrote corresponding tests in default.test.ts.

**Related Issues:** 
- #513 
