### PR TITLE
Ends with Plugin Integrated

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "start:node": "node build/start-server.js",
     "format": "prettier --write \"./**/*.{js,jsx,ts,tsx,json}\"",
     "format:check": "prettier --check \"./**/*.{js,jsx,ts,tsx,json}\"",
-    "test": "ts-jest",
+    "test": "jest",
     "pre-push": "npm run build && node start-test.js",
     "prepare": "node -e \"if (process.env.NODE_ENV !== 'production'){process.exit(1)} \" || husky install"
   },

--- a/plugins/default/default.test.ts
+++ b/plugins/default/default.test.ts
@@ -7,6 +7,7 @@ import { handler as wordCountHandler } from './wordCount';
 import { handler as sentenceCountHandler } from './sentenceCount';
 import { handler as webhookHandler } from './webhook';
 import { handler as logHandler } from './log';
+import {handler as endsWithHandler} from './endsWith';
 
 import { z } from 'zod';
 import { PluginContext, PluginParameters } from '../types';
@@ -520,5 +521,52 @@ describe('log handler', () => {
 
     expect(result.error).toBe(null);
     expect(result.verdict).toBe(true);
+  });
+});
+
+describe('endsWith handler', () => {
+  it('should return true verdict if response ends with provided suffix', async () => {
+    const eventType = 'afterRequestHook';
+    const context: PluginContext = {
+      response: {
+        text: 'This is a sentence that ends with the expect word i.e. HarryPortkey',
+      },
+    };
+    const parameters: PluginParameters = {
+      suffix: 'HarryPortkey',
+    };
+    const result = await endsWithHandler(context, parameters, eventType);
+    expect(result.error).toBe(null);
+    expect(result.verdict).toBe(true);
+  });
+  it('should return false verdict if response not ending with provided suffix', async () => {
+    const context: PluginContext = {
+      response: { text: 'This is a sentence ending with wrong word i.e. MalfoyPortkey.' },
+    };
+    const eventType = 'afterRequestHook';
+
+    const parameters: PluginParameters = {
+      suffix: 'HarryPortkey',
+    };
+
+    const result = await endsWithHandler(context, parameters, eventType);
+
+    expect(result.error).toBe(null);
+    expect(result.verdict).toBe(false);
+  });
+  it('should return error for missing suffix in parameters', async () => {
+    const context: PluginContext = {
+      response: { text: 'This is a sentence which ends with Portkey.' },
+    };
+    const eventType = 'afterRequestHook';
+
+    const parameters: PluginParameters = {};
+
+    const result = await endsWithHandler(context, parameters, eventType);
+
+    expect(result.error).toBeInstanceOf(Error);
+    expect(result.error?.message).toBe('Missing suffix or text');
+    expect(result.verdict).toBe(false);
+    expect(result.data).toBe(null);
   });
 });

--- a/plugins/default/default.test.ts
+++ b/plugins/default/default.test.ts
@@ -7,7 +7,7 @@ import { handler as wordCountHandler } from './wordCount';
 import { handler as sentenceCountHandler } from './sentenceCount';
 import { handler as webhookHandler } from './webhook';
 import { handler as logHandler } from './log';
-import {handler as endsWithHandler} from './endsWith';
+import { handler as endsWithHandler } from './endsWith';
 
 import { z } from 'zod';
 import { PluginContext, PluginParameters } from '../types';
@@ -529,7 +529,7 @@ describe('endsWith handler', () => {
     const eventType = 'afterRequestHook';
     const context: PluginContext = {
       response: {
-        text: 'This is a sentence that ends with the expect word i.e. HarryPortkey',
+        text: 'This is a sentence that ends with the expected word i.e. HarryPortkey.',
       },
     };
     const parameters: PluginParameters = {
@@ -541,7 +541,9 @@ describe('endsWith handler', () => {
   });
   it('should return false verdict if response not ending with provided suffix', async () => {
     const context: PluginContext = {
-      response: { text: 'This is a sentence ending with wrong word i.e. MalfoyPortkey.' },
+      response: {
+        text: 'This is a sentence ending with wrong word i.e. MalfoyPortkey.',
+      },
     };
     const eventType = 'afterRequestHook';
 

--- a/plugins/default/endsWith.ts
+++ b/plugins/default/endsWith.ts
@@ -1,37 +1,32 @@
 import {
-    HookEventType,
-    PluginContext,
-    PluginHandler,
-    PluginParameters,
-  } from '../types';
-  import { getText } from '../utils';
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { getText } from '../utils';
 
-  export const handler: PluginHandler = async (
-    context: PluginContext,
-    parameters: PluginParameters,
-    eventType: HookEventType
-  ) => {
-    let error = null;
-    let verdict = false;
-    let data = null;
-  
-    try {
-      const suffix = parameters.suffix;
-      let text = getText(context, eventType);
-  
-      if (
-        suffix!==undefined && 
-        "" !== suffix &&
-        text.length >= 0
-      ) {
-        verdict = text.endsWith(suffix) || text.endsWith(`${suffix}.`);
-      } else {
-        error = error || new Error('Missing suffix or text');
-      } 
-    } catch (e) {
-      error = e as Error;
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let error = null;
+  let verdict = false;
+  let data = null;
+
+  try {
+    const suffix = parameters.suffix;
+    let text = getText(context, eventType);
+
+    if (suffix !== undefined && '' !== suffix && text.length >= 0) {
+      verdict = text.endsWith(suffix) || text.endsWith(`${suffix}.`);
+    } else {
+      error = error || new Error('Missing suffix or text');
     }
-  
-    return { error, verdict, data };
-  };
-  
+  } catch (e) {
+    error = e as Error;
+  }
+
+  return { error, verdict, data };
+};

--- a/plugins/default/endsWith.ts
+++ b/plugins/default/endsWith.ts
@@ -1,0 +1,37 @@
+import {
+    HookEventType,
+    PluginContext,
+    PluginHandler,
+    PluginParameters,
+  } from '../types';
+  import { getText } from '../utils';
+
+  export const handler: PluginHandler = async (
+    context: PluginContext,
+    parameters: PluginParameters,
+    eventType: HookEventType
+  ) => {
+    let error = null;
+    let verdict = false;
+    let data = null;
+  
+    try {
+      const suffix = parameters.suffix;
+      let text = getText(context, eventType);
+  
+      if (
+        suffix!==undefined && 
+        "" !== suffix &&
+        text.length >= 0
+      ) {
+        verdict = text.endsWith(suffix) || text.endsWith(`${suffix}.`);
+      } else {
+        error = error || new Error('Missing suffix or text');
+      } 
+    } catch (e) {
+      error = e as Error;
+    }
+  
+    return { error, verdict, data };
+  };
+  

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -69,6 +69,7 @@ export const SILICONFLOW: string = 'siliconflow';
 export const CEREBRAS: string = 'cerebras';
 export const INFERENCENET: string = 'inference-net';
 export const SAMBANOVA: string = 'sambanova';
+export const UPSTAGE: string = 'upstage';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -112,6 +113,7 @@ export const VALID_PROVIDERS = [
   CEREBRAS,
   INFERENCENET,
   SAMBANOVA,
+  UPSTAGE,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -42,6 +42,7 @@ import HuggingfaceConfig from './huggingface';
 import { cerebrasProviderAPIConfig } from './cerebras';
 import { InferenceNetProviderConfigs } from './inference-net';
 import SambaNovaConfig from './sambanova';
+import { UpstageProviderConfig } from './upstage';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -85,6 +86,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   cerebras: cerebrasProviderAPIConfig,
   'inference-net': InferenceNetProviderConfigs,
   sambanova: SambaNovaConfig,
+  upstage: UpstageProviderConfig,
 };
 
 export default Providers;

--- a/src/providers/upstage/api.ts
+++ b/src/providers/upstage/api.ts
@@ -1,0 +1,17 @@
+import { ProviderAPIConfig } from '../types';
+
+export const upstageAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://api.upstage.ai/v1/solar',
+  headers({ providerOptions }) {
+    const { apiKey } = providerOptions;
+    return { Authorization: `Bearer ${apiKey}` };
+  },
+  getEndpoint({ fn }) {
+    switch (fn) {
+      case 'chatComplete':
+        return `/chat/completions`;
+      default:
+        return '';
+    }
+  },
+};

--- a/src/providers/upstage/index.ts
+++ b/src/providers/upstage/index.ts
@@ -1,0 +1,12 @@
+import { UPSTAGE } from '../../globals';
+import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import { upstageAPIConfig } from './api';
+
+export const UpstageProviderConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams([], { model: 'solar-pro' }),
+  api: upstageAPIConfig,
+  responseTransforms: responseTransformers(UPSTAGE, {
+    chatComplete: true,
+  }),
+};


### PR DESCRIPTION
**Ends With Plugin** 
- An ends-with default guardRail check has been added. It checks whether the response ends with a given substring or not.

**Description:** (optional)
- Added endsWith.ts 
- Added corresponding tests in default.test.js

**Related Issues:** (optional)
- #513 
