### PR TITLE
Minor fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "format:check": "prettier --check \"./**/*.{js,jsx,ts,tsx,json}\"",
     "test": "ts-jest",
     "pre-push": "npm run build && node start-test.js",
-    "prepare": "node -e \"if (process.env.NODE_ENV !== 'production'){process.exit(1)} \" || husky install"
+    "prepare": "node -e \"if (process.env.NODE_ENV !== 'production'){process.exit(1)} \" || husky"
   },
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,11 @@ const app = new Hono();
 
 app.use('*', (c, next) => {
   const runtime = getRuntimeKey();
-  if (runtime !== 'lagon' && runtime !== 'workerd' && runtime !== 'node') {
-    return compress()(c, next);
+  const runtimesThatDontNeedCompression = ['lagon', 'workerd', 'node'];
+  if (runtimesThatDontNeedCompression.includes(runtime)) {
+    return next();
   }
-  return next();
+  return compress()(c, next);
 });
 
 /**


### PR DESCRIPTION
1. "Husky install" is [deprecated](https://stackoverflow.com/questions/77897612/problem-when-trying-to-add-prettiers-git-hook-husky-install-error-install-com) and throws a warning. replaced it with just "husky" which is the replacement method.

2. Refactored compression middleware check to be explicitly declarative instead of depending on the comment