### PR TITLE
feat: add support for max_completion_tokens param

### DIFF
--- a/src/providers/openai/chatComplete.ts
+++ b/src/providers/openai/chatComplete.ts
@@ -91,10 +91,10 @@ export const OpenAIChatCompleteConfig: ProviderConfig = {
     param: 'stream_options',
   },
   service_tier: {
-    param: 'stream_options',
+    param: 'service_tier',
   },
   parallel_tool_calls: {
-    param: 'stream_options',
+    param: 'parallel_tool_calls',
   },
   max_completion_tokens: {
     param: 'max_completion_tokens',

--- a/src/providers/openai/chatComplete.ts
+++ b/src/providers/openai/chatComplete.ts
@@ -90,6 +90,15 @@ export const OpenAIChatCompleteConfig: ProviderConfig = {
   stream_options: {
     param: 'stream_options',
   },
+  service_tier: {
+    param: 'stream_options',
+  },
+  parallel_tool_calls: {
+    param: 'stream_options',
+  },
+  max_completion_tokens: {
+    param: 'max_completion_tokens',
+  },
 };
 
 export interface OpenAIChatCompleteResponse extends ChatCompletionResponse {


### PR DESCRIPTION
**Title:** 
- add support for max_completion_tokens param

**Description:** (optional)
- Add support for max_completion_tokens param for openai chat completions.
- Also added service_tier and parallel_tool_calls as they were missing from the mapping.

**Motivation:** (optional)
- Support latest OpenAI models (o1)

**Related Issues:** (optional)
- Closes #604 
