### PR TITLE
chore: upgrade portkey mustache package version to 2.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,7 @@
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@hono/node-server": "^1.3.3",
-        "@portkey-ai/mustache": "^2.1.0",
+        "@portkey-ai/mustache": "^2.1.2",
         "@smithy/signature-v4": "^2.1.1",
         "@types/mustache": "^4.2.5",
         "async-retry": "^1.3.3",
@@ -1737,9 +1737,9 @@
       }
     },
     "node_modules/@portkey-ai/mustache": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/@portkey-ai/mustache/-/mustache-2.1.0.tgz",
-      "integrity": "sha512-N2i2PhT7SijBKFBWvg9+HqLRs6vuOws7z7NDUkMwugdxHyzXsJ5JoirhHRxhMmm10CUWgzgm6ecczQhxtrLBoQ=="
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/@portkey-ai/mustache/-/mustache-2.1.2.tgz",
+      "integrity": "sha512-0Ood+f2PPQIwBMVzRUKS/iKzQy61OghUBcp4CkcYVgWpIc3FXbGFUqzRqcOXOAiD34mZ1AKUPlMmPXXYsuA9fA=="
     },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
     "@hono/node-server": "^1.3.3",
-    "@portkey-ai/mustache": "^2.1.0",
+    "@portkey-ai/mustache": "^2.1.2",
     "@smithy/signature-v4": "^2.1.1",
     "@types/mustache": "^4.2.5",
     "async-retry": "^1.3.3",


### PR DESCRIPTION
**Title:** 
- upgrade portkey mustache package version to 2.1.2

**Description:** (optional)
- Upgrade @portkey-ai/mustache to v2.1.2 in package and package-lock

**Motivation:** (optional)
- To stay up-to-date with the package enhancements and fixes

**Related Issues:** (optional)
- Closes #612 
