### PR TITLE
Add missing logprob mapping for Azure OpenAI provider

### DIFF
--- a/src/providers/azure-openai/chatComplete.ts
+++ b/src/providers/azure-openai/chatComplete.ts
@@ -43,6 +43,13 @@ export const AzureOpenAIChatCompleteConfig: ProviderConfig = {
     param: 'n',
     default: 1,
   },
+  logprobs: {
+    param: 'logprobs',
+    default: false,
+  },
+  top_logprobs: {
+    param: 'top_logprobs',
+  },
   stream: {
     param: 'stream',
     default: false,


### PR DESCRIPTION
**Title:** Add missing logprob mapping for Azure OpenAI provider

**Description:** The Portkey gateway doesn't return any logprobs when these are set to True and 5 respectively, calling Azure directly works. I guess the reason is this mapping was missing. Kindly merge this so we can get logprobs when calling Azure via Portkey.


**Motivation:** We use the SaaS version of your gateway @ Haptik, and I need these scores.
