### PR TITLE
fix: chat templating for llama and mistral hosted on bedrock

### DIFF
--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -374,7 +374,7 @@ export const BedrockLLamaChatCompleteConfig: ProviderConfig = {
         let messages: Message[] = params.messages;
         messages.forEach((msg, index) => {
           if (index === 0 && msg.role === 'system') {
-            prompt += `system: ${messages}\n`;
+            prompt += `system: ${msg.content}\n`;
           } else if (msg.role == 'user') {
             prompt += `user: ${msg.content}\n`;
           } else if (msg.role == 'assistant') {
@@ -418,7 +418,7 @@ export const BedrockMistralChatCompleteConfig: ProviderConfig = {
         let messages: Message[] = params.messages;
         messages.forEach((msg, index) => {
           if (index === 0 && msg.role === 'system') {
-            prompt += `system: ${messages}\n`;
+            prompt += `system: ${msg.content}\n`;
           } else if (msg.role == 'user') {
             prompt += `user: ${msg.content}\n`;
           } else if (msg.role == 'assistant') {


### PR DESCRIPTION
Tested by making calls in local

Note: This is a temporary fix, will update the chat templating for llma to follow the standard https://www.llama.com/docs/model-cards-and-prompt-formats/llama3_1

related issues:
https://github.com/Portkey-AI/gateway/issues/620