### PR TITLE
webhook plugin header parsing logic to allow objects

### DIFF
--- a/plugins/default/webhook.ts
+++ b/plugins/default/webhook.ts
@@ -1,6 +1,16 @@
 import { PluginContext, PluginHandler, PluginParameters } from '../types';
 import { post } from '../utils';
 
+function parseHeaders(headers: unknown): Record<string, string> {
+  if (typeof headers === 'object' && headers !== null) {
+    return headers as Record<string, string>;
+  }
+  if (typeof headers === 'string') {
+    return JSON.parse(headers);
+  }
+  return {};
+}
+
 export const handler: PluginHandler = async (
   context: PluginContext,
   parameters: PluginParameters
@@ -8,12 +18,9 @@ export const handler: PluginHandler = async (
   let error = null;
   let verdict = false;
   let data = null;
-
   try {
     let url = parameters.webhookURL;
-    let headers: Record<string, string> = parameters?.headers
-      ? JSON.parse(parameters.headers)
-      : {};
+    const headers = parseHeaders(parameters.headers);
     ({ verdict, data } = await post(url, context, { headers }, 3000));
   } catch (e: any) {
     delete e.stack;


### PR DESCRIPTION
**Title:** 
- webhook plugin header parsing logic to allow objects

**Description:** (optional)
- Allow stringified object as well as objects in webhook plugin headers

**Motivation:** (optional)
- Make plugin flexible

**Related Issues:** (optional)
- Closes #633 
