### PR TITLE
Fix media file prompting for vertex gemini and google gemini

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -116,19 +116,27 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
                   });
 
                   return;
+                } else if (
+                  url.startsWith('gs://') ||
+                  url.startsWith('https://') ||
+                  url.startsWith('http://')
+                ) {
+                  parts.push({
+                    fileData: {
+                      mimeType: getMimeType(url),
+                      fileUri: url,
+                    },
+                  });
+                } else {
+                  // NOTE: This block is kept to maintain backward compatibility
+                  // Earlier we were assuming that all images will be base64 with image/jpeg mimeType
+                  parts.push({
+                    inlineData: {
+                      mimeType: 'image/jpeg',
+                      data: c.image_url?.url,
+                    },
+                  });
                 }
-
-                // This part is problematic because URLs are not supported in the current implementation.
-                // Two problems exist:
-                // 1. Only Google Cloud Storage URLs are supported.
-                // 2. MimeType is not supported in OpenAI API, but it is required in Google Vertex AI API.
-                // Google will return an error here if any other URL is provided.
-                parts.push({
-                  fileData: {
-                    mimeType: getMimeType(url),
-                    fileUri: url,
-                  },
-                });
               }
             });
           } else if (typeof message.content === 'string') {

--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -157,10 +157,11 @@ const fileExtensionMimeTypeMap = {
   flv: 'video/flv',
 };
 
-export const getMimeType = (url: string) => {
+export const getMimeType = (url: string): string | undefined => {
   const urlParts = url.split('.');
   const extension = urlParts[
     urlParts.length - 1
   ] as keyof typeof fileExtensionMimeTypeMap;
-  return fileExtensionMimeTypeMap[extension] || 'image/jpeg';
+  const mimeType = fileExtensionMimeTypeMap[extension];
+  return mimeType;
 };

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -188,7 +188,11 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
                       data: base64Image,
                     },
                   });
-                } else if (url.startsWith('gs://')) {
+                } else if (
+                  url.startsWith('gs://') ||
+                  url.startsWith('https://') ||
+                  url.startsWith('http://')
+                ) {
                   parts.push({
                     fileData: {
                       mimeType: getMimeType(url),


### PR DESCRIPTION
**Title:** 
- Four cases that this supports:
  - [X] Send image base64 in this format: `data:image/png;base64,UklGRkacAABXRUJQVlA4IDqc......`
  - [X] Send image base64: `UklGRkacAABXRUJQVlA4IDqc...`
  - [X] Send google cloud bucket url: `gs://cloud-samples-data/video/animals.mp4`
  - [X] Send public file url: `https://download.samplelib.com/mp3/sample-3s.mp3`

- To-do
  - [ ] support sending youtube videos?

**Related Issues:** (optional)
https://github.com/Portkey-AI/gateway/issues/639
