### PR TITLE
feat: add json mode support for vertex-ai

### DIFF
--- a/src/providers/google-vertex-ai/transformGenerationConfig.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.ts
@@ -26,6 +26,10 @@ export function transformGenerationConfig(params: Params) {
   if (params?.response_format?.type === 'json_object') {
     generationConfig['responseMimeType'] = 'application/json';
   }
+  if (params?.response_format?.type === 'json_schema') {
+    generationConfig['responseMimeType'] = 'application/json';
+    generationConfig['responseSchema'] = params?.response_format.json_schema;
+  }
 
   return generationConfig;
 }

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -291,7 +291,10 @@ export interface Params {
   top_k?: number;
   tools?: Tool[];
   tool_choice?: ToolChoice;
-  response_format?: { type: 'json_object' | 'text' };
+  response_format?: {
+    type: 'json_object' | 'text' | 'json_schema';
+    json_schema?: any;
+  };
   // Google Vertex AI specific
   safety_settings?: any;
 }


### PR DESCRIPTION
**Title:** 
- add json mode support for vertex-ai 

**Description:** (optional)
- Add mapping to convert OpenAI compatible `response_format` field to vertex compatible object

**Motivation:** (optional)
- To support json_schema mode in vertex

**Related Issues:** (optional)
- Closes #644 
