### PR TITLE
Feat: bedrock cross region model ids

### DIFF
--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -55,7 +55,13 @@ import {
 const BedrockConfig: ProviderConfigs = {
   api: BedrockAPIConfig,
   getConfig: (params: Params) => {
-    const providerModel = params.model;
+    if (!params.model) {
+      throw new GatewayError('Bedrock model not found');
+    }
+
+    // To remove the region in case its a cross-region inference profile ID
+    // https://docs.aws.amazon.com/bedrock/latest/userguide/cross-region-inference-support.html
+    const providerModel = params.model.replace(/^(us\.|eu\.)/, '');
     const provider = providerModel?.split('.')[0];
     switch (provider) {
       case ANTHROPIC:


### PR DESCRIPTION
Pre-requisite: #640 
**Title:** 
- bedrock cross region model ids

**Description:** (optional)
- Handle provider fetch logic in bedrock for cross-region model IDs

**Motivation:** (optional)
- To support new model IDs which are also used for recently launched LLama 3.2 models

**Related Issues:** (optional)
- Closes #643 
