### PR TITLE
feat: add controlled generations support for google chat

### DIFF
--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -38,6 +38,13 @@ const transformGenerationConfig = (params: Params) => {
   if (params['stop']) {
     generationConfig['stopSequences'] = params['stop'];
   }
+  if (params?.response_format?.type === 'json_object') {
+    generationConfig['responseMimeType'] = 'application/json';
+  }
+  if (params?.response_format?.type === 'json_schema') {
+    generationConfig['responseMimeType'] = 'application/json';
+    generationConfig['responseSchema'] = params?.response_format.json_schema;
+  }
   return generationConfig;
 };
 
@@ -299,6 +306,10 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
     transform: (params: Params) => transformGenerationConfig(params),
   },
   stop: {
+    param: 'generationConfig',
+    transform: (params: Params) => transformGenerationConfig(params),
+  },
+  response_format: {
     param: 'generationConfig',
     transform: (params: Params) => transformGenerationConfig(params),
   },


### PR DESCRIPTION
**Title:** 
- Add controlled generations support for google chat

**Description:** (optional)
- VertexAI support for controlled generations is already present in gateway. Added it for Google AI studio as well.

**Motivation:** (optional)
- To support structured outputs using google

**Related Issues:** (optional)
- Related to #644 
