### PR TITLE
fix: use token count instead of character count in vertex embeddings …

### DIFF
--- a/src/providers/google-vertex-ai/embed.ts
+++ b/src/providers/google-vertex-ai/embed.ts
@@ -84,7 +84,7 @@ export const GoogleEmbedResponseTransform: (
       model: '', // Todo: find a way to send the google embedding model name back
       usage: {
         prompt_tokens: tokenCount,
-        total_tokens: response.metadata.billableCharacterCount,
+        total_tokens: tokenCount,
       },
     };
   }


### PR DESCRIPTION
…response usage object

**Title:** 
- Brief Description of Changes

**Motivation:** (optional)
- To keep the response structure streamlined across all providers and to avoid confusion between token count and character count in response usage object

**Related Issues:** (optional)
- Closes #658 
