### PR TITLE
Feat: portley llm guardrails update

### DIFF
--- a/plugins/portkey/gibberish.ts
+++ b/plugins/portkey/gibberish.ts
@@ -10,7 +10,8 @@ import { PORTKEY_ENDPOINTS, fetchPortkey } from './globals';
 export const handler: PluginHandler = async (
   context: PluginContext,
   parameters: PluginParameters,
-  eventType: HookEventType
+  eventType: HookEventType,
+  options
 ) => {
   let error = null;
   let verdict = false;
@@ -22,6 +23,7 @@ export const handler: PluginHandler = async (
 
     // Check if the text is gibberish
     const response: any = await fetchPortkey(
+      options.env,
       PORTKEY_ENDPOINTS.GIBBERISH,
       parameters.credentials,
       { input: text }

--- a/plugins/portkey/language.ts
+++ b/plugins/portkey/language.ts
@@ -10,7 +10,8 @@ import { PORTKEY_ENDPOINTS, fetchPortkey } from './globals';
 export const handler: PluginHandler = async (
   context: PluginContext,
   parameters: PluginParameters,
-  eventType: HookEventType
+  eventType: HookEventType,
+  options
 ) => {
   let error = null;
   let verdict = false;
@@ -23,6 +24,7 @@ export const handler: PluginHandler = async (
 
     // Find the language of the text
     const result: any = await fetchPortkey(
+      options.env,
       PORTKEY_ENDPOINTS.LANGUAGE,
       parameters.credentials,
       { input: text }

--- a/plugins/portkey/moderateContent.ts
+++ b/plugins/portkey/moderateContent.ts
@@ -10,7 +10,8 @@ import { PORTKEY_ENDPOINTS, fetchPortkey } from './globals';
 export const handler: PluginHandler = async (
   context: PluginContext,
   parameters: PluginParameters,
-  eventType: HookEventType
+  eventType: HookEventType,
+  options
 ) => {
   let error = null;
   let verdict = false;
@@ -23,6 +24,7 @@ export const handler: PluginHandler = async (
 
     // Get data from the relevant tool
     const result: any = await fetchPortkey(
+      options.env,
       PORTKEY_ENDPOINTS.MODERATIONS,
       parameters.credentials,
       { input: text }

--- a/plugins/portkey/pii.ts
+++ b/plugins/portkey/pii.ts
@@ -7,8 +7,12 @@ import {
 import { getText } from '../utils';
 import { PORTKEY_ENDPOINTS, fetchPortkey } from './globals';
 
-async function detectPII(text: string, credentials: any) {
-  const result = await fetchPortkey(PORTKEY_ENDPOINTS.PII, credentials, {
+async function detectPII(
+  text: string,
+  credentials: any,
+  env: Record<string, any>
+) {
+  const result = await fetchPortkey(env, PORTKEY_ENDPOINTS.PII, credentials, {
     input: text,
   });
 
@@ -36,7 +40,8 @@ async function detectPII(text: string, credentials: any) {
 export const handler: PluginHandler = async (
   context: PluginContext,
   parameters: PluginParameters,
-  eventType: HookEventType
+  eventType: HookEventType,
+  options
 ) => {
   let error = null;
   let verdict = false;
@@ -49,7 +54,8 @@ export const handler: PluginHandler = async (
 
     let { detectedPIICategories, PIIData } = await detectPII(
       text,
-      parameters.credentials
+      parameters.credentials,
+      options.env
     );
 
     // Filter the detected categories based on the categories to check

--- a/plugins/types.ts
+++ b/plugins/types.ts
@@ -19,5 +19,8 @@ export type HookEventType = 'beforeRequestHook' | 'afterRequestHook';
 export type PluginHandler = (
   context: PluginContext,
   parameters: PluginParameters,
-  eventType: HookEventType
+  eventType: HookEventType,
+  options: {
+    env: Record<string, any>;
+  }
 ) => Promise<PluginHandlerResponse>;

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -1328,9 +1328,11 @@ export async function beforeRequestHookHandler(
 ): Promise<any> {
   try {
     const hooksManager = c.get('hooksManager');
-    const hooksResult = await hooksManager.executeHooks(hookSpanId, [
-      'syncBeforeRequestHook',
-    ]);
+    const hooksResult = await hooksManager.executeHooks(
+      hookSpanId,
+      ['syncBeforeRequestHook'],
+      { env: env(c) }
+    );
 
     if (hooksResult.shouldDeny) {
       return new Response(

--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -15,6 +15,7 @@ import {
   handleTextResponse,
 } from './streamHandler';
 import { HookSpan } from '../middlewares/hooks';
+import { env } from 'hono/adapter';
 
 /**
  * Handles various types of responses based on the specified parameters
@@ -162,9 +163,11 @@ export async function afterRequestHookHandler(
       hooksManager.getSpan(hookSpanId).resetHookResult('afterRequestHook');
     }
 
-    let { shouldDeny, results } = await hooksManager.executeHooks(hookSpanId, [
-      'syncAfterRequestHook',
-    ]);
+    let { shouldDeny, results } = await hooksManager.executeHooks(
+      hookSpanId,
+      ['syncAfterRequestHook'],
+      { env: env(c) }
+    );
 
     if (!responseJSON) {
       return response;

--- a/src/middlewares/hooks/index.ts
+++ b/src/middlewares/hooks/index.ts
@@ -8,6 +8,7 @@ import {
   HookOnFailObject,
   HookOnSuccessObject,
   HookResult,
+  HandlerOptions,
 } from './types';
 import { plugins } from '../../../plugins';
 import { Context } from 'hono';
@@ -213,7 +214,8 @@ export class HooksManager {
 
   public async executeHooks(
     spanId: string,
-    eventTypePresets: string[]
+    eventTypePresets: string[],
+    options: HandlerOptions
   ): Promise<{ results: HookResult[]; shouldDeny: boolean }> {
     const span = this.getSpan(spanId);
 
@@ -225,7 +227,9 @@ export class HooksManager {
 
     try {
       const results = await Promise.all(
-        hooksToExecute.map((hook) => this.executeEachHook(spanId, hook))
+        hooksToExecute.map((hook) =>
+          this.executeEachHook(spanId, hook, options)
+        )
       );
       const shouldDeny = results.some(
         (result, index) =>
@@ -247,7 +251,8 @@ export class HooksManager {
   private async executeFunction(
     context: HookSpanContext,
     check: Check,
-    eventType: EventType
+    eventType: EventType,
+    options: HandlerOptions
   ): Promise<GuardrailCheckResult> {
     const [source, fn] = check.id.split('.');
     const createdAt = new Date();
@@ -255,7 +260,8 @@ export class HooksManager {
       const result = await this.plugins[source][fn](
         context,
         check.parameters,
-        eventType
+        eventType,
+        options
       );
       return {
         ...result,
@@ -284,7 +290,8 @@ export class HooksManager {
 
   private async executeEachHook(
     spanId: string,
-    hook: HookObject
+    hook: HookObject,
+    options: HandlerOptions
   ): Promise<HookResult> {
     const span = this.getSpan(spanId);
     let hookResult: HookResult = { id: hook.id } as HookResult;
@@ -296,9 +303,16 @@ export class HooksManager {
 
     if (hook.type === 'guardrail' && hook.checks) {
       const checkResults = await Promise.all(
-        hook.checks.map((check: Check) =>
-          this.executeFunction(span.getContext(), check, hook.eventType)
-        )
+        hook.checks
+          .filter((check: Check) => check.is_enabled !== false)
+          .map((check: Check) =>
+            this.executeFunction(
+              span.getContext(),
+              check,
+              hook.eventType,
+              options
+            )
+          )
       );
 
       hookResult = {

--- a/src/middlewares/hooks/types.ts
+++ b/src/middlewares/hooks/types.ts
@@ -1,6 +1,7 @@
 export interface Check {
   id: string;
   parameters: object;
+  is_enabled?: boolean;
 }
 
 export interface HookOnFailObject {
@@ -86,3 +87,7 @@ export interface GuardrailResult {
 export type HookResult = GuardrailResult;
 
 export type EventType = 'beforeRequestHook' | 'afterRequestHook';
+
+export interface HandlerOptions {
+  env: Record<string, any>;
+}


### PR DESCRIPTION
**Title:** 
- Allow gateway deployments to use Portkey implemented LLM-based guardrails like pii, language detection, etc.

**Description:** (optional)
- Pass env object to handler functions so that it can be used to pick up variables.
- Add is_enabled flag on check level to allow disabling individual checks without removing it from the hooks object.

**Motivation:** (optional)
- Enable portkey llm guardrails

**Related Issues:** (optional)
- #issue-number
