### PR TITLE
Include usage object in stream response of chat completion response by default

### DIFF
--- a/src/providers/openai/chatComplete.ts
+++ b/src/providers/openai/chatComplete.ts
@@ -1,4 +1,5 @@
 import { ANTHROPIC, OPEN_AI } from '../../globals';
+import { Params } from '../../types/requestBody';
 import {
   ChatCompletionResponse,
   ErrorResponse,
@@ -89,6 +90,12 @@ export const OpenAIChatCompleteConfig: ProviderConfig = {
   },
   stream_options: {
     param: 'stream_options',
+    transform: (params: Params) => {
+      if (params.stream_options) return params.stream_options;
+      return {
+        include_usage: true,
+      };
+    },
   },
   service_tier: {
     param: 'service_tier',

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -286,6 +286,9 @@ export interface Params {
   top_p?: number;
   n?: number;
   stream?: boolean;
+  stream_options?: {
+    include_usage: boolean;
+  };
   logprobs?: number;
   echo?: boolean;
   stop?: string | string[];


### PR DESCRIPTION
**Title:** 
- include usage object in stream response of chat completion response by default

**Related Issues:** (optional)
- https://github.com/Portkey-AI/gateway/issues/691
