### PR TITLE
Forward params not in the provider config keys

### DIFF
--- a/src/services/transformToProviderRequest.ts
+++ b/src/services/transformToProviderRequest.ts
@@ -2,26 +2,7 @@ import { GatewayError } from '../errors/GatewayError';
 import { MULTIPART_FORM_DATA_ENDPOINTS } from '../globals';
 import ProviderConfigs from '../providers';
 import { endpointStrings, ProviderConfig } from '../providers/types';
-import { Options, Params, Targets } from '../types/requestBody';
-
-/**
- * Helper function to set a nested property in an object.
- *
- * @param obj - The object on which to set the property.
- * @param path - The dot-separated path to the property.
- * @param value - The value to set the property to.
- */
-function setNestedProperty(obj: any, path: string, value: any) {
-  const parts = path.split('.');
-  let current = obj;
-  for (let i = 0; i < parts.length - 1; i++) {
-    if (!current[parts[i]]) {
-      current[parts[i]] = {};
-    }
-    current = current[parts[i]];
-  }
-  current[parts[parts.length - 1]] = value;
-}
+import { Params } from '../types/requestBody';
 
 const getValue = (configParam: string, params: Params, paramConfig: any) => {
   let value = params[configParam as keyof typeof params];
@@ -104,7 +85,7 @@ const getProviderRequestJSON = (
         }
       } else {
         for (const transformer of transformers) {
-          const setDefault: boolean = params[param] === 'default';
+          const setDefault: boolean = params[param] === 'portkey-default';
           if (setDefault) {
             transformedRequest[transformer.param] = transformer.default;
           } else {

--- a/src/services/transformToProviderRequest.ts
+++ b/src/services/transformToProviderRequest.ts
@@ -108,12 +108,17 @@ const getProviderRequestJSON = (
     } else {
       transformedRequest[param] = params[param];
     }
-
-    // handle default values
-    for (const config of providerConfig) {
-      if (config.required && config.default !== undefined) {
-        transformedRequest[param] = config.default;
-      }
+  }
+  // handle default values
+  for (const configKey of Object.keys(providerConfig)) {
+    const configObject = providerConfig[configKey];
+    const isRequiredAndDefaultisKnown: boolean =
+      configObject &&
+      configObject.required &&
+      configObject.default !== undefined;
+    const isValueAlreadySet: boolean = transformedRequest[configKey] !== null;
+    if (isRequiredAndDefaultisKnown && !isValueAlreadySet) {
+      transformedRequest[configKey] = configObject.default;
     }
   }
   return transformedRequest;

--- a/src/services/transformToProviderRequest.ts
+++ b/src/services/transformToProviderRequest.ts
@@ -90,7 +90,6 @@ const getProviderRequestJSON = (
 ): { [key: string]: any } => {
   const transformedRequest: { [key: string]: any } = {};
   for (const param in params) {
-    transformedRequest[param] = null;
     const config = providerConfig[param];
     const isConfigPresent: boolean = config != null;
     if (isConfigPresent) {

--- a/src/services/transformToProviderRequest.ts
+++ b/src/services/transformToProviderRequest.ts
@@ -94,15 +94,20 @@ const getProviderRequestJSON = (
     const config = providerConfig[param];
     const isConfigPresent: boolean = config != null;
     if (isConfigPresent) {
-      const isTransformFunctionPresent: boolean = config.transform != null;
-      if (isTransformFunctionPresent) {
-        transformedRequest[param] = config.transform(params);
+      const isAtleastOneTransformerPresent: boolean = config.length
+        ? config.some((c: any) => c.transform != null)
+        : config.transform != null;
+      if (isAtleastOneTransformerPresent) {
+        const transformers = config.length ? [...config] : [config];
+        for (const transformer of transformers) {
+          transformedRequest[transformer.param] = transformer.transform(params);
+        }
       } else {
         const setDefault: boolean = params[param] === 'default';
         if (setDefault) {
-          transformedRequest[param] = config.default;
+          transformedRequest[config.param] = config.default;
         } else {
-          transformedRequest[param] = params[param];
+          transformedRequest[config.param] = params[param];
         }
       }
     } else {

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -320,6 +320,7 @@ export interface Params {
   // Anthropic specific
   anthropic_beta?: string;
   anthropic_version?: string;
+  [key: string]: any;
 }
 
 interface Examples {


### PR DESCRIPTION
…
**Title:** 
- transformToProviderConfig has been looping over the provider config and setting keys, Flipped it to loop over request params

**Motivation:** (optional)
- To forward any params not specified in the config without transformation

**Related Issues:** (optional)
- #issue-number

**Testing done**
- [X] Tested when transform object is a recursive array
- [X] Tested nested properties
- [X] Tested value as 'default' 
- [X] Tested when required and default is available
- [X] Tested remaining routes for sanity

**Note**
I've not added support for min and max
