### PR TITLE
Adding model and provider reference routes

### DIFF
--- a/src/data/models.json
+++ b/src/data/models.json
@@ -1,0 +1,15150 @@
+{
+    "object": "list",
+    "version": "1.0.0",
+    "data": [
+        {
+            "id": "meta-llama/llama-3.1-70b-instruct/fp-8",
+            "object": "model",
+            "provider": {
+                "id": "inference-net"
+            },
+            "name": "Llama 3.1 70B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.1-8b-instruct/fp-8",
+            "object": "model",
+            "provider": {
+                "id": "inference-net"
+            },
+            "name": "Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "jamba-1.5-large",
+            "object": "model",
+            "provider": {
+                "id": "ai21"
+            },
+            "name": "Jamba 1.5 Large"
+        },
+        {
+            "id": "jamba-1.5-mini",
+            "object": "model",
+            "provider": {
+                "id": "ai21"
+            },
+            "name": "Jamba 1.5 Mini"
+        },
+        {
+            "id": "jamba-instruct",
+            "object": "model",
+            "provider": {
+                "id": "ai21"
+            },
+            "name": "Jamba Instruct"
+        },
+        {
+            "id": "jurassic-light",
+            "object": "model",
+            "provider": {
+                "id": "ai21"
+            },
+            "name": "Jurassic Light"
+        },
+        {
+            "id": "jurassic-mid",
+            "object": "model",
+            "provider": {
+                "id": "ai21"
+            },
+            "name": "Jurassic Mid"
+        },
+        {
+            "id": "jurassic-ultra",
+            "object": "model",
+            "provider": {
+                "id": "ai21"
+            },
+            "name": "Jurassic Ultra"
+        },
+        {
+            "id": "claude-2.0",
+            "object": "model",
+            "provider": {
+                "id": "anthropic"
+            },
+            "name": "Claude 2.0"
+        },
+        {
+            "id": "claude-2.1",
+            "object": "model",
+            "provider": {
+                "id": "anthropic"
+            },
+            "name": "Claude 2.1"
+        },
+        {
+            "id": "claude-3-5-sonnet-latest",
+            "object": "model",
+            "provider": {
+                "id": "anthropic"
+            },
+            "name": "Claude 3.5 Sonnet"
+        },
+        {
+            "id": "claude-3-haiku-20240307",
+            "object": "model",
+            "provider": {
+                "id": "anthropic"
+            },
+            "name": "Claude 3 Haiku (March 7, 2024)"
+        },
+        {
+            "id": "claude-3-opus-20240229",
+            "object": "model",
+            "provider": {
+                "id": "anthropic"
+            },
+            "name": "Claude 3 Opus (February 29, 2024)"
+        },
+        {
+            "id": "claude-3-sonnet-20240229",
+            "object": "model",
+            "provider": {
+                "id": "anthropic"
+            },
+            "name": "Claude 3 Sonnet (February 29, 2024)"
+        },
+        {
+            "id": "claude-instant-1.2",
+            "object": "model",
+            "provider": {
+                "id": "anthropic"
+            },
+            "name": "Claude Instant 1.2"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3-8B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "anyscale"
+            },
+            "name": "Meta Llama 3 70B Instruct"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3-70B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "anyscale"
+            },
+            "name": "Meta Llama 3 8B Instruct"
+        },
+        {
+            "id": "mistralai/Mistral-7B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "anyscale"
+            },
+            "name": "Mistral 7B Instruct v0.1"
+        },
+        {
+            "id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "anyscale"
+            },
+            "name": "Mixtral 8x7B Instruct v0.1"
+        },
+        {
+            "id": "gpt-4o-realtime-preview",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "GPT-4 Realtime Preview"
+        },
+        {
+            "id": "openai-whisper-large-v3",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Whisper Large v3"
+        },
+        {
+            "id": "openai-whisper-large",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Whisper Large"
+        },
+        {
+            "id": "gpt-4",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "GPT-4"
+        },
+        {
+            "id": "gpt-35-turbo",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "GPT-3.5 Turbo"
+        },
+        {
+            "id": "o1-preview",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "O1 Preview"
+        },
+        {
+            "id": "o1-mini",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "O1 Mini"
+        },
+        {
+            "id": "gpt-4o-mini",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "GPT-4 0 Mini"
+        },
+        {
+            "id": "gpt-4o",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "GPT-4 0"
+        },
+        {
+            "id": "gpt-4-32k",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "GPT-4 32K"
+        },
+        {
+            "id": "gpt-35-turbo-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "GPT-3.5 Turbo Instruct"
+        },
+        {
+            "id": "gpt-35-turbo-16k",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "GPT-3.5 Turbo 16K"
+        },
+        {
+            "id": "dall-e-3",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DALL-E 3"
+        },
+        {
+            "id": "dall-e-2",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DALL-E 2"
+        },
+        {
+            "id": "whisper",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Whisper"
+        },
+        {
+            "id": "tts-hd",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "TTS-HD"
+        },
+        {
+            "id": "tts",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "TTS"
+        },
+        {
+            "id": "text-embedding-3-small",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Text Embedding 3 Small"
+        },
+        {
+            "id": "text-embedding-3-large",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Text Embedding 3 Large"
+        },
+        {
+            "id": "davinci-002",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Davinci 002"
+        },
+        {
+            "id": "text-embedding-ada-002",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Text Embedding Ada 002"
+        },
+        {
+            "id": "babbage-002",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Babbage 002"
+        },
+        {
+            "id": "Phi-3.5-mini-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3.5 Mini Instruct"
+        },
+        {
+            "id": "Phi-3.5-MoE-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3.5 MoE Instruct"
+        },
+        {
+            "id": "Phi-3-medium-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3 Medium 128K Instruct"
+        },
+        {
+            "id": "Phi-3-mini-4k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3 Mini 4K Instruct"
+        },
+        {
+            "id": "Phi-3-medium-4k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3 Medium 4K Instruct"
+        },
+        {
+            "id": "Phi-3-mini-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3 Mini 128K Instruct"
+        },
+        {
+            "id": "Phi-3-small-8k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3 Small 8K Instruct"
+        },
+        {
+            "id": "Phi-3-small-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3 Small 128K Instruct"
+        },
+        {
+            "id": "Phi-3.5-vision-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3.5 Vision Instruct"
+        },
+        {
+            "id": "Phi-3-vision-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Phi-3 Vision 128K Instruct"
+        },
+        {
+            "id": "Meta-Llama-3.1-8B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "Meta-Llama-3.1-8B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3.1 8B"
+        },
+        {
+            "id": "Meta-Llama-3.1-70B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3.1 70B Instruct"
+        },
+        {
+            "id": "Meta-Llama-3.1-70B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3.1 70B"
+        },
+        {
+            "id": "Meta-Llama-3-8B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3 8B Instruct"
+        },
+        {
+            "id": "Meta-Llama-3-8B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3 8B"
+        },
+        {
+            "id": "Meta-Llama-3-70B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3 70B Instruct"
+        },
+        {
+            "id": "Meta-Llama-3-70B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3 70B"
+        },
+        {
+            "id": "Llama-3.2-1B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 3.2 1B"
+        },
+        {
+            "id": "Llama-3.2-3B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 3.2 3B"
+        },
+        {
+            "id": "Llama-Guard-3-8B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama Guard 3 8B"
+        },
+        {
+            "id": "ai21.j2-mid-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "AI21 J2 Mid v1"
+        },
+        {
+            "id": "ai21.j2-ultra-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "AI21 J2 Ultra v1"
+        },
+        {
+            "id": "ai21.j2-ultra-v1:0:8k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "AI21 J2 Ultra v1 (8K context)"
+        },
+        {
+            "id": "ai21.jamba-1-5-large-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "AI21 Jamba 1.5 Large v1"
+        },
+        {
+            "id": "ai21.jamba-1-5-mini-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "AI21 Jamba 1.5 Mini v1"
+        },
+        {
+            "id": "ai21.jamba-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "AI21 Jamba Instruct v1"
+        },
+        {
+            "id": "amazon.titan-embed-image-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Embed Image v1"
+        },
+        {
+            "id": "amazon.titan-embed-image-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Embed Image v1"
+        },
+        {
+            "id": "amazon.titan-embed-text-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Embed Text v1"
+        },
+        {
+            "id": "amazon.titan-embed-text-v1:2:8k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Embed Text v1.2 (8K context)"
+        },
+        {
+            "id": "amazon.titan-embed-text-v2:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Embed Text v2"
+        },
+        {
+            "id": "amazon.titan-embed-text-v2:0:8k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Embed Text v2 (8K context)"
+        },
+        {
+            "id": "amazon.titan-image-generator-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Image Generator v1"
+        },
+        {
+            "id": "amazon.titan-image-generator-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Image Generator v1"
+        },
+        {
+            "id": "amazon.titan-image-generator-v2:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Image Generator v2"
+        },
+        {
+            "id": "amazon.titan-image-generator-v2:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Image Generator v2"
+        },
+        {
+            "id": "amazon.titan-text-express-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Text Express v1"
+        },
+        {
+            "id": "amazon.titan-text-express-v1:0:8k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Text Express v1 (8K context)"
+        },
+        {
+            "id": "amazon.titan-text-lite-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Text Lite v1"
+        },
+        {
+            "id": "amazon.titan-text-lite-v1:0:4k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Text Lite v1 (4K context)"
+        },
+        {
+            "id": "amazon.titan-text-premier-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Text Premier v1"
+        },
+        {
+            "id": "amazon.titan-text-premier-v1:0:32K",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Amazon Titan Text Premier v1 (32K context)"
+        },
+        {
+            "id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3.5 Sonnet (June 20, 2024)"
+        },
+        {
+            "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:18k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3.5 Sonnet (18K context)"
+        },
+        {
+            "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:200k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3.5 Sonnet (200K context)"
+        },
+        {
+            "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:51k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3.5 Sonnet (51K context)"
+        },
+        {
+            "id": "anthropic.claude-3-haiku-20240307-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3 Haiku (March 7, 2024)"
+        },
+        {
+            "id": "anthropic.claude-3-haiku-20240307-v1:0:200k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3 Haiku (200K context)"
+        },
+        {
+            "id": "anthropic.claude-3-haiku-20240307-v1:0:48k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3 Haiku (48K context)"
+        },
+        {
+            "id": "anthropic.claude-3-opus-20240229-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3 Opus (February 29, 2024)"
+        },
+        {
+            "id": "anthropic.claude-3-sonnet-20240229-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3 Sonnet (February 29, 2024)"
+        },
+        {
+            "id": "anthropic.claude-3-sonnet-20240229-v1:0:200k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3 Sonnet (200K context)"
+        },
+        {
+            "id": "anthropic.claude-3-sonnet-20240229-v1:0:28k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude 3 Sonnet (28K context)"
+        },
+        {
+            "id": "anthropic.claude-instant-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude Instant v1"
+        },
+        {
+            "id": "anthropic.claude-instant-v1:2:100k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude Instant v1.2 (100K context)"
+        },
+        {
+            "id": "anthropic.claude-v2",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude v2"
+        },
+        {
+            "id": "anthropic.claude-v2:0:100k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude v2 (100K context)"
+        },
+        {
+            "id": "anthropic.claude-v2:0:18k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude v2 (18K context)"
+        },
+        {
+            "id": "anthropic.claude-v2:1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude v2.1"
+        },
+        {
+            "id": "anthropic.claude-v2:1:18k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude v2.1 (18K context)"
+        },
+        {
+            "id": "anthropic.claude-v2:1:200k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Anthropic Claude v2.1 (200K context)"
+        },
+        {
+            "id": "cohere.command-light-text-v14",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Command Light Text v14"
+        },
+        {
+            "id": "cohere.command-light-text-v14:7:4k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Command Light Text v14.7 (4K context)"
+        },
+        {
+            "id": "cohere.command-r-plus-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Command R Plus v1"
+        },
+        {
+            "id": "cohere.command-r-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Command R v1"
+        },
+        {
+            "id": "cohere.command-text-v14",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Command Text v14"
+        },
+        {
+            "id": "cohere.command-text-v14:7:4k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Command Text v14.7 (4K context)"
+        },
+        {
+            "id": "cohere.embed-english-v3",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Embed English v3"
+        },
+        {
+            "id": "cohere.embed-english-v3:0:512",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Embed English v3 (512 context)"
+        },
+        {
+            "id": "cohere.embed-multilingual-v3",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Embed Multilingual v3"
+        },
+        {
+            "id": "cohere.embed-multilingual-v3:0:512",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Cohere Embed Multilingual v3 (512 context)"
+        },
+        {
+            "id": "meta.llama2-13b-chat-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 2 13B Chat v1"
+        },
+        {
+            "id": "meta.llama2-13b-chat-v1:0:4k",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 2 13B Chat v1 (4K context)"
+        },
+        {
+            "id": "meta.llama2-70b-chat-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 2 70B Chat v1"
+        },
+        {
+            "id": "meta.llama3-1-405b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3.1 405B Instruct v1"
+        },
+        {
+            "id": "meta.llama3-1-70b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3.1 70B Instruct v1"
+        },
+        {
+            "id": "meta.llama3-1-8b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3.1 8B Instruct v1"
+        },
+        {
+            "id": "meta.llama3-2-11b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3.2 11B Instruct v1"
+        },
+        {
+            "id": "meta.llama3-2-1b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3.2 1B Instruct v1"
+        },
+        {
+            "id": "meta.llama3-2-3b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3.2 3B Instruct v1"
+        },
+        {
+            "id": "meta.llama3-2-90b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3.2 90B Instruct v1"
+        },
+        {
+            "id": "meta.llama3-70b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3 70B Instruct v1"
+        },
+        {
+            "id": "meta.llama3-8b-instruct-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Meta LLaMA 3 8B Instruct v1"
+        },
+        {
+            "id": "mistral.mistral-7b-instruct-v0:2",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Mistral 7B Instruct v0.2"
+        },
+        {
+            "id": "mistral.mistral-large-2402-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Mistral Large (February 2024)"
+        },
+        {
+            "id": "mistral.mistral-large-2407-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Mistral Large (July 2024)"
+        },
+        {
+            "id": "mistral.mistral-small-2402-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Mistral Small (February 2024)"
+        },
+        {
+            "id": "mistral.mixtral-8x7b-instruct-v0:1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Mixtral 8x7B Instruct v0.1"
+        },
+        {
+            "id": "stability.sd3-large-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Stability AI SD3 Large v1"
+        },
+        {
+            "id": "stability.stable-diffusion-xl-v0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Stability AI Stable Diffusion XL v0"
+        },
+        {
+            "id": "stability.stable-diffusion-xl-v1",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Stability AI Stable Diffusion XL v1"
+        },
+        {
+            "id": "stability.stable-diffusion-xl-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Stability AI Stable Diffusion XL v1"
+        },
+        {
+            "id": "stability.stable-image-core-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Stability AI Stable Image Core v1"
+        },
+        {
+            "id": "stability.stable-image-ultra-v1:0",
+            "object": "model",
+            "provider": {
+                "id": "bedrock"
+            },
+            "name": "Stability AI Stable Image Ultra v1"
+        },
+        {
+            "id": "llama3.1-70b",
+            "object": "model",
+            "provider": {
+                "id": "cerebras"
+            },
+            "name": "70B"
+        },
+        {
+            "id": "llama3.1-8b",
+            "object": "model",
+            "provider": {
+                "id": "cerebras"
+            },
+            "name": "8B"
+        },
+        {
+            "id": "c4ai-aya-23-35b",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "C4AI Aya 23 35B"
+        },
+        {
+            "id": "c4ai-aya-23-8b",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "C4AI Aya 23 8B"
+        },
+        {
+            "id": "command",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command"
+        },
+        {
+            "id": "command-light",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command Light"
+        },
+        {
+            "id": "command-light-nightly",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command Light Nightly"
+        },
+        {
+            "id": "command-nightly",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command Nightly"
+        },
+        {
+            "id": "command-r",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command R"
+        },
+        {
+            "id": "command-r-03-2024",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command R"
+        },
+        {
+            "id": "command-r-08-2024",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command R (August 2024)"
+        },
+        {
+            "id": "command-r-plus",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command R Plus"
+        },
+        {
+            "id": "command-r-plus-08-2024",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Command R Plus (August 2024)"
+        },
+        {
+            "id": "embed-english-light-v2.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Embed English Light v2.0"
+        },
+        {
+            "id": "embed-english-light-v3.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Embed English Light v3.0"
+        },
+        {
+            "id": "embed-english-v2.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Embed English v2.0"
+        },
+        {
+            "id": "embed-english-v3.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Embed English v3.0"
+        },
+        {
+            "id": "embed-multilingual-light-v3.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Embed Multilingual Light v3.0"
+        },
+        {
+            "id": "embed-multilingual-v2.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Embed Multilingual v2.0"
+        },
+        {
+            "id": "embed-multilingual-v3.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Embed Multilingual v3.0"
+        },
+        {
+            "id": "rerank-english-v2.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Rerank English v2.0"
+        },
+        {
+            "id": "rerank-english-v3.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Rerank English v3.0"
+        },
+        {
+            "id": "rerank-multilingual-v2.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Rerank Multilingual v2.0"
+        },
+        {
+            "id": "rerank-multilingual-v3.0",
+            "object": "model",
+            "provider": {
+                "id": "cohere"
+            },
+            "name": "Cohere Rerank Multilingual v3.0"
+        },
+        {
+            "id": "Claude-3.5-Sonnet",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Claude 3.5 Sonnet"
+        },
+        {
+            "id": "dall-e-3",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Dall E 3"
+        },
+        {
+            "id": "GPT-3.5-turbo",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Gpt 3.5 Turbo"
+        },
+        {
+            "id": "GPT-3.5-turbo-instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Gpt 3.5 Turbo Instruct"
+        },
+        {
+            "id": "GPT-4-turbo",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Gpt 4 Turbo"
+        },
+        {
+            "id": "GPT-4o",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Gpt 4O"
+        },
+        {
+            "id": "GPT-4o-2024-08-06",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Gpt 4O 2024 08 06"
+        },
+        {
+            "id": "GPT-4o-mini",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Gpt 4O Mini"
+        },
+        {
+            "id": "LLama-3-70b",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Llama 3 70B"
+        },
+        {
+            "id": "LLama-3.1-405b",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Llama 3.1 405B"
+        },
+        {
+            "id": "LLama-3.1-70b",
+            "object": "model",
+            "provider": {
+                "id": "deepbricks"
+            },
+            "name": "Llama 3.1 70B"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Meta Llama 3.1 70B Instruct"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Meta Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3.1-405B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Meta Llama 3.1 405B Instruct"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Meta Llama 3.1 70B Instruct Turbo"
+        },
+        {
+            "id": "nvidia/Llama-3.1-Nemotron-70B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Llama 3.1 Nemotron 70B Instruct"
+        },
+        {
+            "id": "Qwen/Qwen2.5-72B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Qwen 2.5 72B Instruct"
+        },
+        {
+            "id": "meta-llama/Llama-3.2-90B-Vision-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Llama 3.2 90B Vision Instruct"
+        },
+        {
+            "id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Llama 3.2 11B Vision Instruct"
+        },
+        {
+            "id": "microsoft/WizardLM-2-8x22B",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "WizardLM 2 8x22B"
+        },
+        {
+            "id": "01-ai/Yi-34B-Chat",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Yi 34B Chat"
+        },
+        {
+            "id": "Austism/chronos-hermes-13b-v2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Chronos Hermes 13B v2"
+        },
+        {
+            "id": "deepseek-chat",
+            "object": "model",
+            "provider": {
+                "id": "deepseek"
+            },
+            "name": "Deepseek Chat"
+        },
+        {
+            "id": "deepseek-coder",
+            "object": "model",
+            "provider": {
+                "id": "deepseek"
+            },
+            "name": "Deepseek Coder"
+        },
+        {
+            "id": "accounts/fireworks/models/chronos-hermes-13b-v2",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Chronos Hermes 13B V2"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-13b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 13B"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-13b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 13B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-13b-python",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 13B Python"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-34b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 34B"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-34b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 34B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-34b-python",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 34B Python"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-70b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 70B"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 70B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-70b-python",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 70B Python"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 7B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/code-llama-7b-python",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Llama 7B Python"
+        },
+        {
+            "id": "accounts/fireworks/models/code-qwen-1p5-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Code Qwen 1P5 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/codegemma-2b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Codegemma 2B"
+        },
+        {
+            "id": "accounts/fireworks/models/codegemma-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Codegemma 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/dbrx-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Dbrx Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-coder-1b-base",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek Coder 1B Base"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-coder-33b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek Coder 33B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-coder-7b-base",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek Coder 7B Base"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-coder-7b-base-v1p5",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek Coder 7B Base V1P5"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek Coder 7B Instruct V1P5"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-coder-v2-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek Coder V2 Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-coder-v2-lite-base",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek Coder V2 Lite Base"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-coder-v2-lite-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek Coder V2 Lite Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/deepseek-v2p5",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Deepseek V2P5"
+        },
+        {
+            "id": "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Dolphin 2 9 2 Qwen2 72B"
+        },
+        {
+            "id": "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Dolphin 2P6 Mixtral 8X7B"
+        },
+        {
+            "id": "accounts/fireworks/models/elyza-japanese-llama-2-7b-fast-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Elyza Japanese Llama 2 7B Fast Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/firefunction-v1",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Firefunction V1"
+        },
+        {
+            "id": "accounts/fireworks/models/firefunction-v2",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Firefunction V2"
+        },
+        {
+            "id": "accounts/fireworks/models/firellava-13b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Firellava 13B"
+        },
+        {
+            "id": "accounts/fireworks/models/flux-1-dev-fp8",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Flux 1 Dev Fp8"
+        },
+        {
+            "id": "accounts/fireworks/models/flux-1-schnell-fp8",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Flux 1 Schnell Fp8"
+        },
+        {
+            "id": "accounts/fireworks/models/gemma-2b-it",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Gemma 2B It"
+        },
+        {
+            "id": "accounts/fireworks/models/gemma-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Gemma 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/gemma-7b-it",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Gemma 7B It"
+        },
+        {
+            "id": "accounts/fireworks/models/hermes-2-pro-mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Hermes 2 Pro Mistral 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/japanese-stable-diffusion-xl",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Japanese Stable Diffusion Xl"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-guard-2-8b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama Guard 2 8B"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v2-13b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V2 13B"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v2-13b-chat",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V2 13B Chat"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v2-70b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V2 70B"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v2-70b-chat",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V2 70B Chat"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v2-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V2 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v2-7b-chat",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V2 7B Chat"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3 70B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3-70b-instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3 70B Instruct Hf"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3-8b-hf",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3 8B Hf"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3 8B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3-8b-instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3 8B Instruct Hf"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3p1-405b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3P1 405B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3p1-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3P1 70B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3p1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3P1 8B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3p2-11b-vision-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3P2 11B Vision Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3p2-1b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3P2 1B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3p2-3b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3P2 3B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llama-v3p2-90b-vision-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llama V3P2 90B Vision Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/llamaguard-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llamaguard 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/llava-yi-34b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Llava Yi 34B"
+        },
+        {
+            "id": "accounts/fireworks/models/mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mistral 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/mistral-7b-instruct-4k",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mistral 7B Instruct 4K"
+        },
+        {
+            "id": "accounts/fireworks/models/mistral-7b-instruct-v0p2",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mistral 7B Instruct V0P2"
+        },
+        {
+            "id": "accounts/fireworks/models/mistral-7b-instruct-v3",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mistral 7B Instruct V3"
+        },
+        {
+            "id": "accounts/fireworks/models/mistral-7b-v0p2",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mistral 7B V0P2"
+        },
+        {
+            "id": "accounts/fireworks/models/mistral-nemo-base-2407",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mistral Nemo Base 2407"
+        },
+        {
+            "id": "accounts/fireworks/models/mistral-nemo-instruct-2407",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mistral Nemo Instruct 2407"
+        },
+        {
+            "id": "accounts/fireworks/models/mixtral-8x22b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mixtral 8X22B"
+        },
+        {
+            "id": "accounts/fireworks/models/mixtral-8x22b-hf",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mixtral 8X22B Hf"
+        },
+        {
+            "id": "accounts/fireworks/models/mixtral-8x22b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mixtral 8X22B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/mixtral-8x22b-instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mixtral 8X22B Instruct Hf"
+        },
+        {
+            "id": "accounts/fireworks/models/mixtral-8x7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mixtral 8X7B"
+        },
+        {
+            "id": "accounts/fireworks/models/mixtral-8x7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mixtral 8X7B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/mixtral-8x7b-instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mixtral 8X7B Instruct Hf"
+        },
+        {
+            "id": "accounts/fireworks/models/mythomax-l2-13b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Mythomax L2 13B"
+        },
+        {
+            "id": "accounts/fireworks/models/nous-capybara-7b-v1p9",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Nous Capybara 7B V1P9"
+        },
+        {
+            "id": "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Nous Hermes 2 Mixtral 8X7B Dpo"
+        },
+        {
+            "id": "accounts/fireworks/models/nous-hermes-2-yi-34b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Nous Hermes 2 Yi 34B"
+        },
+        {
+            "id": "accounts/fireworks/models/nous-hermes-llama2-13b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Nous Hermes Llama2 13B"
+        },
+        {
+            "id": "accounts/fireworks/models/nous-hermes-llama2-70b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Nous Hermes Llama2 70B"
+        },
+        {
+            "id": "accounts/fireworks/models/nous-hermes-llama2-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Nous Hermes Llama2 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/openchat-3p5-0106-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Openchat 3P5 0106 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/openhermes-2-mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Openhermes 2 Mistral 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/openhermes-2p5-mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Openhermes 2P5 Mistral 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/openorca-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Openorca 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/phi-2-3b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Phi 2 3B"
+        },
+        {
+            "id": "accounts/fireworks/models/phi-3-mini-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Phi 3 Mini 128K Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/phi-3-vision-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Phi 3 Vision 128K Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/phind-code-llama-34b-python-v1",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Phind Code Llama 34B Python V1"
+        },
+        {
+            "id": "accounts/fireworks/models/phind-code-llama-34b-v1",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Phind Code Llama 34B V1"
+        },
+        {
+            "id": "accounts/fireworks/models/phind-code-llama-34b-v2",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Phind Code Llama 34B V2"
+        },
+        {
+            "id": "accounts/fireworks/models/playground-v2-1024px-aesthetic",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Playground V2 1024Px Aesthetic"
+        },
+        {
+            "id": "accounts/fireworks/models/playground-v2-5-1024px-aesthetic",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Playground V2 5 1024Px Aesthetic"
+        },
+        {
+            "id": "accounts/fireworks/models/pythia-12b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Pythia 12B"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen-v2p5-14b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen V2P5 14B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen-v2p5-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen V2P5 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen1p5-72b-chat",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen1P5 72B Chat"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2 72B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2 7B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-14b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 14B"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-14b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 14B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-32b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 32B"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-32b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 32B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-72b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 72B"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 72B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 7B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-coder-1p5b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 Coder 1P5B"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-coder-1p5b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 Coder 1P5B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-coder-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 Coder 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-coder-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 Coder 7B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/qwen2p5-math-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Qwen2P5 Math 72B Instruct"
+        },
+        {
+            "id": "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Snorkel Mistral 7B Pairrm Dpo"
+        },
+        {
+            "id": "accounts/fireworks/models/SSD-1B",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Ssd 1B"
+        },
+        {
+            "id": "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Stable Diffusion Xl 1024 V1 0"
+        },
+        {
+            "id": "accounts/fireworks/models/stablecode-3b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Stablecode 3B"
+        },
+        {
+            "id": "accounts/fireworks/models/starcoder-16b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Starcoder 16B"
+        },
+        {
+            "id": "accounts/fireworks/models/starcoder-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Starcoder 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/starcoder2-15b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Starcoder2 15B"
+        },
+        {
+            "id": "accounts/fireworks/models/starcoder2-3b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Starcoder2 3B"
+        },
+        {
+            "id": "accounts/fireworks/models/starcoder2-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Starcoder2 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/toppy-m-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Toppy M 7B"
+        },
+        {
+            "id": "accounts/fireworks/models/yi-34b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Yi 34B"
+        },
+        {
+            "id": "accounts/fireworks/models/yi-34b-200k-capybara",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Yi 34B 200K Capybara"
+        },
+        {
+            "id": "accounts/fireworks/models/yi-34b-chat",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Yi 34B Chat"
+        },
+        {
+            "id": "accounts/fireworks/models/yi-6b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Yi 6B"
+        },
+        {
+            "id": "accounts/fireworks/models/zephyr-7b-beta",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Zephyr 7B Beta"
+        },
+        {
+            "id": "accounts/muhtasham-83b323/models/order-ds-lora",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Models/Order Ds Lora"
+        },
+        {
+            "id": "accounts/stability/models/japanese-stable-vlm-8b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Japanese Stable Vlm 8B"
+        },
+        {
+            "id": "accounts/stability/models/japanese-stablelm-instruct-beta-70b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Japanese Stablelm Instruct Beta 70B"
+        },
+        {
+            "id": "accounts/stability/models/japanese-stablelm-instruct-gamma-7b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Japanese Stablelm Instruct Gamma 7B"
+        },
+        {
+            "id": "accounts/stability/models/sd3",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Sd3"
+        },
+        {
+            "id": "accounts/stability/models/sd3-medium",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Sd3 Medium"
+        },
+        {
+            "id": "accounts/stability/models/sd3-turbo",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Sd3 Turbo"
+        },
+        {
+            "id": "accounts/stability/models/stablecode-3b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Stablecode 3B"
+        },
+        {
+            "id": "accounts/stability/models/stablelm-2-zephyr-2b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Stablelm 2 Zephyr 2B"
+        },
+        {
+            "id": "accounts/stability/models/stablelm-zephyr-3b",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "Stablelm Zephyr 3B"
+        },
+        {
+            "id": "accounts/yi-01-ai/models/yi-large",
+            "object": "model",
+            "provider": {
+                "id": "fireworks-ai"
+            },
+            "name": "I Large"
+        },
+        {
+            "id": "gemini-1.0-pro",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Gemini 1.0 Pro"
+        },
+        {
+            "id": "gemini-1.5-flash",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Gemini 1.5 Flash"
+        },
+        {
+            "id": "gemini-1.5-flash-8b-exp-0827",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Gemini 1.5 Flash 8B (Exp 0827)"
+        },
+        {
+            "id": "gemini-1.5-flash-exp-0827",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Gemini 1.5 Flash (Exp 0827)"
+        },
+        {
+            "id": "gemini-1.5-pro",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Gemini 1.5 Pro"
+        },
+        {
+            "id": "gemini-1.5-pro-exp-0801",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Gemini 1.5 Pro (Exp 0801)"
+        },
+        {
+            "id": "gemini-1.5-pro-exp-0827",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Gemini 1.5 Pro (Exp 0827)"
+        },
+        {
+            "id": "text-embedding-004",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Text Embedding 004"
+        },
+        {
+            "id": "aqa",
+            "object": "model",
+            "provider": {
+                "id": "google"
+            },
+            "name": "Attributed Question-Answering"
+        },
+        {
+            "id": "distil-whisper-large-v3-en",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Distil Whisper Large v3 English"
+        },
+        {
+            "id": "gemma2-9b-it",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Gemma 2 9B Italian"
+        },
+        {
+            "id": "gemma-7b-it",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Gemma 7B Italian"
+        },
+        {
+            "id": "llama3-groq-70b-8192-tool-use-preview",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3 Groq 70B 8192 Tool Use Preview"
+        },
+        {
+            "id": "llama3-groq-8b-8192-tool-use-preview",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3 Groq 8B 8192 Tool Use Preview"
+        },
+        {
+            "id": "llama-3.1-70b-versatile",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3.1 70B Versatile"
+        },
+        {
+            "id": "llama-3.1-8b-instant",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3.1 8B Instant"
+        },
+        {
+            "id": "llama-3.2-1b-preview",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3.2 1B Preview"
+        },
+        {
+            "id": "llama-3.2-3b-preview",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3.2 3B Preview"
+        },
+        {
+            "id": "llama-3.2-11b-vision-preview",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3.2 11B Vision Preview"
+        },
+        {
+            "id": "llama-3.2-90b-vision-preview",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3.2 90B Vision Preview"
+        },
+        {
+            "id": "llama-guard-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama Guard 3 8B"
+        },
+        {
+            "id": "yi-large",
+            "object": "model",
+            "provider": {
+                "id": "lingyi"
+            },
+            "name": "Yi Large"
+        },
+        {
+            "id": "yi-large-fc",
+            "object": "model",
+            "provider": {
+                "id": "lingyi"
+            },
+            "name": "Yi Large FC"
+        },
+        {
+            "id": "yi-large-turbo",
+            "object": "model",
+            "provider": {
+                "id": "lingyi"
+            },
+            "name": "Yi Large Turbo"
+        },
+        {
+            "id": "acolyte-22b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Acolyte 22B I1"
+        },
+        {
+            "id": "all-MiniLM-L6-v2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "All Minilm L6 V2"
+        },
+        {
+            "id": "anjir-8b-l3-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Anjir 8B L3 I1"
+        },
+        {
+            "id": "apollo2-9b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Apollo2 9B"
+        },
+        {
+            "id": "arcee-agent",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Arcee Agent"
+        },
+        {
+            "id": "arcee-spark",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Arcee Spark"
+        },
+        {
+            "id": "arch-function-1.5b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Arch Function 1.5B"
+        },
+        {
+            "id": "arch-function-3b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Arch Function 3B"
+        },
+        {
+            "id": "arch-function-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Arch Function 7B"
+        },
+        {
+            "id": "archangel_sft_pythia2-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Archangel_Sft_Pythia2 8B"
+        },
+        {
+            "id": "arliai-llama-3-8b-dolfin-v0.5",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Arliai Llama 3 8B Dolfin V0.5"
+        },
+        {
+            "id": "arliai-llama-3-8b-formax-v1.0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Arliai Llama 3 8B Formax V1.0"
+        },
+        {
+            "id": "astral-fusion-neural-happy-l3.1-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Astral Fusion Neural Happy L3.1 8B"
+        },
+        {
+            "id": "athena-codegemma-2-2b-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Athena Codegemma 2 2B It"
+        },
+        {
+            "id": "aura-llama-abliterated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Aura Llama Abliterated"
+        },
+        {
+            "id": "aura-uncensored-l3-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Aura Uncensored L3 8B Iq Imatrix"
+        },
+        {
+            "id": "aurora_l3_8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Aurora_L3_8B Iq Imatrix"
+        },
+        {
+            "id": "average_normie_l3_v1_8b-gguf-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Average_Normie_L3_V1_8B Gguf Iq Imatrix"
+        },
+        {
+            "id": "aya-23-35b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Aya 23 35B"
+        },
+        {
+            "id": "aya-23-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Aya 23 8B"
+        },
+        {
+            "id": "azure_dusk-v0.2-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Azure_Dusk V0.2 Iq Imatrix"
+        },
+        {
+            "id": "badger-lambda-llama-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Badger Lambda Llama 3 8B"
+        },
+        {
+            "id": "baldur-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Baldur 8B"
+        },
+        {
+            "id": "bert-embeddings",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Bert Embeddings"
+        },
+        {
+            "id": "big-tiger-gemma-27b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Big Tiger Gemma 27B V1"
+        },
+        {
+            "id": "bigqwen2.5-52b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Bigqwen2.5 52B Instruct"
+        },
+        {
+            "id": "biomistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Biomistral 7B"
+        },
+        {
+            "id": "buddy-2b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Buddy 2B V1"
+        },
+        {
+            "id": "bungo-l3-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Bungo L3 8B Iq Imatrix"
+        },
+        {
+            "id": "bunny-llama-3-8b-v",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Bunny Llama 3 8B V"
+        },
+        {
+            "id": "calme-2.1-phi3.5-4b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Calme 2.1 Phi3.5 4B I1"
+        },
+        {
+            "id": "calme-2.2-qwen2-72b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Calme 2.2 Qwen2 72B"
+        },
+        {
+            "id": "calme-2.2-qwen2.5-72b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Calme 2.2 Qwen2.5 72B I1"
+        },
+        {
+            "id": "calme-2.3-legalkit-8b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Calme 2.3 Legalkit 8B I1"
+        },
+        {
+            "id": "calme-2.3-phi3-4b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Calme 2.3 Phi3 4B"
+        },
+        {
+            "id": "calme-2.4-llama3-70b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Calme 2.4 Llama3 70B"
+        },
+        {
+            "id": "calme-2.8-qwen2-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Calme 2.8 Qwen2 7B"
+        },
+        {
+            "id": "cathallama-70b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Cathallama 70B"
+        },
+        {
+            "id": "chaos-rp_l3_b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Chaos Rp_L3_B Iq Imatrix"
+        },
+        {
+            "id": "codellama-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Codellama 7B"
+        },
+        {
+            "id": "codestral-22b-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Codestral 22B V0.1"
+        },
+        {
+            "id": "command-r-v01:q1_s",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Command R V01:Q1_S"
+        },
+        {
+            "id": "cream-phi-3-14b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Cream Phi 3 14B V1"
+        },
+        {
+            "id": "cursorcore-ds-6.7b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Cursorcore Ds 6.7B I1"
+        },
+        {
+            "id": "cursorcore-qw2.5-1.5b-lc-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Cursorcore Qw2.5 1.5B Lc I1"
+        },
+        {
+            "id": "cursorcore-qw2.5-7b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Cursorcore Qw2.5 7B I1"
+        },
+        {
+            "id": "cursorcore-yi-9b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Cursorcore Yi 9B"
+        },
+        {
+            "id": "dans-personalityengine-v1.0.0-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Dans Personalityengine V1.0.0 8B"
+        },
+        {
+            "id": "darkens-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Darkens 8B"
+        },
+        {
+            "id": "darkidol-llama-3.1-8b-instruct-1.0-uncensored-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Darkidol Llama 3.1 8B Instruct 1.0 Uncensored I1"
+        },
+        {
+            "id": "darkidol-llama-3.1-8b-instruct-1.1-uncensored-iq-imatrix-request",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Darkidol Llama 3.1 8B Instruct 1.1 Uncensored Iq Imatrix Request"
+        },
+        {
+            "id": "datagemma-rag-27b-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Datagemma Rag 27B It"
+        },
+        {
+            "id": "datagemma-rig-27b-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Datagemma Rig 27B It"
+        },
+        {
+            "id": "deepseek-coder-v2-lite-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Deepseek Coder V2 Lite Instruct"
+        },
+        {
+            "id": "doctoraifinetune-3.1-8b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Doctoraifinetune 3.1 8B I1"
+        },
+        {
+            "id": "dolphin-2.9-llama3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Dolphin 2.9 Llama3 8B"
+        },
+        {
+            "id": "dolphin-2.9-llama3-8b:Q6_K",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Dolphin 2.9 Llama3 8B:Q6_K"
+        },
+        {
+            "id": "dolphin-2.9.2-phi-3-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Dolphin 2.9.2 Phi 3 Medium"
+        },
+        {
+            "id": "dolphin-2.9.2-phi-3-Medium-abliterated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Dolphin 2.9.2 Phi 3 Medium Abliterated"
+        },
+        {
+            "id": "dolphin-2.9.2-qwen2-72b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Dolphin 2.9.2 Qwen2 72B"
+        },
+        {
+            "id": "dolphin-2.9.2-qwen2-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Dolphin 2.9.2 Qwen2 7B"
+        },
+        {
+            "id": "dreamshaper",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Dreamshaper"
+        },
+        {
+            "id": "duloxetine-4b-v1-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Duloxetine 4B V1 Iq Imatrix"
+        },
+        {
+            "id": "edgerunner-command-nested-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Edgerunner Command Nested I1"
+        },
+        {
+            "id": "edgerunner-tactical-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Edgerunner Tactical 7B"
+        },
+        {
+            "id": "einstein-v4-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Einstein V4 7B"
+        },
+        {
+            "id": "einstein-v6.1-llama3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Einstein V6.1 Llama3 8B"
+        },
+        {
+            "id": "einstein-v7-qwen2-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Einstein V7 Qwen2 7B"
+        },
+        {
+            "id": "emo-2b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Emo 2B"
+        },
+        {
+            "id": "eva-qwen2.5-14b-v0.1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Eva Qwen2.5 14B V0.1 I1"
+        },
+        {
+            "id": "ezo-common-9b-gemma-2-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Ezo Common 9B Gemma 2 It"
+        },
+        {
+            "id": "fimbulvetr-11b-v2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Fimbulvetr 11B V2"
+        },
+        {
+            "id": "fimbulvetr-11b-v2-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Fimbulvetr 11B V2 Iq Imatrix"
+        },
+        {
+            "id": "fireball-llama-3.11-8b-v1orpo",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Fireball Llama 3.11 8B V1Orpo"
+        },
+        {
+            "id": "fireball-meta-llama-3.2-8b-instruct-agent-003-128k-code-dpo",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Fireball Meta Llama 3.2 8B Instruct Agent 003 128K Code Dpo"
+        },
+        {
+            "id": "firefly-gemma-7b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Firefly Gemma 7B Iq Imatrix"
+        },
+        {
+            "id": "flux.1-dev",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Flux.1 Dev"
+        },
+        {
+            "id": "flux.1-schnell",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Flux.1 Schnell"
+        },
+        {
+            "id": "gemma-1.1-7b-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 1.1 7B It"
+        },
+        {
+            "id": "gemma-2-27b-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2 27B It"
+        },
+        {
+            "id": "gemma-2-2b-arliai-rpmax-v1.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2 2B Arliai Rpmax V1.1"
+        },
+        {
+            "id": "gemma-2-9b-arliai-rpmax-v1.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2 9B Arliai Rpmax V1.1"
+        },
+        {
+            "id": "gemma-2-9b-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2 9B It"
+        },
+        {
+            "id": "gemma-2-9b-it-abliterated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2 9B It Abliterated"
+        },
+        {
+            "id": "gemma-2-9b-it-sppo-iter3",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2 9B It Sppo Iter3"
+        },
+        {
+            "id": "gemma-2-ataraxy-v3i-9b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2 Ataraxy V3I 9B"
+        },
+        {
+            "id": "gemma-2b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2B"
+        },
+        {
+            "id": "gemma-2b-translation-v0.150",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma 2B Translation V0.150"
+        },
+        {
+            "id": "gemma2-9b-daybreak-v0.5",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemma2 9B Daybreak V0.5"
+        },
+        {
+            "id": "gemmasutra-mini-2b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemmasutra Mini 2B V1"
+        },
+        {
+            "id": "gemmasutra-pro-27b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemmasutra Pro 27B V1"
+        },
+        {
+            "id": "gemmoy-9b-g2-mk.3-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Gemmoy 9B G2 Mk.3 I1"
+        },
+        {
+            "id": "genius-llama3.1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Genius Llama3.1 I1"
+        },
+        {
+            "id": "guillaumetell-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Guillaumetell 7B"
+        },
+        {
+            "id": "halomaidrp-v1.33-15b-l3-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Halomaidrp V1.33 15B L3 I1"
+        },
+        {
+            "id": "halu-8b-llama3-blackroot-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Halu 8B Llama3 Blackroot Iq Imatrix"
+        },
+        {
+            "id": "hathor_respawn-l3-8b-v0.8",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hathor_Respawn L3 8B V0.8"
+        },
+        {
+            "id": "hathor_stable-v0.2-l3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hathor_Stable V0.2 L3 8B"
+        },
+        {
+            "id": "hathor_tahsin-l3-8b-v0.85",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hathor_Tahsin L3 8B V0.85"
+        },
+        {
+            "id": "hathor-l3-8b-v.01-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hathor L3 8B V.01 Iq Imatrix"
+        },
+        {
+            "id": "helpingai-9b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Helpingai 9B"
+        },
+        {
+            "id": "hercules-5.0-qwen2-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hercules 5.0 Qwen2 7B"
+        },
+        {
+            "id": "hermes-2-pro-llama-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 2 Pro Llama 3 8B"
+        },
+        {
+            "id": "hermes-2-pro-llama-3-8b:Q5_K_M",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 2 Pro Llama 3 8B:Q5_K_M"
+        },
+        {
+            "id": "hermes-2-pro-llama-3-8b:Q8_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 2 Pro Llama 3 8B:Q8_0"
+        },
+        {
+            "id": "hermes-2-pro-mistral",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 2 Pro Mistral"
+        },
+        {
+            "id": "hermes-2-pro-mistral:Q6_K",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 2 Pro Mistral:Q6_K"
+        },
+        {
+            "id": "hermes-2-pro-mistral:Q8_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 2 Pro Mistral:Q8_0"
+        },
+        {
+            "id": "hermes-2-theta-llama-3-70b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 2 Theta Llama 3 70B"
+        },
+        {
+            "id": "hermes-2-theta-llama-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 2 Theta Llama 3 8B"
+        },
+        {
+            "id": "hermes-3-llama-3.1-405b:vllm",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 405B:Vllm"
+        },
+        {
+            "id": "hermes-3-llama-3.1-70b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 70B"
+        },
+        {
+            "id": "hermes-3-llama-3.1-70b-lorablated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 70B Lorablated"
+        },
+        {
+            "id": "hermes-3-llama-3.1-70b:Q5_K_M",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 70B:Q5_K_M"
+        },
+        {
+            "id": "hermes-3-llama-3.1-70b:vllm",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 70B:Vllm"
+        },
+        {
+            "id": "hermes-3-llama-3.1-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 8B"
+        },
+        {
+            "id": "hermes-3-llama-3.1-8b-lorablated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 8B Lorablated"
+        },
+        {
+            "id": "hermes-3-llama-3.1-8b:Q8",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 8B:Q8"
+        },
+        {
+            "id": "hermes-3-llama-3.1-8b:vllm",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hermes 3 Llama 3.1 8B:Vllm"
+        },
+        {
+            "id": "hodachi-ezo-humanities-9b-gemma-2-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hodachi Ezo Humanities 9B Gemma 2 It"
+        },
+        {
+            "id": "hubble-4b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Hubble 4B V1"
+        },
+        {
+            "id": "humanish-roleplay-llama-3.1-8b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Humanish Roleplay Llama 3.1 8B I1"
+        },
+        {
+            "id": "infinity-instruct-7m-gen-llama3_1-70b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Infinity Instruct 7M Gen Llama3_1 70B"
+        },
+        {
+            "id": "internlm2_5-7b-chat-1m",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Internlm2_5 7B Chat 1M"
+        },
+        {
+            "id": "jsl-medllama-3-8b-v2.0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Jsl Medllama 3 8B V2.0"
+        },
+        {
+            "id": "kumiho-v1-rp-uwu-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Kumiho V1 Rp Uwu 8B"
+        },
+        {
+            "id": "kunocchini-7b-128k-test-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Kunocchini 7B 128K Test Imatrix"
+        },
+        {
+            "id": "l3-15b-etherealmaid-t0.0001-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 15B Etherealmaid T0.0001 I1"
+        },
+        {
+            "id": "l3-15b-mythicalmaid-t0.0001",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 15B Mythicalmaid T0.0001"
+        },
+        {
+            "id": "l3-8b-celeste-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Celeste V1"
+        },
+        {
+            "id": "l3-8b-celeste-v1.2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Celeste V1.2"
+        },
+        {
+            "id": "l3-8b-everything-cot",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Everything Cot"
+        },
+        {
+            "id": "l3-8b-lunaris-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Lunaris V1"
+        },
+        {
+            "id": "l3-8b-niitama-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Niitama V1"
+        },
+        {
+            "id": "l3-8b-niitama-v1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Niitama V1 I1"
+        },
+        {
+            "id": "l3-8b-stheno-horny-v3.3-32k-q5_k_m",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Stheno Horny V3.3 32K Q5_K_M"
+        },
+        {
+            "id": "l3-8b-stheno-v3.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Stheno V3.1"
+        },
+        {
+            "id": "l3-8b-stheno-v3.2-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 8B Stheno V3.2 Iq Imatrix"
+        },
+        {
+            "id": "l3-aethora-15b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 Aethora 15B"
+        },
+        {
+            "id": "l3-aethora-15b-v2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 Aethora 15B V2"
+        },
+        {
+            "id": "l3-chaoticsoliloquy-v1.5-4x8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 Chaoticsoliloquy V1.5 4X8B"
+        },
+        {
+            "id": "l3-ms-astoria-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 Ms Astoria 8B"
+        },
+        {
+            "id": "l3-solana-8b-v1-gguf",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 Solana 8B V1 Gguf"
+        },
+        {
+            "id": "l3-stheno-maid-blackroot-grand-horror-16b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 Stheno Maid Blackroot Grand Horror 16B"
+        },
+        {
+            "id": "l3-umbral-mind-rp-v1.0-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 Umbral Mind Rp V1.0 8B Iq Imatrix"
+        },
+        {
+            "id": "l3-uncen-merger-omelette-rp-v0.2-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3 Uncen Merger Omelette Rp V0.2 8B"
+        },
+        {
+            "id": "l3.1-70b-glitz-v0.2-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3.1 70B Glitz V0.2 I1"
+        },
+        {
+            "id": "l3.1-8b-celeste-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3.1 8B Celeste V1.5"
+        },
+        {
+            "id": "l3.1-8b-llamoutcast-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3.1 8B Llamoutcast I1"
+        },
+        {
+            "id": "l3.1-8b-niitama-v1.1-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3.1 8B Niitama V1.1 Iq Imatrix"
+        },
+        {
+            "id": "l3.1-etherealrainbow-v1.0-rc1-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "L3.1 Etherealrainbow V1.0 Rc1 8B"
+        },
+        {
+            "id": "leetcodewizard_7b_v1.1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Leetcodewizard_7B_V1.1 I1"
+        },
+        {
+            "id": "lexi-llama-3-8b-uncensored",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Lexi Llama 3 8B Uncensored"
+        },
+        {
+            "id": "llama-3_8b_unaligned_alpha",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3_8B_Unaligned_Alpha"
+        },
+        {
+            "id": "llama-3_8b_unaligned_alpha_rp_soup-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3_8B_Unaligned_Alpha_Rp_Soup I1"
+        },
+        {
+            "id": "llama-3_8b_unaligned_beta",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3_8B_Unaligned_Beta"
+        },
+        {
+            "id": "llama-3-11.5b-v2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 11.5B V2"
+        },
+        {
+            "id": "llama-3-13b-instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 13B Instruct V0.1"
+        },
+        {
+            "id": "llama-3-8b-instruct-abliterated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 8B Instruct Abliterated"
+        },
+        {
+            "id": "llama-3-8b-instruct-coder",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 8B Instruct Coder"
+        },
+        {
+            "id": "llama-3-8b-instruct-dpo-v0.3-32k",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 8B Instruct Dpo V0.3 32K"
+        },
+        {
+            "id": "llama-3-8b-instruct-mopeymule",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 8B Instruct Mopeymule"
+        },
+        {
+            "id": "llama-3-8b-lexifun-uncensored-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 8B Lexifun Uncensored V1"
+        },
+        {
+            "id": "llama-3-8b-openhermes-dpo",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 8B Openhermes Dpo"
+        },
+        {
+            "id": "llama-3-alpha-centauri-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Alpha Centauri V0.1"
+        },
+        {
+            "id": "llama-3-cursedstock-v1.8-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Cursedstock V1.8 8B Iq Imatrix"
+        },
+        {
+            "id": "llama-3-ezo-8b-common-it",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Ezo 8B Common It"
+        },
+        {
+            "id": "llama-3-hercules-5.0-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Hercules 5.0 8B"
+        },
+        {
+            "id": "llama-3-instruct-8b-SimPO-ExPO",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Instruct 8B Simpo Expo"
+        },
+        {
+            "id": "llama-3-lewdplay-8b-evo",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Lewdplay 8B Evo"
+        },
+        {
+            "id": "llama-3-llamilitary",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Llamilitary"
+        },
+        {
+            "id": "llama-3-lumimaid-8b-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Lumimaid 8B V0.1"
+        },
+        {
+            "id": "llama-3-lumimaid-8b-v0.1-oas-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Lumimaid 8B V0.1 Oas Iq Imatrix"
+        },
+        {
+            "id": "llama-3-lumimaid-v2-8b-v0.1-oas-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Lumimaid V2 8B V0.1 Oas Iq Imatrix"
+        },
+        {
+            "id": "llama-3-patronus-lynx-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Patronus Lynx 70B Instruct"
+        },
+        {
+            "id": "llama-3-perky-pat-instruct-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Perky Pat Instruct 8B"
+        },
+        {
+            "id": "llama-3-refueled",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Refueled"
+        },
+        {
+            "id": "llama-3-sauerkrautlm-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Sauerkrautlm 8B Instruct"
+        },
+        {
+            "id": "llama-3-sec-chat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Sec Chat"
+        },
+        {
+            "id": "llama-3-smaug-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Smaug 8B"
+        },
+        {
+            "id": "llama-3-soliloquy-8b-v2-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Soliloquy 8B V2 Iq Imatrix"
+        },
+        {
+            "id": "llama-3-sqlcoder-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Sqlcoder 8B"
+        },
+        {
+            "id": "llama-3-stheno-mahou-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Stheno Mahou 8B"
+        },
+        {
+            "id": "llama-3-tulu-2-8b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Tulu 2 8B I1"
+        },
+        {
+            "id": "llama-3-tulu-2-dpo-70b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Tulu 2 Dpo 70B I1"
+        },
+        {
+            "id": "llama-3-ultron",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Ultron"
+        },
+        {
+            "id": "llama-3-unholy-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Unholy 8B"
+        },
+        {
+            "id": "llama-3-unholy-8b:Q8_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Unholy 8B:Q8_0"
+        },
+        {
+            "id": "Llama-3-Yggdrasil-2.0-8B",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3 Yggdrasil 2.0 8B"
+        },
+        {
+            "id": "llama-3.1-70b-japanese-instruct-2407",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 70B Japanese Instruct 2407"
+        },
+        {
+            "id": "llama-3.1-8b-arliai-formax-v1.0-iq-arm-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 8B Arliai Formax V1.0 Iq Arm Imatrix"
+        },
+        {
+            "id": "llama-3.1-8b-arliai-rpmax-v1.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 8B Arliai Rpmax V1.1"
+        },
+        {
+            "id": "llama-3.1-8b-instruct-fei-v1-uncensored",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 8B Instruct Fei V1 Uncensored"
+        },
+        {
+            "id": "llama-3.1-8b-stheno-v3.4-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 8B Stheno V3.4 Iq Imatrix"
+        },
+        {
+            "id": "llama-3.1-nemotron-70b-instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 Nemotron 70B Instruct Hf"
+        },
+        {
+            "id": "llama-3.1-storm-8b-q4_k_m",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 Storm 8B Q4_K_M"
+        },
+        {
+            "id": "llama-3.1-supernova-lite",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 Supernova Lite"
+        },
+        {
+            "id": "llama-3.1-supernova-lite-reflection-v1.0-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 Supernova Lite Reflection V1.0 I1"
+        },
+        {
+            "id": "llama-3.1-swallow-70b-v0.1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 Swallow 70B V0.1 I1"
+        },
+        {
+            "id": "llama-3.1-techne-rp-8b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.1 Techne Rp 8B V1"
+        },
+        {
+            "id": "llama-3.2-1b-instruct:q4_k_m",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.2 1B Instruct:Q4_K_M"
+        },
+        {
+            "id": "llama-3.2-1b-instruct:q8_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.2 1B Instruct:Q8_0"
+        },
+        {
+            "id": "llama-3.2-3b-agent007",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.2 3B Agent007"
+        },
+        {
+            "id": "llama-3.2-3b-agent007-coder",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.2 3B Agent007 Coder"
+        },
+        {
+            "id": "llama-3.2-3b-instruct:q4_k_m",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.2 3B Instruct:Q4_K_M"
+        },
+        {
+            "id": "llama-3.2-3b-instruct:q8_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.2 3B Instruct:Q8_0"
+        },
+        {
+            "id": "llama-3.2-3b-reasoning-time",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.2 3B Reasoning Time"
+        },
+        {
+            "id": "llama-3.2-chibi-3b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama 3.2 Chibi 3B"
+        },
+        {
+            "id": "llama-guard-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama Guard 3 8B"
+        },
+        {
+            "id": "llama-salad-8x8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama Salad 8X8B"
+        },
+        {
+            "id": "llama-spark",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama Spark"
+        },
+        {
+            "id": "llama3-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 70B Instruct"
+        },
+        {
+            "id": "llama3-70b-instruct:IQ1_M",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 70B Instruct:Iq1_M"
+        },
+        {
+            "id": "llama3-70b-instruct:IQ1_S",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 70B Instruct:Iq1_S"
+        },
+        {
+            "id": "llama3-8B-aifeifei-1.0-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Aifeifei 1.0 Iq Imatrix"
+        },
+        {
+            "id": "llama3-8B-aifeifei-1.2-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Aifeifei 1.2 Iq Imatrix"
+        },
+        {
+            "id": "llama3-8b-darkidol-1.1-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Darkidol 1.1 Iq Imatrix"
+        },
+        {
+            "id": "llama3-8b-darkidol-1.2-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Darkidol 1.2 Iq Imatrix"
+        },
+        {
+            "id": "llama3-8b-darkidol-2.1-uncensored-1048k-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Darkidol 2.1 Uncensored 1048K Iq Imatrix"
+        },
+        {
+            "id": "llama3-8b-darkidol-2.2-uncensored-1048k-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Darkidol 2.2 Uncensored 1048K Iq Imatrix"
+        },
+        {
+            "id": "llama3-8b-feifei-1.0-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Feifei 1.0 Iq Imatrix"
+        },
+        {
+            "id": "llama3-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Instruct"
+        },
+        {
+            "id": "llama3-8b-instruct-replete-adapted",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Instruct Replete Adapted"
+        },
+        {
+            "id": "llama3-8b-instruct:Q6_K",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 8B Instruct:Q6_K"
+        },
+        {
+            "id": "llama3-iterative-dpo-final",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 Iterative Dpo Final"
+        },
+        {
+            "id": "llama3-turbcat-instruct-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3 Turbcat Instruct 8B"
+        },
+        {
+            "id": "llama3.1-70b-chinese-chat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3.1 70B Chinese Chat"
+        },
+        {
+            "id": "llama3.1-8b-chinese-chat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3.1 8B Chinese Chat"
+        },
+        {
+            "id": "llama3.1-8b-fireplace2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3.1 8B Fireplace2"
+        },
+        {
+            "id": "llama3.1-8b-shiningvaliant2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3.1 8B Shiningvaliant2"
+        },
+        {
+            "id": "llama3.1-flammades-70b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3.1 Flammades 70B"
+        },
+        {
+            "id": "llama3.1-gutenberg-doppel-70b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3.1 Gutenberg Doppel 70B"
+        },
+        {
+            "id": "llama3.2-3b-enigma",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3.2 3B Enigma"
+        },
+        {
+            "id": "llama3.2-3b-esper2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llama3.2 3B Esper2"
+        },
+        {
+            "id": "llamantino-3-anita-8b-inst-dpo-ita",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llamantino 3 Anita 8B Inst Dpo Ita"
+        },
+        {
+            "id": "llamax3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llamax3 8B"
+        },
+        {
+            "id": "llamax3-8b-alpaca",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llamax3 8B Alpaca"
+        },
+        {
+            "id": "llava-1.5",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llava 1.5"
+        },
+        {
+            "id": "llava-1.6-mistral",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llava 1.6 Mistral"
+        },
+        {
+            "id": "llava-1.6-vicuna",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llava 1.6 Vicuna"
+        },
+        {
+            "id": "llava-llama-3-8b-v1_1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llava Llama 3 8B V1_1"
+        },
+        {
+            "id": "llm-compiler-13b-ftd",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llm Compiler 13B Ftd"
+        },
+        {
+            "id": "llm-compiler-13b-imat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llm Compiler 13B Imat"
+        },
+        {
+            "id": "llm-compiler-7b-ftd-imat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llm Compiler 7B Ftd Imat"
+        },
+        {
+            "id": "llm-compiler-7b-imat-GGUF",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Llm Compiler 7B Imat Gguf"
+        },
+        {
+            "id": "LocalAI-llama3-8b-function-call-v0.2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Localai Llama3 8B Function Call V0.2"
+        },
+        {
+            "id": "loki-base-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Loki Base I1"
+        },
+        {
+            "id": "lumimaid-v0.2-12b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Lumimaid V0.2 12B"
+        },
+        {
+            "id": "lumimaid-v0.2-70b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Lumimaid V0.2 70B I1"
+        },
+        {
+            "id": "lumimaid-v0.2-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Lumimaid V0.2 8B"
+        },
+        {
+            "id": "magnum-32b-v1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Magnum 32B V1 I1"
+        },
+        {
+            "id": "magnum-72b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Magnum 72B V1"
+        },
+        {
+            "id": "magnum-v3-34b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Magnum V3 34B"
+        },
+        {
+            "id": "magnusintellectus-12b-v1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Magnusintellectus 12B V1 I1"
+        },
+        {
+            "id": "mahou-1.2-llama3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mahou 1.2 Llama3 8B"
+        },
+        {
+            "id": "mahou-1.3-llama3.1-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mahou 1.3 Llama3.1 8B"
+        },
+        {
+            "id": "mahou-1.3d-mistral-7b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mahou 1.3D Mistral 7B I1"
+        },
+        {
+            "id": "mahou-1.5-llama3.1-70b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mahou 1.5 Llama3.1 70B I1"
+        },
+        {
+            "id": "master-yi-9b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Master Yi 9B"
+        },
+        {
+            "id": "mathstral-7b-v0.1-imat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mathstral 7B V0.1 Imat"
+        },
+        {
+            "id": "meissa-qwen2.5-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meissa Qwen2.5 7B Instruct"
+        },
+        {
+            "id": "meta-llama-3-instruct-12.2b-brainstorm-20x-form-8",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3 Instruct 12.2B Brainstorm 20X Form 8"
+        },
+        {
+            "id": "meta-llama-3-instruct-8.9b-brainstorm-5x-form-11",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3 Instruct 8.9B Brainstorm 5X Form 11"
+        },
+        {
+            "id": "meta-llama-3.1-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3.1 70B Instruct"
+        },
+        {
+            "id": "meta-llama-3.1-8b-claude-imat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3.1 8B Claude Imat"
+        },
+        {
+            "id": "meta-llama-3.1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "meta-llama-3.1-8b-instruct-abliterated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3.1 8B Instruct Abliterated"
+        },
+        {
+            "id": "meta-llama-3.1-8b-instruct:grammar-functioncall",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3.1 8B Instruct:Grammar Functioncall"
+        },
+        {
+            "id": "meta-llama-3.1-8b-instruct:Q8_grammar-functioncall",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3.1 8B Instruct:Q8_Grammar Functioncall"
+        },
+        {
+            "id": "meta-llama-3.1-instruct-9.99b-brainstorm-10x-form-3",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Meta Llama 3.1 Instruct 9.99B Brainstorm 10X Form 3"
+        },
+        {
+            "id": "minicpm-llama3-v-2_5",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Minicpm Llama3 V 2_5"
+        },
+        {
+            "id": "mirai-nova-llama3-LocalAI-8b-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mirai Nova Llama3 Localai 8B V0.1"
+        },
+        {
+            "id": "mistral-7b-instruct-v0.3",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mistral 7B Instruct V0.3"
+        },
+        {
+            "id": "mistral-nemo-instruct-2407",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mistral Nemo Instruct 2407"
+        },
+        {
+            "id": "ml-ms-etheris-123b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Ml Ms Etheris 123B"
+        },
+        {
+            "id": "mn-12b-celeste-v1.9",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mn 12B Celeste V1.9"
+        },
+        {
+            "id": "mn-12b-lyra-v4-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mn 12B Lyra V4 Iq Imatrix"
+        },
+        {
+            "id": "mn-backyardai-party-12b-v1-iq-arm-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mn Backyardai Party 12B V1 Iq Arm Imatrix"
+        },
+        {
+            "id": "mn-lulanum-12b-fix-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Mn Lulanum 12B Fix I1"
+        },
+        {
+            "id": "moe-girl-1ba-7bt-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Moe Girl 1Ba 7Bt I1"
+        },
+        {
+            "id": "moondream2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Moondream2"
+        },
+        {
+            "id": "neural-sovlish-devil-8b-l3-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Neural Sovlish Devil 8B L3 Iq Imatrix"
+        },
+        {
+            "id": "neuraldaredevil-8b-abliterated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Neuraldaredevil 8B Abliterated"
+        },
+        {
+            "id": "new-dawn-llama-3-70b-32K-v1.0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "New Dawn Llama 3 70B 32K V1.0"
+        },
+        {
+            "id": "nightygurps-14b-v1.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Nightygurps 14B V1.1"
+        },
+        {
+            "id": "nihappy-l3.1-8b-v0.09",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Nihappy L3.1 8B V0.09"
+        },
+        {
+            "id": "noromaid-13b-0.4-DPO",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Noromaid 13B 0.4 Dpo"
+        },
+        {
+            "id": "nymph_8b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Nymph_8B I1"
+        },
+        {
+            "id": "nyun-llama3-62b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Nyun Llama3 62B"
+        },
+        {
+            "id": "openbiollm-llama3-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openbiollm Llama3 8B"
+        },
+        {
+            "id": "openbuddy-llama3.1-8b-v22.1-131k",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openbuddy Llama3.1 8B V22.1 131K"
+        },
+        {
+            "id": "openvino-all-MiniLM-L6-v2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openvino All Minilm L6 V2"
+        },
+        {
+            "id": "openvino-hermes2pro-llama3",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openvino Hermes2Pro Llama3"
+        },
+        {
+            "id": "openvino-llama-3-8b-instruct-ov-int8",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openvino Llama 3 8B Instruct Ov Int8"
+        },
+        {
+            "id": "openvino-llama3-aloe",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openvino Llama3 Aloe"
+        },
+        {
+            "id": "openvino-multilingual-e5-base",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openvino Multilingual E5 Base"
+        },
+        {
+            "id": "openvino-phi3",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openvino Phi3"
+        },
+        {
+            "id": "openvino-starling-lm-7b-beta-openvino-int8",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openvino Starling Lm 7B Beta Openvino Int8"
+        },
+        {
+            "id": "openvino-wizardlm2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Openvino Wizardlm2"
+        },
+        {
+            "id": "orthocopter_8b-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Orthocopter_8B Imatrix"
+        },
+        {
+            "id": "pantheon-rp-1.6-12b-nemo",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Pantheon Rp 1.6 12B Nemo"
+        },
+        {
+            "id": "parler-tts-mini-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Parler Tts Mini V0.1"
+        },
+        {
+            "id": "phi-2-chat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 2 Chat"
+        },
+        {
+            "id": "phi-2-chat:Q8_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 2 Chat:Q8_0"
+        },
+        {
+            "id": "phi-2-orange",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 2 Orange"
+        },
+        {
+            "id": "phi-3-medium-4k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 3 Medium 4K Instruct"
+        },
+        {
+            "id": "phi-3-mini-4k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 3 Mini 4K Instruct"
+        },
+        {
+            "id": "phi-3-mini-4k-instruct:fp16",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 3 Mini 4K Instruct:Fp16"
+        },
+        {
+            "id": "phi-3-vision:vllm",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 3 Vision:Vllm"
+        },
+        {
+            "id": "phi-3.1-mini-4k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 3.1 Mini 4K Instruct"
+        },
+        {
+            "id": "phi-3.5-mini-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 3.5 Mini Instruct"
+        },
+        {
+            "id": "phi-3.5-mini-titanfusion-0.2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 3.5 Mini Titanfusion 0.2"
+        },
+        {
+            "id": "phi-3.5-vision:vllm",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi 3.5 Vision:Vllm"
+        },
+        {
+            "id": "phi3-4x4b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phi3 4X4B V1"
+        },
+        {
+            "id": "phillama-3.8b-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Phillama 3.8B V0.1"
+        },
+        {
+            "id": "poppy_porpoise-v0.72-l3-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Poppy_Porpoise V0.72 L3 8B Iq Imatrix"
+        },
+        {
+            "id": "poppy_porpoise-v0.85-l3-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Poppy_Porpoise V0.85 L3 8B Iq Imatrix"
+        },
+        {
+            "id": "poppy_porpoise-v1.0-l3-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Poppy_Porpoise V1.0 L3 8B Iq Imatrix"
+        },
+        {
+            "id": "poppy_porpoise-v1.30-l3-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Poppy_Porpoise V1.30 L3 8B Iq Imatrix"
+        },
+        {
+            "id": "poppy_porpoise-v1.4-l3-8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Poppy_Porpoise V1.4 L3 8B Iq Imatrix"
+        },
+        {
+            "id": "qevacot-7b-v2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qevacot 7B V2"
+        },
+        {
+            "id": "qwen2-1.5b-ita",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2 1.5B Ita"
+        },
+        {
+            "id": "qwen2-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2 7B Instruct"
+        },
+        {
+            "id": "qwen2-7b-instruct-v0.8",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2 7B Instruct V0.8"
+        },
+        {
+            "id": "qwen2-wukong-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2 Wukong 7B"
+        },
+        {
+            "id": "qwen2.5-0.5b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 0.5B Instruct"
+        },
+        {
+            "id": "qwen2.5-1.5b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 1.5B Instruct"
+        },
+        {
+            "id": "qwen2.5-14b_uncencored",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 14B_Uncencored"
+        },
+        {
+            "id": "qwen2.5-14b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 14B Instruct"
+        },
+        {
+            "id": "qwen2.5-32b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 32B"
+        },
+        {
+            "id": "qwen2.5-32b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 32B Instruct"
+        },
+        {
+            "id": "qwen2.5-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 72B Instruct"
+        },
+        {
+            "id": "qwen2.5-7b-ins-v3",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 7B Ins V3"
+        },
+        {
+            "id": "qwen2.5-coder-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 Coder 7B Instruct"
+        },
+        {
+            "id": "qwen2.5-math-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 Math 72B Instruct"
+        },
+        {
+            "id": "qwen2.5-math-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Qwen2.5 Math 7B Instruct"
+        },
+        {
+            "id": "rawr_llama3_8b-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Rawr_Llama3_8B Iq Imatrix"
+        },
+        {
+            "id": "reflection-llama-3.1-70b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Reflection Llama 3.1 70B"
+        },
+        {
+            "id": "replete-coder-instruct-8b-merged",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Replete Coder Instruct 8B Merged"
+        },
+        {
+            "id": "replete-llm-v2.5-qwen-14b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Replete Llm V2.5 Qwen 14B"
+        },
+        {
+            "id": "replete-llm-v2.5-qwen-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Replete Llm V2.5 Qwen 7B"
+        },
+        {
+            "id": "rocinante-12b-v1.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Rocinante 12B V1.1"
+        },
+        {
+            "id": "rombos-llm-v2.5.1-qwen-3b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Rombos Llm V2.5.1 Qwen 3B"
+        },
+        {
+            "id": "salamandra-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Salamandra 7B Instruct"
+        },
+        {
+            "id": "samantha-qwen-2-7B",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Samantha Qwen 2 7B"
+        },
+        {
+            "id": "seeker-9b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Seeker 9B"
+        },
+        {
+            "id": "sekhmet_aleph-l3.1-8b-v0.1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Sekhmet_Aleph L3.1 8B V0.1 I1"
+        },
+        {
+            "id": "sfr-iterative-dpo-llama-3-8b-r",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Sfr Iterative Dpo Llama 3 8B R"
+        },
+        {
+            "id": "shieldgemma-9b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Shieldgemma 9B I1"
+        },
+        {
+            "id": "smegmma-9b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Smegmma 9B V1"
+        },
+        {
+            "id": "smegmma-deluxe-9b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Smegmma Deluxe 9B V1"
+        },
+        {
+            "id": "smollm-1.7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Smollm 1.7B Instruct"
+        },
+        {
+            "id": "sovl_llama3_8b-gguf-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Sovl_Llama3_8B Gguf Iq Imatrix"
+        },
+        {
+            "id": "stable-diffusion-3-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Stable Diffusion 3 Medium"
+        },
+        {
+            "id": "stablediffusion-cpp",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Stablediffusion Cpp"
+        },
+        {
+            "id": "stellardong-72b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Stellardong 72B I1"
+        },
+        {
+            "id": "sunfall-simpo-9b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Sunfall Simpo 9B"
+        },
+        {
+            "id": "sunfall-simpo-9b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Sunfall Simpo 9B I1"
+        },
+        {
+            "id": "supernova-medius",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Supernova Medius"
+        },
+        {
+            "id": "suzume-llama-3-8B-multilingual",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Suzume Llama 3 8B Multilingual"
+        },
+        {
+            "id": "suzume-llama-3-8b-multilingual-orpo-borda-top25",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Suzume Llama 3 8B Multilingual Orpo Borda Top25"
+        },
+        {
+            "id": "t.e-8.1-iq-imatrix-request",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "T.E 8.1 Iq Imatrix Request"
+        },
+        {
+            "id": "tarnished-9b-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tarnished 9B I1"
+        },
+        {
+            "id": "tess-2.0-llama-3-8B",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tess 2.0 Llama 3 8B"
+        },
+        {
+            "id": "tess-v2.5-gemma-2-27b-alpha",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tess V2.5 Gemma 2 27B Alpha"
+        },
+        {
+            "id": "tess-v2.5-phi-3-medium-128k-14b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tess V2.5 Phi 3 Medium 128K 14B"
+        },
+        {
+            "id": "theia-llama-3.1-8b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Theia Llama 3.1 8B V1"
+        },
+        {
+            "id": "therapyllama-8b-v1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Therapyllama 8B V1"
+        },
+        {
+            "id": "tiamat-8b-1.2-llama-3-dpo",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tiamat 8B 1.2 Llama 3 Dpo"
+        },
+        {
+            "id": "tifa-7b-qwen2-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tifa 7B Qwen2 V0.1"
+        },
+        {
+            "id": "tiger-gemma-9b-v1-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tiger Gemma 9B V1 I1"
+        },
+        {
+            "id": "tor-8b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tor 8B"
+        },
+        {
+            "id": "tsunami-0.5x-7b-instruct-i1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Tsunami 0.5X 7B Instruct I1"
+        },
+        {
+            "id": "una-thepitbull-21.4b-v2",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Una Thepitbull 21.4B V2"
+        },
+        {
+            "id": "versatillama-llama-3.2-3b-instruct-abliterated",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Versatillama Llama 3.2 3B Instruct Abliterated"
+        },
+        {
+            "id": "violet_twilight-v0.2-iq-imatrix",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Violet_Twilight V0.2 Iq Imatrix"
+        },
+        {
+            "id": "voice-ca-upc_ona-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Ca Upc_Ona X Low"
+        },
+        {
+            "id": "voice-ca-upc_pau-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Ca Upc_Pau X Low"
+        },
+        {
+            "id": "voice-da-nst_talesyntese-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Da Nst_Talesyntese Medium"
+        },
+        {
+            "id": "voice-de-eva_k-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice De Eva_K X Low"
+        },
+        {
+            "id": "voice-de-karlsson-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice De Karlsson Low"
+        },
+        {
+            "id": "voice-de-kerstin-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice De Kerstin Low"
+        },
+        {
+            "id": "voice-de-pavoque-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice De Pavoque Low"
+        },
+        {
+            "id": "voice-de-ramona-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice De Ramona Low"
+        },
+        {
+            "id": "voice-de-thorsten-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice De Thorsten Low"
+        },
+        {
+            "id": "voice-el-gr-rapunzelina-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice El Gr Rapunzelina Low"
+        },
+        {
+            "id": "voice-en-gb-alan-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Gb Alan Low"
+        },
+        {
+            "id": "voice-en-gb-southern_english_female-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Gb Southern_English_Female Low"
+        },
+        {
+            "id": "voice-en-us_lessac",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us_Lessac"
+        },
+        {
+            "id": "voice-en-us-amy-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Amy Low"
+        },
+        {
+            "id": "voice-en-us-danny-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Danny Low"
+        },
+        {
+            "id": "voice-en-us-kathleen-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Kathleen Low"
+        },
+        {
+            "id": "voice-en-us-kathleen-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Kathleen Low"
+        },
+        {
+            "id": "voice-en-us-lessac-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Lessac Low"
+        },
+        {
+            "id": "voice-en-us-lessac-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Lessac Medium"
+        },
+        {
+            "id": "voice-en-us-libritts-high",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Libritts High"
+        },
+        {
+            "id": "voice-en-us-ryan-high",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Ryan High"
+        },
+        {
+            "id": "voice-en-us-ryan-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Ryan Low"
+        },
+        {
+            "id": "voice-en-us-ryan-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice En Us Ryan Medium"
+        },
+        {
+            "id": "voice-es-carlfm-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Es Carlfm X Low"
+        },
+        {
+            "id": "voice-es-mls_10246-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Es Mls_10246 Low"
+        },
+        {
+            "id": "voice-es-mls_9972-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Es Mls_9972 Low"
+        },
+        {
+            "id": "voice-fi-harri-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Fi Harri Low"
+        },
+        {
+            "id": "voice-fr-gilles-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Fr Gilles Low"
+        },
+        {
+            "id": "voice-fr-mls_1840-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Fr Mls_1840 Low"
+        },
+        {
+            "id": "voice-fr-siwis-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Fr Siwis Low"
+        },
+        {
+            "id": "voice-fr-siwis-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Fr Siwis Medium"
+        },
+        {
+            "id": "voice-is-bui-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Is Bui Medium"
+        },
+        {
+            "id": "voice-is-salka-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Is Salka Medium"
+        },
+        {
+            "id": "voice-is-steinn-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Is Steinn Medium"
+        },
+        {
+            "id": "voice-is-ugla-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Is Ugla Medium"
+        },
+        {
+            "id": "voice-it-paola-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice It Paola Medium"
+        },
+        {
+            "id": "voice-it-riccardo_fasol-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice It Riccardo_Fasol X Low"
+        },
+        {
+            "id": "voice-kk-iseke-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Kk Iseke X Low"
+        },
+        {
+            "id": "voice-kk-issai-high",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Kk Issai High"
+        },
+        {
+            "id": "voice-kk-raya-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Kk Raya X Low"
+        },
+        {
+            "id": "voice-ne-google-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Ne Google Medium"
+        },
+        {
+            "id": "voice-ne-google-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Ne Google X Low"
+        },
+        {
+            "id": "voice-nl-mls_5809-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Nl Mls_5809 Low"
+        },
+        {
+            "id": "voice-nl-mls_7432-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Nl Mls_7432 Low"
+        },
+        {
+            "id": "voice-nl-nathalie-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Nl Nathalie X Low"
+        },
+        {
+            "id": "voice-nl-rdh-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Nl Rdh Medium"
+        },
+        {
+            "id": "voice-nl-rdh-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Nl Rdh X Low"
+        },
+        {
+            "id": "voice-no-talesyntese-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice No Talesyntese Medium"
+        },
+        {
+            "id": "voice-pl-mls_6892-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Pl Mls_6892 Low"
+        },
+        {
+            "id": "voice-pt-br-edresson-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Pt Br Edresson Low"
+        },
+        {
+            "id": "voice-ru-irinia-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Ru Irinia Medium"
+        },
+        {
+            "id": "voice-sv-se-nst-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Sv Se Nst Medium"
+        },
+        {
+            "id": "voice-uk-lada-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Uk Lada X Low"
+        },
+        {
+            "id": "voice-vi-25hours-single-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Vi 25Hours Single Low"
+        },
+        {
+            "id": "voice-vi-vivos-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Vi Vivos X Low"
+        },
+        {
+            "id": "voice-zh_CN-huayan-medium",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Zh_Cn Huayan Medium"
+        },
+        {
+            "id": "voice-zh-cn-huayan-x-low",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Voice Zh Cn Huayan X Low"
+        },
+        {
+            "id": "whisper-1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper 1"
+        },
+        {
+            "id": "whisper-base",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Base"
+        },
+        {
+            "id": "whisper-base-en",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Base En"
+        },
+        {
+            "id": "whisper-base-en-q5_1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Base En Q5_1"
+        },
+        {
+            "id": "whisper-base-q5_1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Base Q5_1"
+        },
+        {
+            "id": "whisper-large-q5_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Large Q5_0"
+        },
+        {
+            "id": "whisper-medium-q5_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Medium Q5_0"
+        },
+        {
+            "id": "whisper-small",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Small"
+        },
+        {
+            "id": "whisper-small",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Small"
+        },
+        {
+            "id": "whisper-small-en-q5_1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Small En Q5_1"
+        },
+        {
+            "id": "whisper-small-q5_1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Small Q5_1"
+        },
+        {
+            "id": "whisper-small-q5_1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Small Q5_1"
+        },
+        {
+            "id": "whisper-tiny",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Tiny"
+        },
+        {
+            "id": "whisper-tiny-en",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Tiny En"
+        },
+        {
+            "id": "whisper-tiny-en-q5_1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Tiny En Q5_1"
+        },
+        {
+            "id": "whisper-tiny-en-q8_0",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Tiny En Q8_0"
+        },
+        {
+            "id": "whisper-tiny-q5_1",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Whisper Tiny Q5_1"
+        },
+        {
+            "id": "wizardlm2-7b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Wizardlm2 7B"
+        },
+        {
+            "id": "yi-1.5-6b-chat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Yi 1.5 6B Chat"
+        },
+        {
+            "id": "yi-1.5-9b-chat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Yi 1.5 9B Chat"
+        },
+        {
+            "id": "yi-coder-1.5b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Yi Coder 1.5B"
+        },
+        {
+            "id": "yi-coder-1.5b-chat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Yi Coder 1.5B Chat"
+        },
+        {
+            "id": "yi-coder-9b",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Yi Coder 9B"
+        },
+        {
+            "id": "yi-coder-9b-chat",
+            "object": "model",
+            "provider": {
+                "id": "local-ai"
+            },
+            "name": "Yi Coder 9B Chat"
+        },
+        {
+            "id": "ministral-3b-latest",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Ministral 3B"
+        },
+        {
+            "id": "ministral-8b-latest",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Ministral 8B"
+        },
+        {
+            "id": "mistral-large-latest",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Mistral Large"
+        },
+        {
+            "id": "mistral-small-latest",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Mistral Small"
+        },
+        {
+            "id": "codestral-latest",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Codestral"
+        },
+        {
+            "id": "mistral-embed",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Mistral Embed"
+        },
+        {
+            "id": "pixtral-12b-2409",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Pixtral"
+        },
+        {
+            "id": "open-mistral-nemo",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Mistral Nemo"
+        },
+        {
+            "id": "open-codestral-mamba",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Codestral Mamba"
+        },
+        {
+            "id": "open-mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Mistral 7B"
+        },
+        {
+            "id": "google/gemma-2-9b-it",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Gemma 2 9B It"
+        },
+        {
+            "id": "img2img",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Img2Img"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Meta Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "microsoft/Phi-3-mini-4k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Phi 3 Mini 4K Instruct"
+        },
+        {
+            "id": "mistralai/Mistral-7B-Instruct-v0.2",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Mistral 7B Instruct V0.2"
+        },
+        {
+            "id": "photo-maker",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Photo Maker"
+        },
+        {
+            "id": "pix2pix",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Pix2Pix"
+        },
+        {
+            "id": "sdxl-base",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Sdxl Base"
+        },
+        {
+            "id": "speech2text",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Speech2Text"
+        },
+        {
+            "id": "speech2text-v2",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Speech2Text V2"
+        },
+        {
+            "id": "sunoai-bark",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Sunoai Bark"
+        },
+        {
+            "id": "txt2img",
+            "object": "model",
+            "provider": {
+                "id": "monsterapi"
+            },
+            "name": "Txt2Img"
+        },
+        {
+            "id": "cognitivecomputations/dolphin-mixtral-8x22b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Dolphin Mixtral 8x22B"
+        },
+        {
+            "id": "google/gemma-2-9b-it",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Gemma 2 9B IT"
+        },
+        {
+            "id": "google/gemma-2-9b-it",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Gemma 2 9B IT"
+        },
+        {
+            "id": "gryphe/mythomax-l2-13b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "MythoMax L2 13B"
+        },
+        {
+            "id": "gryphe/mythomax-l2-13b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "MythoMax L2 13B"
+        },
+        {
+            "id": "jondurbin/airoboros-l2-70b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Airoboros L2 70B"
+        },
+        {
+            "id": "lzlv_70b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "LZLV 70B"
+        },
+        {
+            "id": "meta-llama/llama-3-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Llama 3 70B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Llama 3 8B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.1-405b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Llama 3.1 405B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.1-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Llama 3.1 70B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "microsoft/wizardlm-2-7b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "WizardLM 2 7B"
+        },
+        {
+            "id": "microsoft/wizardlm-2-8x22b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "WizardLM 2 8x22B"
+        },
+        {
+            "id": "mistralai/mistral-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Mistral 7B Instruct"
+        },
+        {
+            "id": "mistralai/mistral-nemo",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Mistral Nemo"
+        },
+        {
+            "id": "nousresearch/hermes-2-pro-llama-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Hermes 2 Pro Llama 3 8B"
+        },
+        {
+            "id": "nousresearch/meta-llama-3.1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Meta Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "nousresearch/nous-hermes-llama2-13b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Nous Hermes Llama 2 13B"
+        },
+        {
+            "id": "openchat/openchat-7b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "OpenChat 7B"
+        },
+        {
+            "id": "qwen/qwen-2-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Qwen 2 72B Instruct"
+        },
+        {
+            "id": "qwen/qwen-2-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Qwen 2 7B Instruct"
+        },
+        {
+            "id": "sao10k/l3-70b-euryale-v2.1",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "L3 70B Euryale v2.1"
+        },
+        {
+            "id": "sao10k/l31-70b-euryale-v2.2",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "L31 70B Euryale v2.2"
+        },
+        {
+            "id": "sophosympatheia/midnight-rose-70b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "Midnight Rose 70B"
+        },
+        {
+            "id": "teknium/openhermes-2.5-mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "novita-ai"
+            },
+            "name": "OpenHermes 2.5 Mistral 7B"
+        },
+        {
+            "id": "alfred",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Alfred"
+        },
+        {
+            "id": "all-minilm",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "All Minilm"
+        },
+        {
+            "id": "aya",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Aya"
+        },
+        {
+            "id": "bakllava",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Bakllava"
+        },
+        {
+            "id": "bespoke-minicheck",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Bespoke Minicheck"
+        },
+        {
+            "id": "bge-large",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Bge Large"
+        },
+        {
+            "id": "bge-m3",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Bge M3"
+        },
+        {
+            "id": "codebooga",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Codebooga"
+        },
+        {
+            "id": "codegeex4",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Codegeex4"
+        },
+        {
+            "id": "codegemma",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Codegemma"
+        },
+        {
+            "id": "codellama",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Codellama"
+        },
+        {
+            "id": "codeqwen",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Codeqwen"
+        },
+        {
+            "id": "codestral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Codestral"
+        },
+        {
+            "id": "codeup",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Codeup"
+        },
+        {
+            "id": "command-r",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Command R"
+        },
+        {
+            "id": "command-r-plus",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Command R Plus"
+        },
+        {
+            "id": "dbrx",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Dbrx"
+        },
+        {
+            "id": "deepseek-coder",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Deepseek Coder"
+        },
+        {
+            "id": "deepseek-coder-v2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Deepseek Coder V2"
+        },
+        {
+            "id": "deepseek-llm",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Deepseek Llm"
+        },
+        {
+            "id": "deepseek-v2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Deepseek V2"
+        },
+        {
+            "id": "deepseek-v2.5",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Deepseek V2.5"
+        },
+        {
+            "id": "dolphin-llama3",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Dolphin Llama3"
+        },
+        {
+            "id": "dolphin-mistral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Dolphin Mistral"
+        },
+        {
+            "id": "dolphin-mixtral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Dolphin Mixtral"
+        },
+        {
+            "id": "dolphin-phi",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Dolphin Phi"
+        },
+        {
+            "id": "dolphincoder",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Dolphincoder"
+        },
+        {
+            "id": "duckdb-nsql",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Duckdb Nsql"
+        },
+        {
+            "id": "everythinglm",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Everythinglm"
+        },
+        {
+            "id": "falcon",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Falcon"
+        },
+        {
+            "id": "falcon2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Falcon2"
+        },
+        {
+            "id": "firefunction-v2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Firefunction V2"
+        },
+        {
+            "id": "gemma",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Gemma"
+        },
+        {
+            "id": "gemma2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Gemma2"
+        },
+        {
+            "id": "glm4",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Glm4"
+        },
+        {
+            "id": "goliath",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Goliath"
+        },
+        {
+            "id": "granite-code",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Granite Code"
+        },
+        {
+            "id": "granite3-dense",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Granite3 Dense"
+        },
+        {
+            "id": "granite3-moe",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Granite3 Moe"
+        },
+        {
+            "id": "hermes3",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Hermes3"
+        },
+        {
+            "id": "internlm2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Internlm2"
+        },
+        {
+            "id": "llama-guard3",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama Guard3"
+        },
+        {
+            "id": "llama-pro",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama Pro"
+        },
+        {
+            "id": "llama2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama2"
+        },
+        {
+            "id": "llama2-chinese",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama2 Chinese"
+        },
+        {
+            "id": "llama2-uncensored",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama2 Uncensored"
+        },
+        {
+            "id": "llama3",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama3"
+        },
+        {
+            "id": "llama3-chatqa",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama3 Chatqa"
+        },
+        {
+            "id": "llama3-gradient",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama3 Gradient"
+        },
+        {
+            "id": "llama3-groq-tool-use",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama3 Groq Tool Use"
+        },
+        {
+            "id": "llama3.1",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama3.1"
+        },
+        {
+            "id": "llama3.2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llama3.2"
+        },
+        {
+            "id": "llava",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llava"
+        },
+        {
+            "id": "llava-llama3",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llava Llama3"
+        },
+        {
+            "id": "llava-phi3",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Llava Phi3"
+        },
+        {
+            "id": "magicoder",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Magicoder"
+        },
+        {
+            "id": "mathstral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mathstral"
+        },
+        {
+            "id": "meditron",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Meditron"
+        },
+        {
+            "id": "medllama2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Medllama2"
+        },
+        {
+            "id": "megadolphin",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Megadolphin"
+        },
+        {
+            "id": "minicpm-v",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Minicpm V"
+        },
+        {
+            "id": "mistral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mistral"
+        },
+        {
+            "id": "mistral-large",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mistral Large"
+        },
+        {
+            "id": "mistral-nemo",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mistral Nemo"
+        },
+        {
+            "id": "mistral-openorca",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mistral Openorca"
+        },
+        {
+            "id": "mistral-small",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mistral Small"
+        },
+        {
+            "id": "mistrallite",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mistrallite"
+        },
+        {
+            "id": "mixtral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mixtral"
+        },
+        {
+            "id": "moondream",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Moondream"
+        },
+        {
+            "id": "mxbai-embed-large",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Mxbai Embed Large"
+        },
+        {
+            "id": "nemotron",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Nemotron"
+        },
+        {
+            "id": "nemotron-mini",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Nemotron Mini"
+        },
+        {
+            "id": "neural-chat",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Neural Chat"
+        },
+        {
+            "id": "nexusraven",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Nexusraven"
+        },
+        {
+            "id": "nomic-embed-text",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Nomic Embed Text"
+        },
+        {
+            "id": "notus",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Notus"
+        },
+        {
+            "id": "notux",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Notux"
+        },
+        {
+            "id": "nous-hermes",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Nous Hermes"
+        },
+        {
+            "id": "nous-hermes2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Nous Hermes2"
+        },
+        {
+            "id": "nous-hermes2-mixtral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Nous Hermes2 Mixtral"
+        },
+        {
+            "id": "nuextract",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Nuextract"
+        },
+        {
+            "id": "open-orca-platypus2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Open Orca Platypus2"
+        },
+        {
+            "id": "openchat",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Openchat"
+        },
+        {
+            "id": "openhermes",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Openhermes"
+        },
+        {
+            "id": "orca-mini",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Orca Mini"
+        },
+        {
+            "id": "orca2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Orca2"
+        },
+        {
+            "id": "paraphrase-multilingual",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Paraphrase Multilingual"
+        },
+        {
+            "id": "phi",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Phi"
+        },
+        {
+            "id": "phi3",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Phi3"
+        },
+        {
+            "id": "phi3.5",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Phi3.5"
+        },
+        {
+            "id": "phind-codellama",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Phind Codellama"
+        },
+        {
+            "id": "qwen",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Qwen"
+        },
+        {
+            "id": "qwen2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Qwen2"
+        },
+        {
+            "id": "qwen2-math",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Qwen2 Math"
+        },
+        {
+            "id": "qwen2.5",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Qwen2.5"
+        },
+        {
+            "id": "qwen2.5-coder",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Qwen2.5 Coder"
+        },
+        {
+            "id": "reader-lm",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Reader Lm"
+        },
+        {
+            "id": "reflection",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Reflection"
+        },
+        {
+            "id": "samantha-mistral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Samantha Mistral"
+        },
+        {
+            "id": "shieldgemma",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Shieldgemma"
+        },
+        {
+            "id": "smollm",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Smollm"
+        },
+        {
+            "id": "snowflake-arctic-embed",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Snowflake Arctic Embed"
+        },
+        {
+            "id": "solar",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Solar"
+        },
+        {
+            "id": "solar-pro",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Solar Pro"
+        },
+        {
+            "id": "sqlcoder",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Sqlcoder"
+        },
+        {
+            "id": "stable-beluga",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Stable Beluga"
+        },
+        {
+            "id": "stable-code",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Stable Code"
+        },
+        {
+            "id": "stablelm-zephyr",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Stablelm Zephyr"
+        },
+        {
+            "id": "stablelm2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Stablelm2"
+        },
+        {
+            "id": "starcoder",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Starcoder"
+        },
+        {
+            "id": "starcoder2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Starcoder2"
+        },
+        {
+            "id": "starling-lm",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Starling Lm"
+        },
+        {
+            "id": "tinydolphin",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Tinydolphin"
+        },
+        {
+            "id": "tinyllama",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Tinyllama"
+        },
+        {
+            "id": "vicuna",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Vicuna"
+        },
+        {
+            "id": "wizard-math",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Wizard Math"
+        },
+        {
+            "id": "wizard-vicuna",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Wizard Vicuna"
+        },
+        {
+            "id": "wizard-vicuna-uncensored",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Wizard Vicuna Uncensored"
+        },
+        {
+            "id": "wizardcoder",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Wizardcoder"
+        },
+        {
+            "id": "wizardlm",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Wizardlm"
+        },
+        {
+            "id": "wizardlm-uncensored",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Wizardlm Uncensored"
+        },
+        {
+            "id": "wizardlm2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Wizardlm2"
+        },
+        {
+            "id": "xwinlm",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Xwinlm"
+        },
+        {
+            "id": "yarn-llama2",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Yarn Llama2"
+        },
+        {
+            "id": "yarn-mistral",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Yarn Mistral"
+        },
+        {
+            "id": "yi",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Yi"
+        },
+        {
+            "id": "yi-coder",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Yi Coder"
+        },
+        {
+            "id": "zephyr",
+            "object": "model",
+            "provider": {
+                "id": "ollama"
+            },
+            "name": "Zephyr"
+        },
+        {
+            "id": "babbage-002",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Babbage 002"
+        },
+        {
+            "id": "chatgpt-4o-latest",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Chatgpt 4o Latest"
+        },
+        {
+            "id": "dall-e-2",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Dall-E 2"
+        },
+        {
+            "id": "dall-e-3",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Dall-E 3"
+        },
+        {
+            "id": "davinci-002",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Davinci 002"
+        },
+        {
+            "id": "gpt-3.5-turbo",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 3.5 Turbo"
+        },
+        {
+            "id": "gpt-3.5-turbo-0125",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 3.5 Turbo 0125"
+        },
+        {
+            "id": "gpt-3.5-turbo-1106",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 3.5 Turbo 1106"
+        },
+        {
+            "id": "gpt-3.5-turbo-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 3.5 Turbo Instruct"
+        },
+        {
+            "id": "gpt-4",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4"
+        },
+        {
+            "id": "gpt-4-0125-preview",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4 0125 Preview"
+        },
+        {
+            "id": "gpt-4-0314",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4 0314"
+        },
+        {
+            "id": "gpt-4-0613",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4 0613"
+        },
+        {
+            "id": "gpt-4-1106-preview",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4 1106 Preview"
+        },
+        {
+            "id": "gpt-4-turbo",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4 Turbo"
+        },
+        {
+            "id": "gpt-4-turbo-2024-04-09",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4 Turbo 2024 04 09"
+        },
+        {
+            "id": "gpt-4-turbo-preview",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4 Turbo Preview"
+        },
+        {
+            "id": "gpt-4o",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT 4o"
+        },
+        {
+            "id": "gpt-4o-2024-05-13",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT-4o 2024 05 13"
+        },
+        {
+            "id": "gpt-4o-2024-08-06",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT-4o 2024 08 06"
+        },
+        {
+            "id": "gpt-4o-audio-preview",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT-4o Audio Preview"
+        },
+        {
+            "id": "gpt-4o-audio-preview-2024-10-01",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT-4o Audio Preview 2024 10 01"
+        },
+        {
+            "id": "gpt-4o-mini",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT-4o Mini"
+        },
+        {
+            "id": "gpt-4o-mini-2024-07-18",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT-4o Mini 2024 07 18"
+        },
+        {
+            "id": "gpt-4o-realtime-preview",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT-4o Realtime Preview"
+        },
+        {
+            "id": "gpt-4o-realtime-preview-2024-10-01",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "GPT-4o Realtime Preview 2024 10 01"
+        },
+        {
+            "id": "hd/1024-x-1024/dall-e-3",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "HD/1024 X 1024/Dall-E 3"
+        },
+        {
+            "id": "o1-mini",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "O1 Mini"
+        },
+        {
+            "id": "o1-mini-2024-09-12",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "O1 Mini 2024-09-12"
+        },
+        {
+            "id": "o1-preview",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "O1 Preview"
+        },
+        {
+            "id": "o1-preview-2024-09-12",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "O1 Preview 2024-09-12"
+        },
+        {
+            "id": "omni-moderation-2024-09-26",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Omni Moderation 2024-09-26"
+        },
+        {
+            "id": "omni-moderation-latest",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Omni Moderation Latest"
+        },
+        {
+            "id": "standard/1024-x-1024/dall-e-3",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Standard/1024 X 1024/Dall-E 3"
+        },
+        {
+            "id": "standard/1024-x-1792/dall-e-3",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Standard/1024 X 1792/Dall-E 3"
+        },
+        {
+            "id": "standard/1792-x-1024/dall-e-3",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Standard/1792 X 1024/Dall-E 3"
+        },
+        {
+            "id": "text-embedding-3-large",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Text Embedding 3 Large"
+        },
+        {
+            "id": "text-embedding-3-small",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Text Embedding 3 Small"
+        },
+        {
+            "id": "text-embedding-ada-002",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Text Embedding Ada 002"
+        },
+        {
+            "id": "text-moderation-007",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Text Moderation 007"
+        },
+        {
+            "id": "text-moderation-latest",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Text Moderation Latest"
+        },
+        {
+            "id": "text-moderation-stable",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Text Moderation Stable"
+        },
+        {
+            "id": "tts-1",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Tts 1"
+        },
+        {
+            "id": "tts-1",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Tts 1"
+        },
+        {
+            "id": "tts-1-hd",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Tts 1 Hd"
+        },
+        {
+            "id": "tts-1-hd",
+            "object": "model",
+            "provider": {
+                "id": "openai"
+            },
+            "name": "Tts 1 Hd"
+        },
+        {
+            "id": "aetherwiing/mn-starcannon-12b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral Nemo 12B Starcannon"
+        },
+        {
+            "id": "ai21/jamba-1-5-large",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "AI21: Jamba 1.5 Large"
+        },
+        {
+            "id": "ai21/jamba-1-5-mini",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "AI21: Jamba 1.5 Mini"
+        },
+        {
+            "id": "ai21/jamba-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "AI21: Jamba Instruct"
+        },
+        {
+            "id": "alpindale/goliath-120b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Goliath 120B"
+        },
+        {
+            "id": "alpindale/magnum-72b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Magnum 72B"
+        },
+        {
+            "id": "anthracite-org/magnum-v2-72b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Magnum v2 72B"
+        },
+        {
+            "id": "anthropic/claude-1",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude v1"
+        },
+        {
+            "id": "anthropic/claude-1.2",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude v1.2"
+        },
+        {
+            "id": "anthropic/claude-2",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude v2"
+        },
+        {
+            "id": "anthropic/claude-2:beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude v2 (self-moderated)"
+        },
+        {
+            "id": "anthropic/claude-2.0",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude v2.0"
+        },
+        {
+            "id": "anthropic/claude-2.0:beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude v2.0 (self-moderated)"
+        },
+        {
+            "id": "anthropic/claude-2.1",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude v2.1"
+        },
+        {
+            "id": "anthropic/claude-2.1:beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude v2.1 (self-moderated)"
+        },
+        {
+            "id": "anthropic/claude-3-haiku",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude 3 Haiku"
+        },
+        {
+            "id": "anthropic/claude-3-haiku:beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude 3 Haiku (self-moderated)"
+        },
+        {
+            "id": "anthropic/claude-3-opus",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude 3 Opus"
+        },
+        {
+            "id": "anthropic/claude-3-opus:beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude 3 Opus (self-moderated)"
+        },
+        {
+            "id": "anthropic/claude-3-sonnet",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude 3 Sonnet"
+        },
+        {
+            "id": "anthropic/claude-3-sonnet:beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude 3 Sonnet (self-moderated)"
+        },
+        {
+            "id": "anthropic/claude-3.5-sonnet",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude 3.5 Sonnet"
+        },
+        {
+            "id": "anthropic/claude-3.5-sonnet:beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude 3.5 Sonnet (self-moderated)"
+        },
+        {
+            "id": "anthropic/claude-instant-1",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude Instant v1"
+        },
+        {
+            "id": "anthropic/claude-instant-1:beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude Instant v1 (self-moderated)"
+        },
+        {
+            "id": "anthropic/claude-instant-1.0",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude Instant v1.0"
+        },
+        {
+            "id": "anthropic/claude-instant-1.1",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Anthropic: Claude Instant v1.1"
+        },
+        {
+            "id": "cognitivecomputations/dolphin-mixtral-8x22b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Dolphin 2.9.2 Mixtral 8x22B \ud83d\udc2c"
+        },
+        {
+            "id": "cognitivecomputations/dolphin-mixtral-8x7b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Dolphin 2.6 Mixtral 8x7B \ud83d\udc2c"
+        },
+        {
+            "id": "cohere/command",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Cohere: Command"
+        },
+        {
+            "id": "cohere/command-r",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Cohere: Command R"
+        },
+        {
+            "id": "cohere/command-r-03-2024",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Cohere: Command R (03-2024)"
+        },
+        {
+            "id": "cohere/command-r-08-2024",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Cohere: Command R (08-2024)"
+        },
+        {
+            "id": "cohere/command-r-plus",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Cohere: Command R+"
+        },
+        {
+            "id": "cohere/command-r-plus-04-2024",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Cohere: Command R+ (04-2024)"
+        },
+        {
+            "id": "cohere/command-r-plus-08-2024",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Cohere: Command R+ (08-2024)"
+        },
+        {
+            "id": "databricks/dbrx-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Databricks: DBRX 132B Instruct"
+        },
+        {
+            "id": "deepseek/deepseek-chat",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "DeepSeek V2.5"
+        },
+        {
+            "id": "eva-unit-01/eva-qwen-2.5-14b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "EVA Qwen2.5 14B"
+        },
+        {
+            "id": "google/gemini-flash-1.5",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemini Flash 1.5"
+        },
+        {
+            "id": "google/gemini-flash-1.5-8b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemini 1.5 Flash-8B"
+        },
+        {
+            "id": "google/gemini-flash-1.5-8b-exp",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemini Flash 8B 1.5 Experimental"
+        },
+        {
+            "id": "google/gemini-flash-1.5-exp",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemini Flash 1.5 Experimental"
+        },
+        {
+            "id": "google/gemini-pro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemini Pro 1.0"
+        },
+        {
+            "id": "google/gemini-pro-1.5",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemini Pro 1.5"
+        },
+        {
+            "id": "google/gemini-pro-1.5-exp",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemini Pro 1.5 Experimental"
+        },
+        {
+            "id": "google/gemini-pro-vision",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemini Pro Vision 1.0"
+        },
+        {
+            "id": "google/gemma-2-27b-it",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemma 2 27B"
+        },
+        {
+            "id": "google/gemma-2-9b-it",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemma 2 9B"
+        },
+        {
+            "id": "google/gemma-2-9b-it:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: Gemma 2 9B (free)"
+        },
+        {
+            "id": "google/palm-2-chat-bison",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: PaLM 2 Chat"
+        },
+        {
+            "id": "google/palm-2-chat-bison-32k",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: PaLM 2 Chat 32k"
+        },
+        {
+            "id": "google/palm-2-codechat-bison",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: PaLM 2 Code Chat"
+        },
+        {
+            "id": "google/palm-2-codechat-bison-32k",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Google: PaLM 2 Code Chat 32k"
+        },
+        {
+            "id": "gryphe/mythomax-l2-13b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "MythoMax 13B"
+        },
+        {
+            "id": "gryphe/mythomax-l2-13b:extended",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "MythoMax 13B (extended)"
+        },
+        {
+            "id": "gryphe/mythomax-l2-13b:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "MythoMax 13B (free)"
+        },
+        {
+            "id": "gryphe/mythomax-l2-13b:nitro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "MythoMax 13B (nitro)"
+        },
+        {
+            "id": "gryphe/mythomist-7b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "MythoMist 7B"
+        },
+        {
+            "id": "gryphe/mythomist-7b:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "MythoMist 7B (free)"
+        },
+        {
+            "id": "huggingfaceh4/zephyr-7b-beta:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Hugging Face: Zephyr 7B (free)"
+        },
+        {
+            "id": "inflection/inflection-3-pi",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Inflection: Inflection 3 Pi"
+        },
+        {
+            "id": "inflection/inflection-3-productivity",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Inflection: Inflection 3 Productivity"
+        },
+        {
+            "id": "jondurbin/airoboros-l2-70b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Airoboros 70B"
+        },
+        {
+            "id": "liquid/lfm-40b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Liquid: LFM 40B MoE"
+        },
+        {
+            "id": "liquid/lfm-40b:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Liquid: LFM 40B MoE (free)"
+        },
+        {
+            "id": "lizpreciatior/lzlv-70b-fp16-hf",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "lzlv 70B"
+        },
+        {
+            "id": "mancer/weaver",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mancer: Weaver (alpha)"
+        },
+        {
+            "id": "meta-llama/llama-2-13b-chat",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama v2 13B Chat"
+        },
+        {
+            "id": "meta-llama/llama-3-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3 70B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3-70b-instruct:nitro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3 70B Instruct (nitro)"
+        },
+        {
+            "id": "meta-llama/llama-3-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3 8B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3-8b-instruct:extended",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3 8B Instruct (extended)"
+        },
+        {
+            "id": "meta-llama/llama-3-8b-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3 8B Instruct (free)"
+        },
+        {
+            "id": "meta-llama/llama-3-8b-instruct:nitro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3 8B Instruct (nitro)"
+        },
+        {
+            "id": "meta-llama/llama-3.1-405b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 405B (base)"
+        },
+        {
+            "id": "meta-llama/llama-3.1-405b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 405B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.1-405b-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 405B Instruct (free)"
+        },
+        {
+            "id": "meta-llama/llama-3.1-405b-instruct:nitro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 405B Instruct (nitro)"
+        },
+        {
+            "id": "meta-llama/llama-3.1-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 70B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.1-70b-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 70B Instruct (free)"
+        },
+        {
+            "id": "meta-llama/llama-3.1-70b-instruct:nitro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 70B Instruct (nitro)"
+        },
+        {
+            "id": "meta-llama/llama-3.1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.1-8b-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.1 8B Instruct (free)"
+        },
+        {
+            "id": "meta-llama/llama-3.2-11b-vision-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.2 11B Vision Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.2-11b-vision-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.2 11B Vision Instruct (free)"
+        },
+        {
+            "id": "meta-llama/llama-3.2-1b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.2 1B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.2-1b-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.2 1B Instruct (free)"
+        },
+        {
+            "id": "meta-llama/llama-3.2-3b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.2 3B Instruct"
+        },
+        {
+            "id": "meta-llama/llama-3.2-3b-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.2 3B Instruct (free)"
+        },
+        {
+            "id": "meta-llama/llama-3.2-90b-vision-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: Llama 3.2 90B Vision Instruct"
+        },
+        {
+            "id": "meta-llama/llama-guard-2-8b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Meta: LlamaGuard 2 8B"
+        },
+        {
+            "id": "microsoft/phi-3-medium-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Phi-3 Medium 128K Instruct"
+        },
+        {
+            "id": "microsoft/phi-3-medium-128k-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Phi-3 Medium 128K Instruct (free)"
+        },
+        {
+            "id": "microsoft/phi-3-mini-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Phi-3 Mini 128K Instruct"
+        },
+        {
+            "id": "microsoft/phi-3-mini-128k-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Phi-3 Mini 128K Instruct (free)"
+        },
+        {
+            "id": "microsoft/phi-3.5-mini-128k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Phi-3.5 Mini 128K Instruct"
+        },
+        {
+            "id": "microsoft/wizardlm-2-7b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "WizardLM-2 7B"
+        },
+        {
+            "id": "microsoft/wizardlm-2-8x22b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "WizardLM-2 8x22B"
+        },
+        {
+            "id": "mistralai/codestral-mamba",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Codestral Mamba"
+        },
+        {
+            "id": "mistralai/ministral-3b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Ministral 3B"
+        },
+        {
+            "id": "mistralai/ministral-8b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Ministral 8B"
+        },
+        {
+            "id": "mistralai/mistral-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Mistral 7B Instruct"
+        },
+        {
+            "id": "mistralai/mistral-7b-instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Mistral 7B Instruct v0.1"
+        },
+        {
+            "id": "mistralai/mistral-7b-instruct-v0.2",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Mistral 7B Instruct v0.2"
+        },
+        {
+            "id": "mistralai/mistral-7b-instruct-v0.3",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Mistral 7B Instruct v0.3"
+        },
+        {
+            "id": "mistralai/mistral-7b-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Mistral 7B Instruct (free)"
+        },
+        {
+            "id": "mistralai/mistral-7b-instruct:nitro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Mistral 7B Instruct (nitro)"
+        },
+        {
+            "id": "mistralai/mistral-large",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral Large"
+        },
+        {
+            "id": "mistralai/mistral-medium",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral Medium"
+        },
+        {
+            "id": "mistralai/mistral-nemo",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Mistral Nemo"
+        },
+        {
+            "id": "mistralai/mistral-small",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral Small"
+        },
+        {
+            "id": "mistralai/mistral-tiny",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral Tiny"
+        },
+        {
+            "id": "mistralai/mixtral-8x22b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Mixtral 8x22B Instruct"
+        },
+        {
+            "id": "mistralai/mixtral-8x7b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mixtral 8x7B (base)"
+        },
+        {
+            "id": "mistralai/mixtral-8x7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mixtral 8x7B Instruct"
+        },
+        {
+            "id": "mistralai/mixtral-8x7b-instruct:nitro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mixtral 8x7B Instruct (nitro)"
+        },
+        {
+            "id": "mistralai/pixtral-12b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral: Pixtral 12B"
+        },
+        {
+            "id": "neversleep/llama-3-lumimaid-70b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Llama 3 Lumimaid 70B"
+        },
+        {
+            "id": "neversleep/llama-3-lumimaid-8b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Llama 3 Lumimaid 8B"
+        },
+        {
+            "id": "neversleep/llama-3-lumimaid-8b:extended",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Llama 3 Lumimaid 8B (extended)"
+        },
+        {
+            "id": "neversleep/llama-3.1-lumimaid-8b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Lumimaid v0.2 8B"
+        },
+        {
+            "id": "neversleep/noromaid-20b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Noromaid 20B"
+        },
+        {
+            "id": "nothingiisreal/mn-celeste-12b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Mistral Nemo 12B Celeste"
+        },
+        {
+            "id": "nousresearch/hermes-2-pro-llama-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "NousResearch: Hermes 2 Pro - Llama-3 8B"
+        },
+        {
+            "id": "nousresearch/hermes-2-theta-llama-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Nous: Hermes 2 Theta 8B"
+        },
+        {
+            "id": "nousresearch/hermes-3-llama-3.1-405b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Nous: Hermes 3 405B Instruct"
+        },
+        {
+            "id": "nousresearch/hermes-3-llama-3.1-405b:extended",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Nous: Hermes 3 405B Instruct (extended)"
+        },
+        {
+            "id": "nousresearch/hermes-3-llama-3.1-405b:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Nous: Hermes 3 405B Instruct (free)"
+        },
+        {
+            "id": "nousresearch/hermes-3-llama-3.1-70b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Nous: Hermes 3 70B Instruct"
+        },
+        {
+            "id": "nousresearch/nous-hermes-2-mixtral-8x7b-dpo",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Nous: Hermes 2 Mixtral 8x7B DPO"
+        },
+        {
+            "id": "nousresearch/nous-hermes-llama2-13b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Nous: Hermes 13B"
+        },
+        {
+            "id": "nvidia/llama-3.1-nemotron-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "NVIDIA: Llama 3.1 Nemotron 70B Instruct"
+        },
+        {
+            "id": "openai/chatgpt-4o-latest",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: ChatGPT-4o"
+        },
+        {
+            "id": "openai/gpt-3.5-turbo",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-3.5 Turbo"
+        },
+        {
+            "id": "openai/gpt-3.5-turbo-0125",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-3.5 Turbo 16k"
+        },
+        {
+            "id": "openai/gpt-3.5-turbo-0613",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-3.5 Turbo (older v0613)"
+        },
+        {
+            "id": "openai/gpt-3.5-turbo-1106",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-3.5 Turbo 16k (older v1106)"
+        },
+        {
+            "id": "openai/gpt-3.5-turbo-16k",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-3.5 Turbo 16k"
+        },
+        {
+            "id": "openai/gpt-3.5-turbo-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-3.5 Turbo Instruct"
+        },
+        {
+            "id": "openai/gpt-4",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4"
+        },
+        {
+            "id": "openai/gpt-4-0314",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4 (older v0314)"
+        },
+        {
+            "id": "openai/gpt-4-1106-preview",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4 Turbo (older v1106)"
+        },
+        {
+            "id": "openai/gpt-4-32k",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4 32k"
+        },
+        {
+            "id": "openai/gpt-4-32k-0314",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4 32k (older v0314)"
+        },
+        {
+            "id": "openai/gpt-4-turbo",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4 Turbo"
+        },
+        {
+            "id": "openai/gpt-4-turbo-preview",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4 Turbo Preview"
+        },
+        {
+            "id": "openai/gpt-4-vision-preview",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4 Vision"
+        },
+        {
+            "id": "openai/gpt-4o",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4o"
+        },
+        {
+            "id": "openai/gpt-4o-2024-05-13",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4o (2024-05-13)"
+        },
+        {
+            "id": "openai/gpt-4o-2024-08-06",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4o (2024-08-06)"
+        },
+        {
+            "id": "openai/gpt-4o-mini",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4o-mini"
+        },
+        {
+            "id": "openai/gpt-4o-mini-2024-07-18",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4o-mini (2024-07-18)"
+        },
+        {
+            "id": "openai/gpt-4o:extended",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: GPT-4o (extended)"
+        },
+        {
+            "id": "openai/o1-mini",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: o1-mini"
+        },
+        {
+            "id": "openai/o1-mini-2024-09-12",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: o1-mini (2024-09-12)"
+        },
+        {
+            "id": "openai/o1-preview",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: o1-preview"
+        },
+        {
+            "id": "openai/o1-preview-2024-09-12",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenAI: o1-preview (2024-09-12)"
+        },
+        {
+            "id": "openchat/openchat-7b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenChat 3.5 7B"
+        },
+        {
+            "id": "openchat/openchat-7b:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenChat 3.5 7B (free)"
+        },
+        {
+            "id": "openrouter/auto",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Auto (best for prompt)"
+        },
+        {
+            "id": "perplexity/llama-3-sonar-large-32k-chat",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Perplexity: Llama3 Sonar 70B"
+        },
+        {
+            "id": "perplexity/llama-3-sonar-large-32k-online",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Perplexity: Llama3 Sonar 70B Online"
+        },
+        {
+            "id": "perplexity/llama-3-sonar-small-32k-chat",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Perplexity: Llama3 Sonar 8B"
+        },
+        {
+            "id": "perplexity/llama-3.1-sonar-huge-128k-online",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Perplexity: Llama 3.1 Sonar 405B Online"
+        },
+        {
+            "id": "perplexity/llama-3.1-sonar-large-128k-chat",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Perplexity: Llama 3.1 Sonar 70B"
+        },
+        {
+            "id": "perplexity/llama-3.1-sonar-large-128k-online",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Perplexity: Llama 3.1 Sonar 70B Online"
+        },
+        {
+            "id": "perplexity/llama-3.1-sonar-small-128k-chat",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Perplexity: Llama 3.1 Sonar 8B"
+        },
+        {
+            "id": "perplexity/llama-3.1-sonar-small-128k-online",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Perplexity: Llama 3.1 Sonar 8B Online"
+        },
+        {
+            "id": "pygmalionai/mythalion-13b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Pygmalion: Mythalion 13B"
+        },
+        {
+            "id": "qwen/qwen-110b-chat",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen 1.5 110B Chat"
+        },
+        {
+            "id": "qwen/qwen-2-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen 2 72B Instruct"
+        },
+        {
+            "id": "qwen/qwen-2-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen 2 7B Instruct"
+        },
+        {
+            "id": "qwen/qwen-2-7b-instruct:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen 2 7B Instruct (free)"
+        },
+        {
+            "id": "qwen/qwen-2-vl-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen2-VL 72B Instruct"
+        },
+        {
+            "id": "qwen/qwen-2-vl-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen2-VL 7B Instruct"
+        },
+        {
+            "id": "qwen/qwen-2.5-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen2.5 72B Instruct"
+        },
+        {
+            "id": "qwen/qwen-2.5-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen2.5 7B Instruct"
+        },
+        {
+            "id": "qwen/qwen-72b-chat",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Qwen 1.5 72B Chat"
+        },
+        {
+            "id": "sao10k/fimbulvetr-11b-v2",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Fimbulvetr 11B v2"
+        },
+        {
+            "id": "sao10k/l3-euryale-70b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Llama 3 Euryale 70B v2.1"
+        },
+        {
+            "id": "sao10k/l3-lunaris-8b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Llama 3 8B Lunaris"
+        },
+        {
+            "id": "sao10k/l3.1-euryale-70b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Llama 3.1 Euryale 70B v2.2"
+        },
+        {
+            "id": "sophosympatheia/midnight-rose-70b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Midnight Rose 70B"
+        },
+        {
+            "id": "teknium/openhermes-2.5-mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "OpenHermes 2.5 Mistral 7B"
+        },
+        {
+            "id": "thedrummer/rocinante-12b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Rocinante 12B"
+        },
+        {
+            "id": "undi95/remm-slerp-l2-13b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "ReMM SLERP 13B"
+        },
+        {
+            "id": "undi95/remm-slerp-l2-13b:extended",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "ReMM SLERP 13B (extended)"
+        },
+        {
+            "id": "undi95/toppy-m-7b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Toppy M 7B"
+        },
+        {
+            "id": "undi95/toppy-m-7b:free",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Toppy M 7B (free)"
+        },
+        {
+            "id": "undi95/toppy-m-7b:nitro",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Toppy M 7B (nitro)"
+        },
+        {
+            "id": "x-ai/grok-beta",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "xAI: Grok Beta"
+        },
+        {
+            "id": "xwin-lm/xwin-lm-70b",
+            "object": "model",
+            "provider": {
+                "id": "openrouter"
+            },
+            "name": "Xwin 70B"
+        },
+        {
+            "id": "llama-3.1-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "perplexity"
+            },
+            "name": "Llama 3.1 70B Instruct"
+        },
+        {
+            "id": "llama-3.1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "perplexity"
+            },
+            "name": "Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "llama-3.1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "perplexity"
+            },
+            "name": "Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "llama-3.1-sonar-huge-128k-online",
+            "object": "model",
+            "provider": {
+                "id": "perplexity"
+            },
+            "name": "Llama 3.1 Sonar Huge 128k Online"
+        },
+        {
+            "id": "llama-3.1-sonar-large-128k-chat",
+            "object": "model",
+            "provider": {
+                "id": "perplexity"
+            },
+            "name": "Llama 3.1 Sonar Large 128k Chat"
+        },
+        {
+            "id": "llama-3.1-sonar-large-128k-online",
+            "object": "model",
+            "provider": {
+                "id": "perplexity"
+            },
+            "name": "Llama 3.1 Sonar Large 128k Online"
+        },
+        {
+            "id": "llama-3.1-sonar-small-128k-chat",
+            "object": "model",
+            "provider": {
+                "id": "perplexity"
+            },
+            "name": "Llama 3.1 Sonar Small 128k Chat"
+        },
+        {
+            "id": "llama-3.1-sonar-small-128k-online",
+            "object": "model",
+            "provider": {
+                "id": "perplexity"
+            },
+            "name": "Llama 3.1 Sonar Small 128k Online"
+        },
+        {
+            "id": "codellama-13b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Codellama 13B Instruct"
+        },
+        {
+            "id": "codellama-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Codellama 70B Instruct"
+        },
+        {
+            "id": "codellama-7b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Codellama 7B"
+        },
+        {
+            "id": "codellama-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Codellama 7B Instruct"
+        },
+        {
+            "id": "gemma-2-27b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Gemma 2 27B"
+        },
+        {
+            "id": "gemma-2-27b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Gemma 2 27B Instruct"
+        },
+        {
+            "id": "gemma-2-9b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Gemma 2 9B"
+        },
+        {
+            "id": "gemma-2-9b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Gemma 2 9B Instruct"
+        },
+        {
+            "id": "gemma-2b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Gemma 2B"
+        },
+        {
+            "id": "gemma-2b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Gemma 2B Instruct"
+        },
+        {
+            "id": "gemma-7b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Gemma 7B"
+        },
+        {
+            "id": "gemma-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Gemma 7B Instruct"
+        },
+        {
+            "id": "llama-2-13b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 2 13B"
+        },
+        {
+            "id": "llama-2-13b-chat",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 2 13B Chat"
+        },
+        {
+            "id": "llama-2-70b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 2 70B"
+        },
+        {
+            "id": "llama-2-70b-chat",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 2 70B Chat"
+        },
+        {
+            "id": "llama-2-7b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 2 7B"
+        },
+        {
+            "id": "llama-2-7b-chat",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 2 7B Chat"
+        },
+        {
+            "id": "llama-3-1-8b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 3 1 8B"
+        },
+        {
+            "id": "llama-3-1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 3 1 8B Instruct"
+        },
+        {
+            "id": "llama-3-70b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 3 70B"
+        },
+        {
+            "id": "llama-3-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 3 70B Instruct"
+        },
+        {
+            "id": "llama-3-8b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 3 8B"
+        },
+        {
+            "id": "llama-3-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Llama 3 8B Instruct"
+        },
+        {
+            "id": "mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Mistral 7B"
+        },
+        {
+            "id": "mistral-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Mistral 7B Instruct"
+        },
+        {
+            "id": "mistral-7b-instruct-v0-2",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Mistral 7B Instruct V0 2"
+        },
+        {
+            "id": "mistral-7b-instruct-v0-3",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Mistral 7B Instruct V0 3"
+        },
+        {
+            "id": "mistral-nemo-12b-2407",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Mistral Nemo 12B 2407"
+        },
+        {
+            "id": "mistral-nemo-12b-instruct-2407",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Mistral Nemo 12B Instruct 2407"
+        },
+        {
+            "id": "mixtral-8x7b-instruct-v0-1",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Mixtral 8X7B Instruct V0 1"
+        },
+        {
+            "id": "mixtral-8x7b-v0-1",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Mixtral 8X7B V0 1"
+        },
+        {
+            "id": "phi-2",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Phi 2"
+        },
+        {
+            "id": "phi-3-5-mini-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Phi 3 5 Mini Instruct"
+        },
+        {
+            "id": "phi-3-mini-4k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Phi 3 Mini 4K Instruct"
+        },
+        {
+            "id": "qwen2-1-5b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Qwen2 1 5B"
+        },
+        {
+            "id": "qwen2-1-5b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Qwen2 1 5B Instruct"
+        },
+        {
+            "id": "qwen2-72b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Qwen2 72B"
+        },
+        {
+            "id": "qwen2-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Qwen2 72B Instruct"
+        },
+        {
+            "id": "qwen2-7b",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Qwen2 7B"
+        },
+        {
+            "id": "qwen2-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Qwen2 7B Instruct"
+        },
+        {
+            "id": "solar-1-mini-chat-240612",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Solar 1 Mini Chat 240612"
+        },
+        {
+            "id": "solar-pro-preview-instruct",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Solar Pro Preview Instruct"
+        },
+        {
+            "id": "zephyr-7b-beta",
+            "object": "model",
+            "provider": {
+                "id": "predibase"
+            },
+            "name": "Zephyr 7B Beta"
+        },
+        {
+            "id": "reka-core",
+            "object": "model",
+            "provider": {
+                "id": "reka"
+            },
+            "name": "Reka Core"
+        },
+        {
+            "id": "reka-edge",
+            "object": "model",
+            "provider": {
+                "id": "reka"
+            },
+            "name": "Reka Edge"
+        },
+        {
+            "id": "reka-flash",
+            "object": "model",
+            "provider": {
+                "id": "reka"
+            },
+            "name": "Reka Flash"
+        },
+        {
+            "id": "rerank-2",
+            "object": "model",
+            "provider": {
+                "id": "voyage"
+            },
+            "name": "Rerank 2"
+        },
+        {
+            "id": "rerank-2-lite",
+            "object": "model",
+            "provider": {
+                "id": "voyage"
+            },
+            "name": "Rerank 2 Lite"
+        },
+        {
+            "id": "voyage-3",
+            "object": "model",
+            "provider": {
+                "id": "voyage"
+            },
+            "name": "Voyage 3"
+        },
+        {
+            "id": "voyage-3-lite",
+            "object": "model",
+            "provider": {
+                "id": "voyage"
+            },
+            "name": "Voyage 3 Lite"
+        },
+        {
+            "id": "voyage-code-2",
+            "object": "model",
+            "provider": {
+                "id": "voyage"
+            },
+            "name": "Voyage Code 2"
+        },
+        {
+            "id": "voyage-finance-2",
+            "object": "model",
+            "provider": {
+                "id": "voyage"
+            },
+            "name": "Voyage Finance 2"
+        },
+        {
+            "id": "voyage-law-2",
+            "object": "model",
+            "provider": {
+                "id": "voyage"
+            },
+            "name": "Voyage Law 2"
+        },
+        {
+            "id": "voyage-multilingual-2",
+            "object": "model",
+            "provider": {
+                "id": "voyage"
+            },
+            "name": "Voyage Multilingual 2"
+        },
+        {
+            "id": "bart-large-cnn",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Bart Large Cnn"
+        },
+        {
+            "id": "bge-base-en-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Bge Base En V1.5"
+        },
+        {
+            "id": "bge-large-en-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Bge Large En V1.5"
+        },
+        {
+            "id": "bge-small-en-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Bge Small En V1.5"
+        },
+        {
+            "id": "deepseek-coder-6.7b-base-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Deepseek Coder 6.7B Base Awq"
+        },
+        {
+            "id": "deepseek-coder-6.7b-instruct-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Deepseek Coder 6.7B Instruct Awq"
+        },
+        {
+            "id": "deepseek-math-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Deepseek Math 7B Instruct"
+        },
+        {
+            "id": "detr-resnet-50",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Detr Resnet 50"
+        },
+        {
+            "id": "discolm-german-7b-v1-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Discolm German 7B V1 Awq"
+        },
+        {
+            "id": "distilbert-sst-2-int8",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Distilbert Sst 2 Int8"
+        },
+        {
+            "id": "dreamshaper-8-lcm",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Dreamshaper 8 Lcm"
+        },
+        {
+            "id": "falcon-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Falcon 7B Instruct"
+        },
+        {
+            "id": "flux-1-schnell",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Flux 1 Schnell"
+        },
+        {
+            "id": "gemma-2b-it-lora",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Gemma 2B It Lora"
+        },
+        {
+            "id": "gemma-7b-it",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Gemma 7B It"
+        },
+        {
+            "id": "gemma-7b-it-lora",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Gemma 7B It Lora"
+        },
+        {
+            "id": "hermes-2-pro-mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Hermes 2 Pro Mistral 7B"
+        },
+        {
+            "id": "llama-2-13b-chat-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 2 13B Chat Awq"
+        },
+        {
+            "id": "llama-2-7b-chat-fp16",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 2 7B Chat Fp16"
+        },
+        {
+            "id": "llama-2-7b-chat-hf-lora",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 2 7B Chat Hf Lora"
+        },
+        {
+            "id": "llama-2-7b-chat-int8",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 2 7B Chat Int8"
+        },
+        {
+            "id": "llama-3-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3 8B Instruct"
+        },
+        {
+            "id": "llama-3-8b-instruct-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3 8B Instruct Awq"
+        },
+        {
+            "id": "llama-3.1-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3.1 70B Instruct"
+        },
+        {
+            "id": "llama-3.1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "llama-3.1-8b-instruct-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3.1 8B Instruct Awq"
+        },
+        {
+            "id": "llama-3.1-8b-instruct-fast",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3.1 8B Instruct Fast"
+        },
+        {
+            "id": "llama-3.1-8b-instruct-fp8",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3.1 8B Instruct Fp8"
+        },
+        {
+            "id": "llama-3.2-11b-vision-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3.2 11B Vision Instruct"
+        },
+        {
+            "id": "llama-3.2-1b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3.2 1B Instruct"
+        },
+        {
+            "id": "llama-3.2-3b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llama 3.2 3B Instruct"
+        },
+        {
+            "id": "llamaguard-7b-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llamaguard 7B Awq"
+        },
+        {
+            "id": "llava-1.5-7b-hf",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Llava 1.5 7B Hf"
+        },
+        {
+            "id": "m2m100-1.2b",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "M2M100 1.2B"
+        },
+        {
+            "id": "meta-llama-3-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Meta Llama 3 8B Instruct"
+        },
+        {
+            "id": "mistral-7b-instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Mistral 7B Instruct V0.1"
+        },
+        {
+            "id": "mistral-7b-instruct-v0.1-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Mistral 7B Instruct V0.1 Awq"
+        },
+        {
+            "id": "mistral-7b-instruct-v0.2",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Mistral 7B Instruct V0.2"
+        },
+        {
+            "id": "mistral-7b-instruct-v0.2-lora",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Mistral 7B Instruct V0.2 Lora"
+        },
+        {
+            "id": "neural-chat-7b-v3-1-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Neural Chat 7B V3 1 Awq"
+        },
+        {
+            "id": "openchat-3.5-0106",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Openchat 3.5 0106"
+        },
+        {
+            "id": "openhermes-2.5-mistral-7b-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Openhermes 2.5 Mistral 7B Awq"
+        },
+        {
+            "id": "phi-2",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Phi 2"
+        },
+        {
+            "id": "qwen1.5-0.5b-chat",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Qwen1.5 0.5B Chat"
+        },
+        {
+            "id": "qwen1.5-1.8b-chat",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Qwen1.5 1.8B Chat"
+        },
+        {
+            "id": "qwen1.5-14b-chat-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Qwen1.5 14B Chat Awq"
+        },
+        {
+            "id": "qwen1.5-7b-chat-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Qwen1.5 7B Chat Awq"
+        },
+        {
+            "id": "resnet-50",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Resnet 50"
+        },
+        {
+            "id": "sqlcoder-7b-2",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Sqlcoder 7B 2"
+        },
+        {
+            "id": "stable-diffusion-v1-5-img2img",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Stable Diffusion V1 5 Img2Img"
+        },
+        {
+            "id": "stable-diffusion-v1-5-inpainting",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Stable Diffusion V1 5 Inpainting"
+        },
+        {
+            "id": "stable-diffusion-xl-base-1.0",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Stable Diffusion Xl Base 1.0"
+        },
+        {
+            "id": "stable-diffusion-xl-lightning",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Stable Diffusion Xl Lightning"
+        },
+        {
+            "id": "starling-lm-7b-beta",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Starling Lm 7B Beta"
+        },
+        {
+            "id": "tinyllama-1.1b-chat-v1.0",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Tinyllama 1.1B Chat V1.0"
+        },
+        {
+            "id": "uform-gen2-qwen-500m",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Uform Gen2 Qwen 500M"
+        },
+        {
+            "id": "una-cybertron-7b-v2-bf16",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Una Cybertron 7B V2 Bf16"
+        },
+        {
+            "id": "whisper",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Whisper"
+        },
+        {
+            "id": "whisper-tiny-en",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Whisper Tiny En"
+        },
+        {
+            "id": "zephyr-7b-beta-awq",
+            "object": "model",
+            "provider": {
+                "id": "workers-ai"
+            },
+            "name": "Zephyr 7B Beta Awq"
+        },
+        {
+            "id": "glm-3-turbo",
+            "object": "model",
+            "provider": {
+                "id": "zhipu"
+            },
+            "name": "GLM-3 Turbo"
+        },
+        {
+            "id": "glm-4",
+            "object": "model",
+            "provider": {
+                "id": "zhipu"
+            },
+            "name": "GLM-4"
+        },
+        {
+            "id": "glm-4-0520",
+            "object": "model",
+            "provider": {
+                "id": "zhipu"
+            },
+            "name": "GLM-4 0520"
+        },
+        {
+            "id": "glm-4-air",
+            "object": "model",
+            "provider": {
+                "id": "zhipu"
+            },
+            "name": "GLM-4 Air"
+        },
+        {
+            "id": "glm-4-airx",
+            "object": "model",
+            "provider": {
+                "id": "zhipu"
+            },
+            "name": "GLM-4 AirX"
+        },
+        {
+            "id": "glm-4-flashx",
+            "object": "model",
+            "provider": {
+                "id": "zhipu"
+            },
+            "name": "GLM-4 FlashX"
+        },
+        {
+            "id": "glm-4-long",
+            "object": "model",
+            "provider": {
+                "id": "zhipu"
+            },
+            "name": "GLM-4 Long"
+        },
+        {
+            "id": "glm-4-plus",
+            "object": "model",
+            "provider": {
+                "id": "zhipu"
+            },
+            "name": "GLM-4 Plus"
+        },
+        {
+            "id": "mistralai/Mixtral-8x22B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "anyscale"
+            },
+            "name": "Mixtral 8x22B Instruct v0.1"
+        },
+        {
+            "id": "Llama-3.2-3B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 3.2 3B Instruct"
+        },
+        {
+            "id": "Llama-3.2-1B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 3.2 1B Instruct"
+        },
+        {
+            "id": "Llama-Guard-3-11B-Vision",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama Guard 3 11B Vision"
+        },
+        {
+            "id": "Llama-3.2-11B-Vision-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 3.2 11B Vision Instruct"
+        },
+        {
+            "id": "Llama-Guard-3-1B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama Guard 3 1B"
+        },
+        {
+            "id": "Llama-3.2-90B-Vision-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 3.2 90B Vision Instruct"
+        },
+        {
+            "id": "Llama-2-7b",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 2 7B"
+        },
+        {
+            "id": "Llama-2-70b",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 2 70B"
+        },
+        {
+            "id": "Llama-2-13b",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 2 13B"
+        },
+        {
+            "id": "Llama-2-7b-chat",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 2 7B Chat"
+        },
+        {
+            "id": "Llama-2-70b-chat",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 2 70B Chat"
+        },
+        {
+            "id": "Llama-2-13b-chat",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Llama 2 13B Chat"
+        },
+        {
+            "id": "CodeLlama-7b-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 7B HF"
+        },
+        {
+            "id": "CodeLlama-7b-Python-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 7B Python HF"
+        },
+        {
+            "id": "CodeLlama-7b-Instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 7B Instruct HF"
+        },
+        {
+            "id": "CodeLlama-34b-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 34B HF"
+        },
+        {
+            "id": "CodeLlama-34b-Python-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 34B Python HF"
+        },
+        {
+            "id": "CodeLlama-34b-Instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 34B Instruct HF"
+        },
+        {
+            "id": "CodeLlama-13b-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 13B HF"
+        },
+        {
+            "id": "CodeLlama-13b-Python-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 13B Python HF"
+        },
+        {
+            "id": "CodeLlama-13b-Instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 13B Instruct HF"
+        },
+        {
+            "id": "Prompt-Guard-86M",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Prompt Guard 86M"
+        },
+        {
+            "id": "Meta-Llama-3.1-405B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Meta Llama 3.1 405B Instruct"
+        },
+        {
+            "id": "Ministral-3B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Ministral 3B"
+        },
+        {
+            "id": "Mistral-large-2407",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mistral Large 2407"
+        },
+        {
+            "id": "Mistral-Nemo",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mistral Nemo"
+        },
+        {
+            "id": "mistralai-Mixtral-8x7B-v01",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mixtral 8x7B v01"
+        },
+        {
+            "id": "mistralai-Mixtral-8x7B-Instruct-v01",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mixtral 8x7B Instruct v01"
+        },
+        {
+            "id": "mistralai-Mixtral-8x22B-v0-1",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mixtral 8x22B v0-1"
+        },
+        {
+            "id": "mistralai-Mixtral-8x22B-Instruct-v0-1",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mixtral 8x22B Instruct v0-1"
+        },
+        {
+            "id": "mistralai-Mistral-7B-v01",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mistral 7B v01"
+        },
+        {
+            "id": "mistralai-Mistral-7B-Instruct-v0-2",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mistral 7B Instruct v0-2"
+        },
+        {
+            "id": "mistral-community-Mixtral-8x22B-v0-1",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mixtral 8x22B v0-1"
+        },
+        {
+            "id": "mistralai-Mistral-7B-Instruct-v01",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mistral 7B Instruct v01"
+        },
+        {
+            "id": "Mistral-small",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mistral Small"
+        },
+        {
+            "id": "Mistral-large",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Mistral Large"
+        },
+        {
+            "id": "Nemotron-3-8B-Chat-SteerLM",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Nemotron 3 8B Chat SteerLM"
+        },
+        {
+            "id": "Nemotron-3-8B-Chat-RLHF",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Nemotron 3 8B Chat RLHF"
+        },
+        {
+            "id": "Nemotron-3-8B-Chat-SFT",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Nemotron 3 8B Chat SFT"
+        },
+        {
+            "id": "AI21-Jamba-1.5-Mini",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "AI21 Jamba 1.5 Mini"
+        },
+        {
+            "id": "AI21-Jamba-1.5-Large",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "AI21 Jamba 1.5 Large"
+        },
+        {
+            "id": "Deci-DeciLM-7B-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DeciLM 7B Instruct"
+        },
+        {
+            "id": "Deci-DeciLM-7B",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DeciLM 7B"
+        },
+        {
+            "id": "Deci-DeciCoder-1b",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DeciCoder 1B"
+        },
+        {
+            "id": "TimeGEN-1",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "TimeGEN 1"
+        },
+        {
+            "id": "jais-30b-chat",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Jais 30B Chat"
+        },
+        {
+            "id": "Cohere-command-r-plus-08-2024",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Cohere Command R+ 08-2024"
+        },
+        {
+            "id": "Cohere-command-r-08-2024",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Cohere Command R 08-2024"
+        },
+        {
+            "id": "Cohere-rerank-v3-multilingual",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Cohere Rerank v3 Multilingual"
+        },
+        {
+            "id": "Cohere-rerank-v3-english",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Cohere Rerank v3 English"
+        },
+        {
+            "id": "Cohere-embed-v3-multilingual",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Cohere Embed v3 Multilingual"
+        },
+        {
+            "id": "Cohere-embed-v3-english",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Cohere Embed v3 English"
+        },
+        {
+            "id": "Cohere-command-r-plus",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Cohere Command R+"
+        },
+        {
+            "id": "Cohere-command-r",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Cohere Command R"
+        },
+        {
+            "id": "databricks-dolly-v2-12b",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Dolly v2 12B"
+        },
+        {
+            "id": "snowflake-arctic-base",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Snowflake Arctic Base"
+        },
+        {
+            "id": "ALLaM-2-7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "ALLaM 2 7B Instruct"
+        },
+        {
+            "id": "MedImageParse",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "MedImageParse"
+        },
+        {
+            "id": "MedImageInsight",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "MedImageInsight"
+        },
+        {
+            "id": "CxrReportGen",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CxrReportGen"
+        },
+        {
+            "id": "Virchow2",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Virchow2"
+        },
+        {
+            "id": "Prism",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Prism"
+        },
+        {
+            "id": "Virchow",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Virchow"
+        },
+        {
+            "id": "BiomedCLIP-PubMedBERT_256-vit_base_patch16_224",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "BiomedCLIP PubMedBERT_256-vit_base_patch16_224"
+        },
+        {
+            "id": "microsoft-llava-med-v1.5-mistral-7b",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Microsoft LLaMA-Med v1.5 Mistral 7B"
+        },
+        {
+            "id": "snowflake-arctic-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Snowflake Arctic Instruct"
+        },
+        {
+            "id": "facebook-dinov2-base-imagenet1k-1-layer",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DinoV2 Base ImageNet1K 1-Layer"
+        },
+        {
+            "id": "CodeLlama-70b-Python-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 70B Python HF"
+        },
+        {
+            "id": "microsoft-phi-1-5",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Microsoft Phi-1.5"
+        },
+        {
+            "id": "CodeLlama-70b-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 70B HF"
+        },
+        {
+            "id": "CodeLlama-70b-Instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "CodeLlama 70B Instruct HF"
+        },
+        {
+            "id": "deci-decidiffusion-v1-0",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Deci Diffusion v1.0"
+        },
+        {
+            "id": "facebook-deit-base-patch16-224",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DEiT Base Patch16 224"
+        },
+        {
+            "id": "openai-clip-vit-large-patch14",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "OpenAI CLIP ViT-Large Patch14"
+        },
+        {
+            "id": "openai-clip-vit-base-patch32",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "OpenAI CLIP ViT-Base Patch32"
+        },
+        {
+            "id": "facebook-sam-vit-large",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "SAM ViT-Large"
+        },
+        {
+            "id": "facebook-sam-vit-huge",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "SAM ViT-Huge"
+        },
+        {
+            "id": "facebook-sam-vit-base",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "SAM ViT-Base"
+        },
+        {
+            "id": "OpenAI-CLIP-Image-Text-Embeddings-vit-base-patch32",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "OpenAI CLIP Image Text Embeddings ViT-Base Patch32"
+        },
+        {
+            "id": "microsoft-phi-2",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Microsoft Phi-2"
+        },
+        {
+            "id": "microsoft-swinv2-base-patch4-window12-192-22k",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "SwinV2 Base Patch4 Window12 192 22K"
+        },
+        {
+            "id": "microsoft-beit-base-patch16-224-pt22k-ft22k",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "BEiT Base Patch16 224 PT22K FT22K"
+        },
+        {
+            "id": "OpenAI-CLIP-Image-Text-Embeddings-ViT-Large-Patch14-336",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "OpenAI CLIP Image Text Embeddings ViT-Large Patch14 336"
+        },
+        {
+            "id": "Facebook-DinoV2-Image-Embeddings-ViT-Giant",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DinoV2 Image Embeddings ViT-Giant"
+        },
+        {
+            "id": "Facebook-DinoV2-Image-Embeddings-ViT-Base",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DinoV2 Image Embeddings ViT-Base"
+        },
+        {
+            "id": "microsoft-Orca-2-7b",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Microsoft Orca 2 7B"
+        },
+        {
+            "id": "microsoft-Orca-2-13b",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "Microsoft Orca 2 13B"
+        },
+        {
+            "id": "databricks-dbrx-instruct",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DBRX Instruct"
+        },
+        {
+            "id": "databricks-dbrx-base",
+            "object": "model",
+            "provider": {
+                "id": "azure"
+            },
+            "name": "DBRX Base"
+        },
+        {
+            "id": "stable-diffusion-3.5-turbo-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 3.5 Turbo Text-to-Image"
+        },
+        {
+            "id": "llama3-70b-8192",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3 70B 8192"
+        },
+        {
+            "id": "llama3-8b-8192",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Llama 3 8B 8192"
+        },
+        {
+            "id": "mixtral-8x7b-32768",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Mixtral 8x7B 32768"
+        },
+        {
+            "id": "whisper-large-v3",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Whisper Large v3"
+        },
+        {
+            "id": "whisper-large-v3-turbo",
+            "object": "model",
+            "provider": {
+                "id": "groq"
+            },
+            "name": "Whisper Large v3 Turbo"
+        },
+        {
+            "id": "yi-vision",
+            "object": "model",
+            "provider": {
+                "id": "lingyi"
+            },
+            "name": "Yi Vision"
+        },
+        {
+            "id": "open-mixtral-8x7b",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Mixtral 8x7B"
+        },
+        {
+            "id": "open-mixtral-8x22b",
+            "object": "model",
+            "provider": {
+                "id": "mistral-ai"
+            },
+            "name": "Mixtral 8x22B"
+        },
+        {
+            "id": "stable-diffusion-3.5-large-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 3.5 Large Text-to-Image"
+        },
+        {
+            "id": "flux-1.1-pro",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux 1.1 Pro"
+        },
+        {
+            "id": "Simple_Vector_Flux",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Simple Vector Flux"
+        },
+        {
+            "id": "ideogram-txt-2-img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Ideogram Text-to-Image"
+        },
+        {
+            "id": "fast-flux-schnell",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Fast Flux Schnell"
+        },
+        {
+            "id": "flux-realism-lora",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux Realism LoRA"
+        },
+        {
+            "id": "flux-dev",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux Dev"
+        },
+        {
+            "id": "flux-schnell",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux Schnell"
+        },
+        {
+            "id": "flux-pro",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux Pro"
+        },
+        {
+            "id": "sdxl1.0-realdream-pony-v9",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 RealDream Pony v9"
+        },
+        {
+            "id": "sdxl1.0-realdream-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 RealDream Lightning"
+        },
+        {
+            "id": "playground-v2.5",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Playground v2.5"
+        },
+        {
+            "id": "background-eraser",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Background Eraser"
+        },
+        {
+            "id": "stable-diffusion-3-medium-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 3 Medium Text-to-Image"
+        },
+        {
+            "id": "sdxl1.0-yamers-realistic",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Yamers Realistic"
+        },
+        {
+            "id": "sdxl1.0-newreality-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 NewReality Lightning"
+        },
+        {
+            "id": "sdxl1.0-dreamshaper-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Dreamshaper Lightning"
+        },
+        {
+            "id": "sdxl1.0-colossus-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Colossus Lightning"
+        },
+        {
+            "id": "sdxl1.0-samaritan-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Samaritan Lightning"
+        },
+        {
+            "id": "sdxl1.0-realism-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Realism Lightning"
+        },
+        {
+            "id": "sdxl1.0-protovis-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Protovis Lightning"
+        },
+        {
+            "id": "sdxl1.0-nightvis-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Nightvis Lightning"
+        },
+        {
+            "id": "sdxl1.0-wildcard-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Wildcard Lightning"
+        },
+        {
+            "id": "sdxl1.0-dyanvis-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Dyanvis Lightning"
+        },
+        {
+            "id": "sdxl1.0-juggernaut-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Juggernaut Lightning"
+        },
+        {
+            "id": "sdxl1.0-realvis-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Realvis Lightning"
+        },
+        {
+            "id": "sdxl1.0-samaritan-3d",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Samaritan 3D"
+        },
+        {
+            "id": "segmind-vega",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Segmind Vega"
+        },
+        {
+            "id": "segmind-vega-rt-v1",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Segmind Vega RT v1"
+        },
+        {
+            "id": "ssd-1b",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SSD 1B"
+        },
+        {
+            "id": "sdxl1.0-timeless",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Timeless"
+        },
+        {
+            "id": "sdxl1.0-zavychroma",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Zavychroma"
+        },
+        {
+            "id": "sdxl1.0-realvis",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Realvis"
+        },
+        {
+            "id": "sdxl1.0-dreamshaper",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Dreamshaper"
+        },
+        {
+            "id": "sd2.1-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 2.1 Text-to-Image"
+        },
+        {
+            "id": "sdxl-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL Text-to-Image"
+        },
+        {
+            "id": "tinysd1.5-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "TinySD 1.5 Text-to-Image"
+        },
+        {
+            "id": "smallsd1.5-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SmallSD 1.5 Text-to-Image"
+        },
+        {
+            "id": "sdxl1.0-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL 1.0 Text-to-Image"
+        },
+        {
+            "id": "sd1.5-scifi",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Sci-Fi"
+        },
+        {
+            "id": "sd1.5-samaritan_3d",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Samaritan 3D"
+        },
+        {
+            "id": "sd1.5-rpg",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 RPG"
+        },
+        {
+            "id": "sd1.5-reliberate",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 ReLiberate"
+        },
+        {
+            "id": "sd1.5-realisticvision",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Realistic Vision"
+        },
+        {
+            "id": "sd1.5-rcnz",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 RCNZ"
+        },
+        {
+            "id": "sd1.5-paragon",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Paragon"
+        },
+        {
+            "id": "sd1.5-manmarumix",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Manmarumix"
+        },
+        {
+            "id": "sd1.5-majicmix",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Majicmix"
+        },
+        {
+            "id": "sd1.5-juggernaut",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Juggernaut"
+        },
+        {
+            "id": "sd1.5-fruitfusion",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 FruitFusion"
+        },
+        {
+            "id": "sd1.5-flat2d",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Flat2D"
+        },
+        {
+            "id": "sd1.5-fantassifiedicons",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 FantassifiedIcons"
+        },
+        {
+            "id": "sd1.5-epicrealism",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Epic Realism"
+        },
+        {
+            "id": "sd1.5-edgeofrealism",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Edge of Realism"
+        },
+        {
+            "id": "sd1.5-dvrach",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Dvrach"
+        },
+        {
+            "id": "sd1.5-dreamshaper",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Dreamshaper"
+        },
+        {
+            "id": "sd1.5-deepspacediffusion",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 DeepSpaceDiffusion"
+        },
+        {
+            "id": "sd1.5-cyberrealistic",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 CyberRealistic"
+        },
+        {
+            "id": "sd1.5-cuterichstyle",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 CuteRichStyle"
+        },
+        {
+            "id": "sd1.5-colorful",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Colorful"
+        },
+        {
+            "id": "sd1.5-allinonepixel",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 AllInOnePixel"
+        },
+        {
+            "id": "sd1.5-526mix",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 526mix"
+        },
+        {
+            "id": "qrsd1.5-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "QRS 1.5 Text-to-Image"
+        },
+        {
+            "id": "potraitsd1.5-txt2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "PortraitSD 1.5 Text-to-Image"
+        },
+        {
+            "id": "kandinsky2.1-txt2im",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Kandinsky 2.1 Text-to-Image"
+        },
+        {
+            "id": "sd1.5-revanimated",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Reanimated"
+        },
+        {
+            "id": "face-detailer",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Face Detailer"
+        },
+        {
+            "id": "expression-editor",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Expression Editor"
+        },
+        {
+            "id": "consistent-character-with-pose",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Consistent Character with Pose"
+        },
+        {
+            "id": "consistent-character-AI-neolemon-v3",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Consistent Character AI Neolemon v3"
+        },
+        {
+            "id": "flux-pulid",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux Pulid"
+        },
+        {
+            "id": "flux-ipadapter",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux IPAdapter"
+        },
+        {
+            "id": "flux-inpaint",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux Inpaint"
+        },
+        {
+            "id": "flux-controlnet",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux ControlNet"
+        },
+        {
+            "id": "text-overlay",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Text Overlay"
+        },
+        {
+            "id": "consistent-character-AI-neolemon-v2",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Consistent Character AI Neolemon v2"
+        },
+        {
+            "id": "sam-v2-image",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SAM v2 Image"
+        },
+        {
+            "id": "consistent-character-ai-neolemon",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Consistent Character AI Neolemon"
+        },
+        {
+            "id": "flux-img2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Flux Img2Img"
+        },
+        {
+            "id": "ai-product-photo-editor",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "AI Product Photo Editor"
+        },
+        {
+            "id": "sd3-med-tile",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SD 3 Med Tile"
+        },
+        {
+            "id": "sd3-med-canny",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SD 3 Med Canny"
+        },
+        {
+            "id": "sd3-med-pose",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SD 3 Med Pose"
+        },
+        {
+            "id": "superimpose-v2",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Superimpose v2"
+        },
+        {
+            "id": "aura-flow",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Aura Flow"
+        },
+        {
+            "id": "kolors",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Kolors"
+        },
+        {
+            "id": "superimpose",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Superimpose"
+        },
+        {
+            "id": "sdxl-img2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL Img2Img"
+        },
+        {
+            "id": "sdxl-controlnet",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL ControlNet"
+        },
+        {
+            "id": "storydiffusion",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "StoryDiffusion"
+        },
+        {
+            "id": "omni-zero",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Omni Zero"
+        },
+        {
+            "id": "ic-light",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "IC Light"
+        },
+        {
+            "id": "automatic-mask-generator",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Automatic Mask Generator"
+        },
+        {
+            "id": "magic-eraser",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Magic Eraser"
+        },
+        {
+            "id": "inpaint-mask-maker",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Inpaint Mask Maker"
+        },
+        {
+            "id": "clarity-upscaler",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Clarity Upscaler"
+        },
+        {
+            "id": "consistent-character",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Consistent Character"
+        },
+        {
+            "id": "idm-vton",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "IDM-VTON"
+        },
+        {
+            "id": "fooocus",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Fooocus"
+        },
+        {
+            "id": "style-transfer",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Style Transfer"
+        },
+        {
+            "id": "become-image",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Become Image"
+        },
+        {
+            "id": "illusion-diffusion-hq",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Illusion Diffusion HQ"
+        },
+        {
+            "id": "pulid-base",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Pulid Base"
+        },
+        {
+            "id": "pulid-lightning",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Pulid Lightning"
+        },
+        {
+            "id": "fashion-ai",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Fashion AI"
+        },
+        {
+            "id": "face-to-many",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Face-to-Many"
+        },
+        {
+            "id": "face-to-sticker",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Face-to-Sticker"
+        },
+        {
+            "id": "material-transfer",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Material Transfer"
+        },
+        {
+            "id": "faceswap-v2",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "FaceSwap v2"
+        },
+        {
+            "id": "insta-depth",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Insta Depth"
+        },
+        {
+            "id": "bg-removal-v2",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "BG Removal v2"
+        },
+        {
+            "id": "focus-outpaint",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Focus Outpaint"
+        },
+        {
+            "id": "instantid",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Instantid"
+        },
+        {
+            "id": "ip-sdxl-openpose",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "IP-SDXL OpenPose"
+        },
+        {
+            "id": "ip-sdxl-canny",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "IP-SDXL Canny"
+        },
+        {
+            "id": "ip-sdxl-depth",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "IP-SDXL Depth"
+        },
+        {
+            "id": "ssd-img2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SSD Img2Img"
+        },
+        {
+            "id": "sdxl-openpose",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SDXL OpenPose"
+        },
+        {
+            "id": "ssd-depth",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SSD Depth"
+        },
+        {
+            "id": "ssd-canny",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SSD Canny"
+        },
+        {
+            "id": "w2imgsd1.5-img2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "W2ImgSD 1.5 Img2Img"
+        },
+        {
+            "id": "sd1.5-img2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Img2Img"
+        },
+        {
+            "id": "sd1.5-outpaint",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 Outpaint"
+        },
+        {
+            "id": "sd1.5-controlnet-softedge",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 ControlNet Softedge"
+        },
+        {
+            "id": "sd1.5-controlnet-scribble",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 ControlNet Scribble"
+        },
+        {
+            "id": "sd1.5-controlnet-depth",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 ControlNet Depth"
+        },
+        {
+            "id": "sd1.5-controlnet-canny",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 ControlNet Canny"
+        },
+        {
+            "id": "codeformer",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "CodeFormer"
+        },
+        {
+            "id": "sam-img2img",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "SAM Img2Img"
+        },
+        {
+            "id": "sd2.1-faceswapper",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 2.1 FaceSwapper"
+        },
+        {
+            "id": "bg-removal",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "BG Removal"
+        },
+        {
+            "id": "esrgan",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "ESRGAN"
+        },
+        {
+            "id": "sd1.5-controlnet-openpose",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Stable Diffusion 1.5 ControlNet OpenPose"
+        },
+        {
+            "id": "o1-preview",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "O1 Preview"
+        },
+        {
+            "id": "llama-v3p1-405b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Llama V3P1 405B Instruct"
+        },
+        {
+            "id": "llama-v3p1-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Llama V3P1 70B Instruct"
+        },
+        {
+            "id": "llama-v3p1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Llama V3P1 8B Instruct"
+        },
+        {
+            "id": "claude-3-haiku",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Claude 3 Haiku"
+        },
+        {
+            "id": "claude-3-opus",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Claude 3 Opus"
+        },
+        {
+            "id": "gemini-1.5-pro",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Gemini 1.5 Pro"
+        },
+        {
+            "id": "gemini-1.5-flash",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Gemini 1.5 Flash"
+        },
+        {
+            "id": "claude-3.5-sonnet",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Claude 3.5 Sonnet"
+        },
+        {
+            "id": "llava-13b",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "LLaMA 13B"
+        },
+        {
+            "id": "gpt-4-turbo",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "GPT-4 Turbo"
+        },
+        {
+            "id": "gpt-4o",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "GPT-4 0"
+        },
+        {
+            "id": "gpt-4",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "GPT-4"
+        },
+        {
+            "id": "mixtral-8x7b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Mixtral 8x7B Instruct"
+        },
+        {
+            "id": "mixtral-8x22b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Mixtral 8x22B Instruct"
+        },
+        {
+            "id": "llama-v3-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Llama V3 8B Instruct"
+        },
+        {
+            "id": "llama-v3-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "Segmind"
+            },
+            "name": "Llama V3 70B Instruct"
+        },
+        {
+            "id": "moonshot-v1-8k",
+            "object": "model",
+            "provider": {
+                "id": "moonshot"
+            },
+            "name": "Moonshot (8k Context)"
+        },
+        {
+            "id": "moonshot-v1-32k",
+            "object": "model",
+            "provider": {
+                "id": "moonshot"
+            },
+            "name": "Moonshot (132k Context)"
+        },
+        {
+            "id": "moonshot-v1-128k",
+            "object": "model",
+            "provider": {
+                "id": "moonshot"
+            },
+            "name": "Moonshot (128k Context)"
+        },
+        {
+            "id": "nomic-embed-vision-v1",
+            "object": "model",
+            "provider": {
+                "id": "nomic"
+            },
+            "name": "Nomic Embed vision v1"
+        },
+        {
+            "id": "nomic-embed-vision-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "nomic"
+            },
+            "name": "Nomic Embed vision v1.5"
+        },
+        {
+            "id": "nomic-embed-text-v1",
+            "object": "model",
+            "provider": {
+                "id": "nomic"
+            },
+            "name": "Nomic Embed v1"
+        },
+        {
+            "id": "nomic-embed-text-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "nomic"
+            },
+            "name": "Nomic Embed v1.5"
+        },
+        {
+            "id": "deepseek-coder-v2-lite-instruct",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "DeepSeek Coder v2 Lite Instruct"
+        },
+        {
+            "id": "Meta-Llama-3.2-1B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "sambanova"
+            },
+            "name": "Llama 3.2 1B"
+        },
+        {
+            "id": "Meta-Llama-3.2-3B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "sambanova"
+            },
+            "name": "Llama 3.2 3B"
+        },
+        {
+            "id": "Llama-3.2-11B-Vision-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "sambanova"
+            },
+            "name": "Llama 3.2 11B"
+        },
+        {
+            "id": "Llama-3.2-90B-Vision-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "sambanova"
+            },
+            "name": "Llama 3.2 90B"
+        },
+        {
+            "id": "Meta-Llama-3.1-8B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "sambanova"
+            },
+            "name": "Llama 3.1 8B"
+        },
+        {
+            "id": "Meta-Llama-3.1-70B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "sambanova"
+            },
+            "name": "Llama 3.1 70B"
+        },
+        {
+            "id": "Meta-Llama-3.1-405B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "sambanova"
+            },
+            "name": "Llama 3.1 405B"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3.1 8B Instruct Turbo"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3.1 70B Instruct Turbo"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3.1 405B Instruct Turbo"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3-8B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3 8B Instruct Turbo"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3-70B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3 70B Instruct Turbo"
+        },
+        {
+            "id": "meta-llama/Llama-3.2-3B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3.2 3B Instruct Turbo"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3-8B-Instruct-Lite",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3 8B Instruct Lite"
+        },
+        {
+            "id": "meta-llama/Meta-Llama-3-70B-Instruct-Lite",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3 70B Instruct Lite"
+        },
+        {
+            "id": "meta-llama/Llama-3-8b-chat-hf",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3 8B Instruct Reference"
+        },
+        {
+            "id": "meta-llama/Llama-3-70b-chat-hf",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3 70B Instruct Reference"
+        },
+        {
+            "id": "microsoft/WizardLM-2-8x22B",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "WizardLM-2 8x22B"
+        },
+        {
+            "id": "google/gemma-2-27b-it",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Gemma 2 27B"
+        },
+        {
+            "id": "google/gemma-2-9b-it",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Gemma 2 9B"
+        },
+        {
+            "id": "databricks/dbrx-instruct",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "DBRX Instruct"
+        },
+        {
+            "id": "deepseek-ai/deepseek-llm-67b-chat",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "DeepSeek LLM Chat (67B)"
+        },
+        {
+            "id": "google/gemma-2b-it",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Gemma Instruct (2B)"
+        },
+        {
+            "id": "Gryphe/MythoMax-L2-13b",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "MythoMax-L2 (13B)"
+        },
+        {
+            "id": "meta-llama/Llama-2-13b-chat-hf",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "LLaMA-2 Chat (13B)"
+        },
+        {
+            "id": "mistralai/Mistral-7B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Mistral (7B) Instruct"
+        },
+        {
+            "id": "mistralai/Mistral-7B-Instruct-v0.2",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Mistral (7B) Instruct v0.2"
+        },
+        {
+            "id": "mistralai/Mistral-7B-Instruct-v0.3",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Mistral (7B) Instruct v0.3"
+        },
+        {
+            "id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Mixtral-8x7B Instruct (46.7B)"
+        },
+        {
+            "id": "mistralai/Mixtral-8x22B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Mixtral-8x22B Instruct (141B)"
+        },
+        {
+            "id": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Nous Hermes 2 - Mixtral 8x7B-DPO (46.7B)"
+        },
+        {
+            "id": "Qwen/Qwen2.5-7B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Qwen 2.5 7B Instruct Turbo"
+        },
+        {
+            "id": "Qwen/Qwen2.5-72B-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Qwen 2.5 72B Instruct Turbo"
+        },
+        {
+            "id": "Qwen/Qwen2-72B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Qwen 2 Instruct (72B)"
+        },
+        {
+            "id": "togethercomputer/StripedHyena-Nous-7B",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "StripedHyena Nous (7B)"
+        },
+        {
+            "id": "upstage/SOLAR-10.7B-Instruct-v1.0",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Upstage SOLAR Instruct v1 (11B)"
+        },
+        {
+            "id": "black-forest-labs/FLUX.1-schnell-Free",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Flux.1 [schnell] (free)*"
+        },
+        {
+            "id": "black-forest-labs/FLUX.1-schnell",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Flux.1 [schnell] (Turbo)"
+        },
+        {
+            "id": "black-forest-labs/FLUX.1.1-pro",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Flux1.1 [pro]"
+        },
+        {
+            "id": "black-forest-labs/FLUX.1-pro",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Flux.1 [pro]"
+        },
+        {
+            "id": "stabilityai/stable-diffusion-xl-base-1.0",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Stable Diffusion XL 1.0"
+        },
+        {
+            "id": "togethercomputer/m2-bert-80M-2k-retrieval",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "M2-BERT-80M-2K-Retrieval"
+        },
+        {
+            "id": "togethercomputer/m2-bert-80M-8k-retrieval",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "M2-BERT-80M-8K-Retrieval"
+        },
+        {
+            "id": "togethercomputer/m2-bert-80M-32k-retrieval",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "M2-BERT-80M-32K-Retrieval"
+        },
+        {
+            "id": "WhereIsAI/UAE-Large-V1",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "UAE-Large-v1"
+        },
+        {
+            "id": "BAAI/bge-large-en-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "BGE-Large-EN-v1.5"
+        },
+        {
+            "id": "BAAI/bge-base-en-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "BGE-Base-EN-v1.5"
+        },
+        {
+            "id": "sentence-transformers/msmarco-bert-base-dot-v5",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Sentence-BERT"
+        },
+        {
+            "id": "bert-base-uncased",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "BERT"
+        },
+        {
+            "id": "meta-llama/Llama-Vision-Free",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "(Free) Llama 3.2 11B Vision Instruct Turbo*"
+        },
+        {
+            "id": "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3.2 11B Vision Instruct Turbo"
+        },
+        {
+            "id": "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama 3.2 90B Vision Instruct Turbo"
+        },
+        {
+            "id": "meta-llama/Llama-2-70b-hf",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "LLaMA-2 (70B)"
+        },
+        {
+            "id": "mistralai/Mistral-7B-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Mistral (7B)"
+        },
+        {
+            "id": "mistralai/Mixtral-8x7B-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Mixtral-8x7B (46.7B)"
+        },
+        {
+            "id": "Meta-Llama/Llama-Guard-7b",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "Llama Guard (7B)"
+        },
+        {
+            "id": "Salesforce/Llama-Rank-v1",
+            "object": "model",
+            "provider": {
+                "id": "together-ai"
+            },
+            "name": "LlamaRank"
+        },
+        {
+            "id": "dracarys2-72b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Dracarys 2 72B Instruct"
+        },
+        {
+            "id": "hermes3-405b",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Hermes 3 405B"
+        },
+        {
+            "id": "hermes3-405b-fp8-128k",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Hermes 3 405B FP8 128K"
+        },
+        {
+            "id": "hermes3-70b",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Hermes 3 70B"
+        },
+        {
+            "id": "hermes3-8b",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Hermes 3 8B"
+        },
+        {
+            "id": "lfm-40b",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "LFM 40B"
+        },
+        {
+            "id": "llama3.1-405b-instruct-fp8",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Llama 3.1 405B Instruct FP8"
+        },
+        {
+            "id": "llama3.1-70b-instruct-fp8",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Llama 3.1 70B Instruct FP8"
+        },
+        {
+            "id": "llama3.1-8b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Llama 3.1 8B Instruct"
+        },
+        {
+            "id": "llama3.2-3b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Llama 3.2 3B Instruct"
+        },
+        {
+            "id": "llama3.1-nemotron-70b-instruct",
+            "object": "model",
+            "provider": {
+                "id": "lambda"
+            },
+            "name": "Llama 3.1 Nemotron 70B Instruct"
+        },
+        {
+            "id": "llama-8b-chat",
+            "object": "model",
+            "provider": {
+                "id": "lemonfox-ai"
+            },
+            "name": "Llama 3.1 8B"
+        },
+        {
+            "id": "llama-70b-chat",
+            "object": "model",
+            "provider": {
+                "id": "lemonfox-ai"
+            },
+            "name": "Llama 3.1 70B"
+        },
+        {
+            "id": "mixtral-chat",
+            "object": "model",
+            "provider": {
+                "id": "lemonfox-ai"
+            },
+            "name": "Mixtral Chat"
+        },
+        {
+            "id": "embedding-query",
+            "object": "model",
+            "provider": {
+                "id": "upstage"
+            },
+            "name": "Embedding Query"
+        },
+        {
+            "id": "embedding-passage",
+            "object": "model",
+            "provider": {
+                "id": "upstage"
+            },
+            "name": "Embedding Passage"
+        },
+        {
+            "id": "solar-pro-preview-240910",
+            "object": "model",
+            "provider": {
+                "id": "upstage"
+            },
+            "name": "Solar Pro Preview"
+        },
+        {
+            "id": "solar-mini-240612",
+            "object": "model",
+            "provider": {
+                "id": "upstage"
+            },
+            "name": "Solar Mini"
+        },
+        {
+            "id": "solar-mini-ja-240612",
+            "object": "model",
+            "provider": {
+                "id": "upstage"
+            },
+            "name": "Solar Mini Japanese"
+        },
+        {
+            "id": "stable-diffusion-3.5-medium",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Diffusion 3.5 Medium"
+        },
+        {
+            "id": "stable-diffusion-3.5-large",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Diffusion 3.5 Large"
+        },
+        {
+            "id": "stable-diffusion-3.5-large-turbo",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Diffusion 3.5 Large Turbo"
+        },
+        {
+            "id": "stable-diffusion-3-medium",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Diffusion 3 Medium"
+        },
+        {
+            "id": "sdxl-turbo",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Diffusion XL Turbo"
+        },
+        {
+            "id": "sd-turbo",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Diffusion Turbo"
+        },
+        {
+            "id": "stable-video-diffusion-img2vid",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Video Diffusion Img2Vid"
+        },
+        {
+            "id": "stable-video-diffusion-img2vid-xt",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Video Diffusion Img2Vid XT"
+        },
+        {
+            "id": "stable-video-diffusion-img2vid-xt-1-1",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Video Diffusion Img2Vid XT 1.1"
+        },
+        {
+            "id": "japanese-stable-diffusion-xl",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Japanese Stable Diffusion XL"
+        },
+        {
+            "id": "japanese-stable-clip-vit-l-16",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Japanese Stable Diffusion CLIP Vit-L-16"
+        },
+        {
+            "id": "stablelm-2-12b",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "StableLM 2 12B"
+        },
+        {
+            "id": "lityai/stablelm-2-1_6b-zephyr",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "StableLM 2 1.6B Zephyr"
+        },
+        {
+            "id": "stablelm-zephyr-3b",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "StableLM Zephyr 3B"
+        },
+        {
+            "id": "japanese-stablelm-2-instruct-1_6b",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Japanese StableLM 2 Instruct 1.6B"
+        },
+        {
+            "id": "japanese-stable-vlm",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Japanese StableVLM"
+        },
+        {
+            "id": "stable-code-3b",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Code 3B"
+        },
+        {
+            "id": "stable-fast-3d",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Fast 3D"
+        },
+        {
+            "id": "stable-zero123",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Zero123"
+        },
+        {
+            "id": "sv3d",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable 3D"
+        },
+        {
+            "id": "stable-audio-open-1.0",
+            "object": "model",
+            "provider": {
+                "id": "stability-ai"
+            },
+            "name": "Stable Audio Open 1.0"
+        },
+        {
+            "id": "gemini-1.5-pro-002",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Gemini 1.5 Pro"
+        },
+        {
+            "id": "gemini-1.5-flash-002",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Gemini 1.5 Flash"
+        },
+        {
+            "id": "gemini-pro",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Gemini 1.0 Pro"
+        },
+        {
+            "id": "gemini-pro-vision",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Gemini 1.0 Pro Vision"
+        },
+        {
+            "id": "imagen-3.0-generate-001",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Imagen for Generation and Editing"
+        },
+        {
+            "id": "imagegeneration",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Imagen 2 for Generation and Editing"
+        },
+        {
+            "id": "claude-3-5-sonnet-v2",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Claude 3.5 Sonnet v2"
+        },
+        {
+            "id": "claude-3-opus",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Claude 3 Opus"
+        },
+        {
+            "id": "claude-3-haiku",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Claude 3 Haiku"
+        },
+        {
+            "id": "gemma2",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Gemma 2"
+        },
+        {
+            "id": "paligemma",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "PaliGemma"
+        },
+        {
+            "id": "gemma",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Gemma"
+        },
+        {
+            "id": "codegemma",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "CodeGemma"
+        },
+        {
+            "id": "llama-3.1-405b-instruct-maas",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Llama 3.1 API Service"
+        },
+        {
+            "id": "llama-3.2-90b-vision-instruct-maas",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Llama 3.2 API Service"
+        },
+        {
+            "id": "llama3_1",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Llama 3.1"
+        },
+        {
+            "id": "llama3-2",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Llama 3.2"
+        },
+        {
+            "id": "llama3",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Llama 3"
+        },
+        {
+            "id": "llama-guard",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Llama Guard"
+        },
+        {
+            "id": "prompt-guard",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Prompt Guard"
+        },
+        {
+            "id": "llama2",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Llama 2"
+        },
+        {
+            "id": "mistral-large",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Mistral Large (2407)"
+        },
+        {
+            "id": "mistral-nemo",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Mistral Nemo"
+        },
+        {
+            "id": "codestral",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Codestral"
+        },
+        {
+            "id": "jamba-1.5-large",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Jamba 1.5 Large (Preview)"
+        },
+        {
+            "id": "jamba-1.5-mini",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Jamba 1.5 Mini (Preview)"
+        },
+        {
+            "id": "mixtral",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Mixtral"
+        },
+        {
+            "id": "chat-bison",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "PaLM 2 Chat Bison"
+        },
+        {
+            "id": "text-bison",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "PaLM 2 Text Bison"
+        },
+        {
+            "id": "claude-3-5-sonnet",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Claude 3.5 Sonnet"
+        },
+        {
+            "id": "claude-3-sonnet",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Claude 3 Sonnet"
+        },
+        {
+            "id": "whisper-large",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Whisper Large"
+        },
+        {
+            "id": "chirp-2",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Chirp 2"
+        },
+        {
+            "id": "image-segmentation-001",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Vertex Image Segmentation"
+        },
+        {
+            "id": "flux1-schnell",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Flux"
+        },
+        {
+            "id": "phi3",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Phi-3"
+        },
+        {
+            "id": "qwen2",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Qwen2"
+        },
+        {
+            "id": "mammut",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "MaMMUT"
+        },
+        {
+            "id": "e5",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "E5 Text Embedding"
+        },
+        {
+            "id": "timesfm",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "TimesFM 1.0"
+        },
+        {
+            "id": "stable-diffusion-xl-lightning",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Stable Diffusion XL Lightning"
+        },
+        {
+            "id": "instant-id",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Instant ID"
+        },
+        {
+            "id": "stable-diffusion-xl-lcm",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Stable Diffusion XL LCM"
+        },
+        {
+            "id": "pytorch-llava",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "LLaVA 1.5"
+        },
+        {
+            "id": "lama",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "LaMa (Large Mask Inpainting)"
+        },
+        {
+            "id": "lmsys-vicuna-7b",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Vicuna"
+        },
+        {
+            "id": "bio-gpt",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "BioGPT"
+        },
+        {
+            "id": "jax-owl-vit-v2",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "OWL-ViT v2"
+        },
+        {
+            "id": "dito",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "DITO"
+        },
+        {
+            "id": "microsoft-biomedclip",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "BiomedCLIP"
+        },
+        {
+            "id": "mistral",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Mistral Self-host (7B & Nemo)"
+        },
+        {
+            "id": "nllb",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "NLLB"
+        },
+        {
+            "id": "codellama-7b-hf",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Code Llama"
+        },
+        {
+            "id": "stable-diffusion-xl-base",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Stable Diffusion XL"
+        },
+        {
+            "id": "openclip",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "OpenCLIP"
+        },
+        {
+            "id": "f-vlm-jax",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "F-VLM"
+        },
+        {
+            "id": "llama-2-quantized",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Llama 2 (Quantized)"
+        },
+        {
+            "id": "stable-diffusion-2-1",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Stable Diffusion v2.1"
+        },
+        {
+            "id": "bert-base-uncased",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "BERT (PEFT)"
+        },
+        {
+            "id": "falcon-instruct-7b-peft",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Falcon-instruct (PEFT)"
+        },
+        {
+            "id": "openllama",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "OpenLLaMA (PEFT)"
+        },
+        {
+            "id": "roberta-large",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "RoBERTa-large (PEFT)"
+        },
+        {
+            "id": "xlm-roberta-large",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "XLM-RoBERTa-large (PEFT)"
+        },
+        {
+            "id": "stable-diffusion-4x-upscaler",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Stable-diffusion-4x-upscaler"
+        },
+        {
+            "id": "segment-anything",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Segment Anything (SAM)"
+        },
+        {
+            "id": "bart-large-cnn",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Bart-large-cnn"
+        },
+        {
+            "id": "dolly-v2",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Dolly-v2"
+        },
+        {
+            "id": "imagetext",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Imagen for Captioning & VQA"
+        },
+        {
+            "id": "stable-diffusion-v1-4",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Stable Diffusion 1.4 (Keras)"
+        },
+        {
+            "id": "chirp-rnnt1",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Chirp"
+        },
+        {
+            "id": "label-detector-pali-001",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Label detector (PaLI zero-shot)"
+        },
+        {
+            "id": "codechat-bison",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Codey for Code Chat"
+        },
+        {
+            "id": "code-bison",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Codey for Code Generation"
+        },
+        {
+            "id": "code-gecko",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Codey for Code Completion"
+        },
+        {
+            "id": "text-unicorn",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "PaLM 2 Text Unicorn"
+        },
+        {
+            "id": "textembedding-gecko",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Embeddings for Text"
+        },
+        {
+            "id": "t5-flan",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "T5-FLAN"
+        },
+        {
+            "id": "t5-1.1",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "T5-1.1"
+        },
+        {
+            "id": "blip2-opt-2.7-b",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "BLIP2"
+        },
+        {
+            "id": "instruct-pix2pix",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "InstructPix2Pix"
+        },
+        {
+            "id": "stable-diffusion-inpainting",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Stable Diffusion Inpainting"
+        },
+        {
+            "id": "control-net",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "ControlNet"
+        },
+        {
+            "id": "bert-base",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "BERT"
+        },
+        {
+            "id": "layoutlm-document-qa",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "LayoutLM for VQA"
+        },
+        {
+            "id": "vilt-b32-finetuned-vqa",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "ViLT VQA"
+        },
+        {
+            "id": "vit-gpt2-image-captioning",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "ViT GPT2"
+        },
+        {
+            "id": "owlvit-base-patch32",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "OWL-ViT"
+        },
+        {
+            "id": "clip-vit-base-patch32",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "CLIP"
+        },
+        {
+            "id": "blip-vqa-base",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "BLIP VQA"
+        },
+        {
+            "id": "blip-image-captioning-base",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "BLIP image captioning"
+        },
+        {
+            "id": "multimodalembedding",
+            "object": "model",
+            "provider": {
+                "id": "vertex-ai"
+            },
+            "name": "Embeddings for Multimodal"
+        },
+        {
+            "id": "Gryphe/MythoMax-L2-13b",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "MythoMax L2 13B"
+        },
+        {
+            "id": "Gryphe/MythoMax-L2-13b-turbo",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "MythoMax L2 13B Turbo"
+        },
+        {
+            "id": "HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Zephyr Orpo 141B A35b v0.1"
+        },
+        {
+            "id": "KoboldAI/LLaMA2-13B-Tiefighter",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "LLaMA 2 13B Tiefighter"
+        },
+        {
+            "id": "NousResearch/Hermes-3-Llama-3.1-405B",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Hermes 3 Llama 3.1 405B"
+        },
+        {
+            "id": "Phind/Phind-CodeLlama-34B-v2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Phind CodeLlama 34B v2"
+        },
+        {
+            "id": "Qwen/Qwen2-72B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Qwen 2 72B Instruct"
+        },
+        {
+            "id": "Qwen/Qwen2.5-Coder-7B",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Qwen 2.5 Coder 7B"
+        },
+        {
+            "id": "Sao10K/L3-70B-Euryale-v2.1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "L3 70B Euryale v2.1"
+        },
+        {
+            "id": "Sao10K/L3.1-70B-Euryale-v2.2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "L3.1 70B Euryale v2.2"
+        },
+        {
+            "id": "bigcode/starcoder2-15b",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Starcoder 2 15B"
+        },
+        {
+            "id": "bigcode/starcoder2-15b-instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Starcoder 2 15B Instruct v0.1"
+        },
+        {
+            "id": "codellama/CodeLlama-34b-Instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "CodeLlama 34B Instruct HF"
+        },
+        {
+            "id": "codellama/CodeLlama-70b-Instruct-hf",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "CodeLlama 70B Instruct HF"
+        },
+        {
+            "id": "cognitivecomputations/dolphin-2.6-mixtral-8x7b",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Dolphin 2.6 Mixtral 8x7B"
+        },
+        {
+            "id": "cognitivecomputations/dolphin-2.9.1-llama-3-70b",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Dolphin 2.9.1 Llama 3 70B"
+        },
+        {
+            "id": "databricks/dbrx-instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "DBRX Instruct"
+        },
+        {
+            "id": "deepinfra/airoboros-70b",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Airoboros 70B"
+        },
+        {
+            "id": "google/codegemma-7b-it",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "CodeGemma 7B IT"
+        },
+        {
+            "id": "google/gemma-1.1-7b-it",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Gemma 1.1 7B IT"
+        },
+        {
+            "id": "google/gemma-2-27b-it",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Gemma 2 27B IT"
+        },
+        {
+            "id": "google/gemma-2-9b-it",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Gemma 2 9B IT"
+        },
+        {
+            "id": "lizpreciatior/lzlv_70b_fp16_hf",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "LzLV 70B FP16 HF"
+        },
+        {
+            "id": "mattshumer/Reflection-Llama-3.1-70B",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Reflection Llama 3.1 70B"
+        },
+        {
+            "id": "Llama-2-13b-chat-hf",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Llama 2 13B Chat HF"
+        },
+        {
+            "id": "Llama-2-70b-chat-hf",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Llama 2 70B Chat HF"
+        },
+        {
+            "id": "Llama-2-7b-chat-hf",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Llama 2 7B Chat HF"
+        },
+        {
+            "id": "Llama-3.2-1B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Llama 3.2 1B Instruct"
+        },
+        {
+            "id": "Llama-3.2-3B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Llama 3.2 3B Instruct"
+        },
+        {
+            "id": "Meta-Llama-3-70B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Meta Llama 3 70B Instruct"
+        },
+        {
+            "id": "Meta-Llama-3-8B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Meta Llama 3 8B Instruct"
+        },
+        {
+            "id": "Phi-3-medium-4k-instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Phi 3 Medium 4K Instruct"
+        },
+        {
+            "id": "WizardLM-2-7B",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "WizardLM 2 7B"
+        },
+        {
+            "id": "Mistral-7B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Mistral 7B Instruct v0.1"
+        },
+        {
+            "id": "Mistral-7B-Instruct-v0.2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Mistral 7B Instruct v0.2"
+        },
+        {
+            "id": "Mistral-7B-Instruct-v0.3",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Mistral 7B Instruct v0.3"
+        },
+        {
+            "id": "Mistral-Nemo-Instruct-2407",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Mistral Nemo Instruct 2407"
+        },
+        {
+            "id": "Mixtral-8x22B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Mixtral 8x22B Instruct v0.1"
+        },
+        {
+            "id": "Mixtral-8x22B-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Mixtral 8x22B v0.1"
+        },
+        {
+            "id": "Mixtral-8x7B-Instruct-v0.1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Mixtral 8x7B Instruct v0.1"
+        },
+        {
+            "id": "Nemotron-4-340B-Instruct",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Nemotron 4 340B Instruct"
+        },
+        {
+            "id": "MiniCPM-Llama3-V-2_5",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "MiniCPM Llama3 V 2.5"
+        },
+        {
+            "id": "openchat/openchat_3.5",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "OpenChat 3.5"
+        },
+        {
+            "id": "openchat/openchat-3.6-8b",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "OpenChat 3.6 8B"
+        },
+        {
+            "id": "stabilityai/sd3.5",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Stable Diffusion 3.5"
+        },
+        {
+            "id": "black-forest-labs/FLUX-1.1-pro",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "FLUX 1.1 Pro"
+        },
+        {
+            "id": "black-forest-labs/FLUX-1-schnell",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "FLUX 1 Schnell"
+        },
+        {
+            "id": "black-forest-labs/FLUX-1-dev",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "FLUX 1 Dev"
+        },
+        {
+            "id": "black-forest-labs/FLUX-pro",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "FLUX Pro"
+        },
+        {
+            "id": "stabilityai/sd3.5-medium",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Stable Diffusion 3.5 Medium"
+        },
+        {
+            "id": "CompVis/stable-diffusion-v1-4",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Stable Diffusion v1-4"
+        },
+        {
+            "id": "XpucT/Deliberate",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Deliberate"
+        },
+        {
+            "id": "prompthero/openjourney",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "OpenJourney"
+        },
+        {
+            "id": "runwayml/stable-diffusion-v1-5",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Stable Diffusion v1-5"
+        },
+        {
+            "id": "stabilityai/sdxl-turbo",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "SDXL Turbo"
+        },
+        {
+            "id": "stabilityai/stable-diffusion-2-1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Stable Diffusion 2.1"
+        },
+        {
+            "id": "openai/whisper-large-v3-turbo",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Large v3 Turbo"
+        },
+        {
+            "id": "openai/whisper-large-v3",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Large v3"
+        },
+        {
+            "id": "distil-whisper/distil-large-v3",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Distil Whisper Large v3"
+        },
+        {
+            "id": "openai/whisper-base",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Base"
+        },
+        {
+            "id": "openai/whisper-base.en",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Base English"
+        },
+        {
+            "id": "openai/whisper-large",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Large"
+        },
+        {
+            "id": "openai/whisper-medium",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Medium"
+        },
+        {
+            "id": "openai/whisper-medium.en",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Medium English"
+        },
+        {
+            "id": "openai/whisper-small",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Small"
+        },
+        {
+            "id": "openai/whisper-small.en",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Small English"
+        },
+        {
+            "id": "openai/whisper-timestamped-medium",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Timestamped Medium"
+        },
+        {
+            "id": "openai/whisper-timestamped-medium.en",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Timestamped Medium English"
+        },
+        {
+            "id": "openai/whisper-tiny",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Tiny"
+        },
+        {
+            "id": "openai/whisper-tiny.en",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Whisper Tiny English"
+        },
+        {
+            "id": "BAAI/bge-base-en-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "BGE Base EN v1.5"
+        },
+        {
+            "id": "BAAI/bge-large-en-v1.5",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "BGE Large EN v1.5"
+        },
+        {
+            "id": "BAAI/bge-m3",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "BGE M3"
+        },
+        {
+            "id": "intfloat/e5-base-v2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "E5 Base v2"
+        },
+        {
+            "id": "intfloat/e5-large-v2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "E5 Large v2"
+        },
+        {
+            "id": "intfloat/multilingual-e5-large",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Multilingual E5 Large"
+        },
+        {
+            "id": "sentence-transformers/all-MiniLM-L12-v2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "All-MiniLM-L12-v2"
+        },
+        {
+            "id": "sentence-transformers/all-MiniLM-L6-v2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "All-MiniLM-L6-v2"
+        },
+        {
+            "id": "sentence-transformers/all-mpnet-base-v2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "All-MPNet-base-v2"
+        },
+        {
+            "id": "sentence-transformers/clip-ViT-B-32",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "CLIP ViT-B-32"
+        },
+        {
+            "id": "sentence-transformers/clip-ViT-B-32-multilingual-v1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "CLIP ViT-B-32 Multilingual v1"
+        },
+        {
+            "id": "sentence-transformers/multi-qa-mpnet-base-dot-v1",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Multi-QA-MPNet-base-dot-v1"
+        },
+        {
+            "id": "sentence-transformers/paraphrase-MiniLM-L6-v2",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Paraphrase-MiniLM-L6-v2"
+        },
+        {
+            "id": "shibing624/text2vec-base-chinese",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "Text2Vec-Base-Chinese"
+        },
+        {
+            "id": "thenlper/gte-base",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "GTE Base"
+        },
+        {
+            "id": "thenlper/gte-large",
+            "object": "model",
+            "provider": {
+                "id": "deepinfra"
+            },
+            "name": "GTE Large"
+        },
+        {
+            "id": "jina-embeddings-v2-base-en",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Embeddings v2 Base English"
+        },
+        {
+            "id": "jina-embeddings-v2-base-zh",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Embeddings v2 Base Chinese"
+        },
+        {
+            "id": "jina-embeddings-v2-base-de",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Embeddings v2 Base German"
+        },
+        {
+            "id": "jina-embeddings-v2-base-code",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Embeddings v2 Base Code"
+        },
+        {
+            "id": "jina-embeddings-v2-base-es",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Embeddings v2 Base Spanish"
+        },
+        {
+            "id": "jina-colbert-v1-en",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Colbert v1 English"
+        },
+        {
+            "id": "jina-reranker-v1-base-en",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Reranker v1 Base English"
+        },
+        {
+            "id": "jina-reranker-v1-turbo-en",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Reranker v1 Turbo English"
+        },
+        {
+            "id": "jina-reranker-v1-tiny-en",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Reranker v1 Tiny English"
+        },
+        {
+            "id": "jina-clip-v1",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina CLIP v1"
+        },
+        {
+            "id": "jina-reranker-v2-base-multilingual",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Reranker v2 Base Multilingual"
+        },
+        {
+            "id": "jina-colbert-v2",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Colbert v2"
+        },
+        {
+            "id": "jina-embeddings-v3",
+            "object": "model",
+            "provider": {
+                "id": "jina"
+            },
+            "name": "Jina Embeddings v3"
+        }
+    ]
+}

--- a/src/data/models.json
+++ b/src/data/models.json
@@ -1,15150 +1,15150 @@
 {
-    "object": "list",
-    "version": "1.0.0",
-    "data": [
-        {
-            "id": "meta-llama/llama-3.1-70b-instruct/fp-8",
-            "object": "model",
-            "provider": {
-                "id": "inference-net"
-            },
-            "name": "Llama 3.1 70B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.1-8b-instruct/fp-8",
-            "object": "model",
-            "provider": {
-                "id": "inference-net"
-            },
-            "name": "Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "jamba-1.5-large",
-            "object": "model",
-            "provider": {
-                "id": "ai21"
-            },
-            "name": "Jamba 1.5 Large"
-        },
-        {
-            "id": "jamba-1.5-mini",
-            "object": "model",
-            "provider": {
-                "id": "ai21"
-            },
-            "name": "Jamba 1.5 Mini"
-        },
-        {
-            "id": "jamba-instruct",
-            "object": "model",
-            "provider": {
-                "id": "ai21"
-            },
-            "name": "Jamba Instruct"
-        },
-        {
-            "id": "jurassic-light",
-            "object": "model",
-            "provider": {
-                "id": "ai21"
-            },
-            "name": "Jurassic Light"
-        },
-        {
-            "id": "jurassic-mid",
-            "object": "model",
-            "provider": {
-                "id": "ai21"
-            },
-            "name": "Jurassic Mid"
-        },
-        {
-            "id": "jurassic-ultra",
-            "object": "model",
-            "provider": {
-                "id": "ai21"
-            },
-            "name": "Jurassic Ultra"
-        },
-        {
-            "id": "claude-2.0",
-            "object": "model",
-            "provider": {
-                "id": "anthropic"
-            },
-            "name": "Claude 2.0"
-        },
-        {
-            "id": "claude-2.1",
-            "object": "model",
-            "provider": {
-                "id": "anthropic"
-            },
-            "name": "Claude 2.1"
-        },
-        {
-            "id": "claude-3-5-sonnet-latest",
-            "object": "model",
-            "provider": {
-                "id": "anthropic"
-            },
-            "name": "Claude 3.5 Sonnet"
-        },
-        {
-            "id": "claude-3-haiku-20240307",
-            "object": "model",
-            "provider": {
-                "id": "anthropic"
-            },
-            "name": "Claude 3 Haiku (March 7, 2024)"
-        },
-        {
-            "id": "claude-3-opus-20240229",
-            "object": "model",
-            "provider": {
-                "id": "anthropic"
-            },
-            "name": "Claude 3 Opus (February 29, 2024)"
-        },
-        {
-            "id": "claude-3-sonnet-20240229",
-            "object": "model",
-            "provider": {
-                "id": "anthropic"
-            },
-            "name": "Claude 3 Sonnet (February 29, 2024)"
-        },
-        {
-            "id": "claude-instant-1.2",
-            "object": "model",
-            "provider": {
-                "id": "anthropic"
-            },
-            "name": "Claude Instant 1.2"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3-8B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "anyscale"
-            },
-            "name": "Meta Llama 3 70B Instruct"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3-70B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "anyscale"
-            },
-            "name": "Meta Llama 3 8B Instruct"
-        },
-        {
-            "id": "mistralai/Mistral-7B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "anyscale"
-            },
-            "name": "Mistral 7B Instruct v0.1"
-        },
-        {
-            "id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "anyscale"
-            },
-            "name": "Mixtral 8x7B Instruct v0.1"
-        },
-        {
-            "id": "gpt-4o-realtime-preview",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "GPT-4 Realtime Preview"
-        },
-        {
-            "id": "openai-whisper-large-v3",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Whisper Large v3"
-        },
-        {
-            "id": "openai-whisper-large",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Whisper Large"
-        },
-        {
-            "id": "gpt-4",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "GPT-4"
-        },
-        {
-            "id": "gpt-35-turbo",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "GPT-3.5 Turbo"
-        },
-        {
-            "id": "o1-preview",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "O1 Preview"
-        },
-        {
-            "id": "o1-mini",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "O1 Mini"
-        },
-        {
-            "id": "gpt-4o-mini",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "GPT-4 0 Mini"
-        },
-        {
-            "id": "gpt-4o",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "GPT-4 0"
-        },
-        {
-            "id": "gpt-4-32k",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "GPT-4 32K"
-        },
-        {
-            "id": "gpt-35-turbo-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "GPT-3.5 Turbo Instruct"
-        },
-        {
-            "id": "gpt-35-turbo-16k",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "GPT-3.5 Turbo 16K"
-        },
-        {
-            "id": "dall-e-3",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DALL-E 3"
-        },
-        {
-            "id": "dall-e-2",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DALL-E 2"
-        },
-        {
-            "id": "whisper",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Whisper"
-        },
-        {
-            "id": "tts-hd",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "TTS-HD"
-        },
-        {
-            "id": "tts",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "TTS"
-        },
-        {
-            "id": "text-embedding-3-small",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Text Embedding 3 Small"
-        },
-        {
-            "id": "text-embedding-3-large",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Text Embedding 3 Large"
-        },
-        {
-            "id": "davinci-002",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Davinci 002"
-        },
-        {
-            "id": "text-embedding-ada-002",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Text Embedding Ada 002"
-        },
-        {
-            "id": "babbage-002",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Babbage 002"
-        },
-        {
-            "id": "Phi-3.5-mini-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3.5 Mini Instruct"
-        },
-        {
-            "id": "Phi-3.5-MoE-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3.5 MoE Instruct"
-        },
-        {
-            "id": "Phi-3-medium-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3 Medium 128K Instruct"
-        },
-        {
-            "id": "Phi-3-mini-4k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3 Mini 4K Instruct"
-        },
-        {
-            "id": "Phi-3-medium-4k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3 Medium 4K Instruct"
-        },
-        {
-            "id": "Phi-3-mini-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3 Mini 128K Instruct"
-        },
-        {
-            "id": "Phi-3-small-8k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3 Small 8K Instruct"
-        },
-        {
-            "id": "Phi-3-small-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3 Small 128K Instruct"
-        },
-        {
-            "id": "Phi-3.5-vision-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3.5 Vision Instruct"
-        },
-        {
-            "id": "Phi-3-vision-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Phi-3 Vision 128K Instruct"
-        },
-        {
-            "id": "Meta-Llama-3.1-8B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "Meta-Llama-3.1-8B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3.1 8B"
-        },
-        {
-            "id": "Meta-Llama-3.1-70B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3.1 70B Instruct"
-        },
-        {
-            "id": "Meta-Llama-3.1-70B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3.1 70B"
-        },
-        {
-            "id": "Meta-Llama-3-8B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3 8B Instruct"
-        },
-        {
-            "id": "Meta-Llama-3-8B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3 8B"
-        },
-        {
-            "id": "Meta-Llama-3-70B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3 70B Instruct"
-        },
-        {
-            "id": "Meta-Llama-3-70B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3 70B"
-        },
-        {
-            "id": "Llama-3.2-1B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 3.2 1B"
-        },
-        {
-            "id": "Llama-3.2-3B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 3.2 3B"
-        },
-        {
-            "id": "Llama-Guard-3-8B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama Guard 3 8B"
-        },
-        {
-            "id": "ai21.j2-mid-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "AI21 J2 Mid v1"
-        },
-        {
-            "id": "ai21.j2-ultra-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "AI21 J2 Ultra v1"
-        },
-        {
-            "id": "ai21.j2-ultra-v1:0:8k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "AI21 J2 Ultra v1 (8K context)"
-        },
-        {
-            "id": "ai21.jamba-1-5-large-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "AI21 Jamba 1.5 Large v1"
-        },
-        {
-            "id": "ai21.jamba-1-5-mini-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "AI21 Jamba 1.5 Mini v1"
-        },
-        {
-            "id": "ai21.jamba-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "AI21 Jamba Instruct v1"
-        },
-        {
-            "id": "amazon.titan-embed-image-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Embed Image v1"
-        },
-        {
-            "id": "amazon.titan-embed-image-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Embed Image v1"
-        },
-        {
-            "id": "amazon.titan-embed-text-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Embed Text v1"
-        },
-        {
-            "id": "amazon.titan-embed-text-v1:2:8k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Embed Text v1.2 (8K context)"
-        },
-        {
-            "id": "amazon.titan-embed-text-v2:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Embed Text v2"
-        },
-        {
-            "id": "amazon.titan-embed-text-v2:0:8k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Embed Text v2 (8K context)"
-        },
-        {
-            "id": "amazon.titan-image-generator-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Image Generator v1"
-        },
-        {
-            "id": "amazon.titan-image-generator-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Image Generator v1"
-        },
-        {
-            "id": "amazon.titan-image-generator-v2:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Image Generator v2"
-        },
-        {
-            "id": "amazon.titan-image-generator-v2:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Image Generator v2"
-        },
-        {
-            "id": "amazon.titan-text-express-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Text Express v1"
-        },
-        {
-            "id": "amazon.titan-text-express-v1:0:8k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Text Express v1 (8K context)"
-        },
-        {
-            "id": "amazon.titan-text-lite-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Text Lite v1"
-        },
-        {
-            "id": "amazon.titan-text-lite-v1:0:4k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Text Lite v1 (4K context)"
-        },
-        {
-            "id": "amazon.titan-text-premier-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Text Premier v1"
-        },
-        {
-            "id": "amazon.titan-text-premier-v1:0:32K",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Amazon Titan Text Premier v1 (32K context)"
-        },
-        {
-            "id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3.5 Sonnet (June 20, 2024)"
-        },
-        {
-            "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:18k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3.5 Sonnet (18K context)"
-        },
-        {
-            "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:200k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3.5 Sonnet (200K context)"
-        },
-        {
-            "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:51k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3.5 Sonnet (51K context)"
-        },
-        {
-            "id": "anthropic.claude-3-haiku-20240307-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3 Haiku (March 7, 2024)"
-        },
-        {
-            "id": "anthropic.claude-3-haiku-20240307-v1:0:200k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3 Haiku (200K context)"
-        },
-        {
-            "id": "anthropic.claude-3-haiku-20240307-v1:0:48k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3 Haiku (48K context)"
-        },
-        {
-            "id": "anthropic.claude-3-opus-20240229-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3 Opus (February 29, 2024)"
-        },
-        {
-            "id": "anthropic.claude-3-sonnet-20240229-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3 Sonnet (February 29, 2024)"
-        },
-        {
-            "id": "anthropic.claude-3-sonnet-20240229-v1:0:200k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3 Sonnet (200K context)"
-        },
-        {
-            "id": "anthropic.claude-3-sonnet-20240229-v1:0:28k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude 3 Sonnet (28K context)"
-        },
-        {
-            "id": "anthropic.claude-instant-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude Instant v1"
-        },
-        {
-            "id": "anthropic.claude-instant-v1:2:100k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude Instant v1.2 (100K context)"
-        },
-        {
-            "id": "anthropic.claude-v2",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude v2"
-        },
-        {
-            "id": "anthropic.claude-v2:0:100k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude v2 (100K context)"
-        },
-        {
-            "id": "anthropic.claude-v2:0:18k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude v2 (18K context)"
-        },
-        {
-            "id": "anthropic.claude-v2:1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude v2.1"
-        },
-        {
-            "id": "anthropic.claude-v2:1:18k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude v2.1 (18K context)"
-        },
-        {
-            "id": "anthropic.claude-v2:1:200k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Anthropic Claude v2.1 (200K context)"
-        },
-        {
-            "id": "cohere.command-light-text-v14",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Command Light Text v14"
-        },
-        {
-            "id": "cohere.command-light-text-v14:7:4k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Command Light Text v14.7 (4K context)"
-        },
-        {
-            "id": "cohere.command-r-plus-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Command R Plus v1"
-        },
-        {
-            "id": "cohere.command-r-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Command R v1"
-        },
-        {
-            "id": "cohere.command-text-v14",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Command Text v14"
-        },
-        {
-            "id": "cohere.command-text-v14:7:4k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Command Text v14.7 (4K context)"
-        },
-        {
-            "id": "cohere.embed-english-v3",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Embed English v3"
-        },
-        {
-            "id": "cohere.embed-english-v3:0:512",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Embed English v3 (512 context)"
-        },
-        {
-            "id": "cohere.embed-multilingual-v3",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Embed Multilingual v3"
-        },
-        {
-            "id": "cohere.embed-multilingual-v3:0:512",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Cohere Embed Multilingual v3 (512 context)"
-        },
-        {
-            "id": "meta.llama2-13b-chat-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 2 13B Chat v1"
-        },
-        {
-            "id": "meta.llama2-13b-chat-v1:0:4k",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 2 13B Chat v1 (4K context)"
-        },
-        {
-            "id": "meta.llama2-70b-chat-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 2 70B Chat v1"
-        },
-        {
-            "id": "meta.llama3-1-405b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3.1 405B Instruct v1"
-        },
-        {
-            "id": "meta.llama3-1-70b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3.1 70B Instruct v1"
-        },
-        {
-            "id": "meta.llama3-1-8b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3.1 8B Instruct v1"
-        },
-        {
-            "id": "meta.llama3-2-11b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3.2 11B Instruct v1"
-        },
-        {
-            "id": "meta.llama3-2-1b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3.2 1B Instruct v1"
-        },
-        {
-            "id": "meta.llama3-2-3b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3.2 3B Instruct v1"
-        },
-        {
-            "id": "meta.llama3-2-90b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3.2 90B Instruct v1"
-        },
-        {
-            "id": "meta.llama3-70b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3 70B Instruct v1"
-        },
-        {
-            "id": "meta.llama3-8b-instruct-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Meta LLaMA 3 8B Instruct v1"
-        },
-        {
-            "id": "mistral.mistral-7b-instruct-v0:2",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Mistral 7B Instruct v0.2"
-        },
-        {
-            "id": "mistral.mistral-large-2402-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Mistral Large (February 2024)"
-        },
-        {
-            "id": "mistral.mistral-large-2407-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Mistral Large (July 2024)"
-        },
-        {
-            "id": "mistral.mistral-small-2402-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Mistral Small (February 2024)"
-        },
-        {
-            "id": "mistral.mixtral-8x7b-instruct-v0:1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Mixtral 8x7B Instruct v0.1"
-        },
-        {
-            "id": "stability.sd3-large-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Stability AI SD3 Large v1"
-        },
-        {
-            "id": "stability.stable-diffusion-xl-v0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Stability AI Stable Diffusion XL v0"
-        },
-        {
-            "id": "stability.stable-diffusion-xl-v1",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Stability AI Stable Diffusion XL v1"
-        },
-        {
-            "id": "stability.stable-diffusion-xl-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Stability AI Stable Diffusion XL v1"
-        },
-        {
-            "id": "stability.stable-image-core-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Stability AI Stable Image Core v1"
-        },
-        {
-            "id": "stability.stable-image-ultra-v1:0",
-            "object": "model",
-            "provider": {
-                "id": "bedrock"
-            },
-            "name": "Stability AI Stable Image Ultra v1"
-        },
-        {
-            "id": "llama3.1-70b",
-            "object": "model",
-            "provider": {
-                "id": "cerebras"
-            },
-            "name": "70B"
-        },
-        {
-            "id": "llama3.1-8b",
-            "object": "model",
-            "provider": {
-                "id": "cerebras"
-            },
-            "name": "8B"
-        },
-        {
-            "id": "c4ai-aya-23-35b",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "C4AI Aya 23 35B"
-        },
-        {
-            "id": "c4ai-aya-23-8b",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "C4AI Aya 23 8B"
-        },
-        {
-            "id": "command",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command"
-        },
-        {
-            "id": "command-light",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command Light"
-        },
-        {
-            "id": "command-light-nightly",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command Light Nightly"
-        },
-        {
-            "id": "command-nightly",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command Nightly"
-        },
-        {
-            "id": "command-r",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command R"
-        },
-        {
-            "id": "command-r-03-2024",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command R"
-        },
-        {
-            "id": "command-r-08-2024",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command R (August 2024)"
-        },
-        {
-            "id": "command-r-plus",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command R Plus"
-        },
-        {
-            "id": "command-r-plus-08-2024",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Command R Plus (August 2024)"
-        },
-        {
-            "id": "embed-english-light-v2.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Embed English Light v2.0"
-        },
-        {
-            "id": "embed-english-light-v3.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Embed English Light v3.0"
-        },
-        {
-            "id": "embed-english-v2.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Embed English v2.0"
-        },
-        {
-            "id": "embed-english-v3.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Embed English v3.0"
-        },
-        {
-            "id": "embed-multilingual-light-v3.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Embed Multilingual Light v3.0"
-        },
-        {
-            "id": "embed-multilingual-v2.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Embed Multilingual v2.0"
-        },
-        {
-            "id": "embed-multilingual-v3.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Embed Multilingual v3.0"
-        },
-        {
-            "id": "rerank-english-v2.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Rerank English v2.0"
-        },
-        {
-            "id": "rerank-english-v3.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Rerank English v3.0"
-        },
-        {
-            "id": "rerank-multilingual-v2.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Rerank Multilingual v2.0"
-        },
-        {
-            "id": "rerank-multilingual-v3.0",
-            "object": "model",
-            "provider": {
-                "id": "cohere"
-            },
-            "name": "Cohere Rerank Multilingual v3.0"
-        },
-        {
-            "id": "Claude-3.5-Sonnet",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Claude 3.5 Sonnet"
-        },
-        {
-            "id": "dall-e-3",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Dall E 3"
-        },
-        {
-            "id": "GPT-3.5-turbo",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Gpt 3.5 Turbo"
-        },
-        {
-            "id": "GPT-3.5-turbo-instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Gpt 3.5 Turbo Instruct"
-        },
-        {
-            "id": "GPT-4-turbo",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Gpt 4 Turbo"
-        },
-        {
-            "id": "GPT-4o",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Gpt 4O"
-        },
-        {
-            "id": "GPT-4o-2024-08-06",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Gpt 4O 2024 08 06"
-        },
-        {
-            "id": "GPT-4o-mini",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Gpt 4O Mini"
-        },
-        {
-            "id": "LLama-3-70b",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Llama 3 70B"
-        },
-        {
-            "id": "LLama-3.1-405b",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Llama 3.1 405B"
-        },
-        {
-            "id": "LLama-3.1-70b",
-            "object": "model",
-            "provider": {
-                "id": "deepbricks"
-            },
-            "name": "Llama 3.1 70B"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3.1-70B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Meta Llama 3.1 70B Instruct"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Meta Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3.1-405B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Meta Llama 3.1 405B Instruct"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Meta Llama 3.1 70B Instruct Turbo"
-        },
-        {
-            "id": "nvidia/Llama-3.1-Nemotron-70B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Llama 3.1 Nemotron 70B Instruct"
-        },
-        {
-            "id": "Qwen/Qwen2.5-72B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Qwen 2.5 72B Instruct"
-        },
-        {
-            "id": "meta-llama/Llama-3.2-90B-Vision-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Llama 3.2 90B Vision Instruct"
-        },
-        {
-            "id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Llama 3.2 11B Vision Instruct"
-        },
-        {
-            "id": "microsoft/WizardLM-2-8x22B",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "WizardLM 2 8x22B"
-        },
-        {
-            "id": "01-ai/Yi-34B-Chat",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Yi 34B Chat"
-        },
-        {
-            "id": "Austism/chronos-hermes-13b-v2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Chronos Hermes 13B v2"
-        },
-        {
-            "id": "deepseek-chat",
-            "object": "model",
-            "provider": {
-                "id": "deepseek"
-            },
-            "name": "Deepseek Chat"
-        },
-        {
-            "id": "deepseek-coder",
-            "object": "model",
-            "provider": {
-                "id": "deepseek"
-            },
-            "name": "Deepseek Coder"
-        },
-        {
-            "id": "accounts/fireworks/models/chronos-hermes-13b-v2",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Chronos Hermes 13B V2"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-13b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 13B"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-13b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 13B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-13b-python",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 13B Python"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-34b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 34B"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-34b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 34B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-34b-python",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 34B Python"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-70b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 70B"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 70B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-70b-python",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 70B Python"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 7B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/code-llama-7b-python",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Llama 7B Python"
-        },
-        {
-            "id": "accounts/fireworks/models/code-qwen-1p5-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Code Qwen 1P5 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/codegemma-2b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Codegemma 2B"
-        },
-        {
-            "id": "accounts/fireworks/models/codegemma-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Codegemma 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/dbrx-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Dbrx Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-coder-1b-base",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek Coder 1B Base"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-coder-33b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek Coder 33B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-coder-7b-base",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek Coder 7B Base"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-coder-7b-base-v1p5",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek Coder 7B Base V1P5"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek Coder 7B Instruct V1P5"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-coder-v2-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek Coder V2 Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-coder-v2-lite-base",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek Coder V2 Lite Base"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-coder-v2-lite-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek Coder V2 Lite Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/deepseek-v2p5",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Deepseek V2P5"
-        },
-        {
-            "id": "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Dolphin 2 9 2 Qwen2 72B"
-        },
-        {
-            "id": "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Dolphin 2P6 Mixtral 8X7B"
-        },
-        {
-            "id": "accounts/fireworks/models/elyza-japanese-llama-2-7b-fast-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Elyza Japanese Llama 2 7B Fast Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/firefunction-v1",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Firefunction V1"
-        },
-        {
-            "id": "accounts/fireworks/models/firefunction-v2",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Firefunction V2"
-        },
-        {
-            "id": "accounts/fireworks/models/firellava-13b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Firellava 13B"
-        },
-        {
-            "id": "accounts/fireworks/models/flux-1-dev-fp8",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Flux 1 Dev Fp8"
-        },
-        {
-            "id": "accounts/fireworks/models/flux-1-schnell-fp8",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Flux 1 Schnell Fp8"
-        },
-        {
-            "id": "accounts/fireworks/models/gemma-2b-it",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Gemma 2B It"
-        },
-        {
-            "id": "accounts/fireworks/models/gemma-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Gemma 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/gemma-7b-it",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Gemma 7B It"
-        },
-        {
-            "id": "accounts/fireworks/models/hermes-2-pro-mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Hermes 2 Pro Mistral 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/japanese-stable-diffusion-xl",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Japanese Stable Diffusion Xl"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-guard-2-8b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama Guard 2 8B"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v2-13b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V2 13B"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v2-13b-chat",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V2 13B Chat"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v2-70b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V2 70B"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v2-70b-chat",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V2 70B Chat"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v2-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V2 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v2-7b-chat",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V2 7B Chat"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3 70B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3-70b-instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3 70B Instruct Hf"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3-8b-hf",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3 8B Hf"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3 8B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3-8b-instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3 8B Instruct Hf"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3p1-405b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3P1 405B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3p1-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3P1 70B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3p1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3P1 8B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3p2-11b-vision-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3P2 11B Vision Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3p2-1b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3P2 1B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3p2-3b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3P2 3B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llama-v3p2-90b-vision-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llama V3P2 90B Vision Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/llamaguard-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llamaguard 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/llava-yi-34b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Llava Yi 34B"
-        },
-        {
-            "id": "accounts/fireworks/models/mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mistral 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/mistral-7b-instruct-4k",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mistral 7B Instruct 4K"
-        },
-        {
-            "id": "accounts/fireworks/models/mistral-7b-instruct-v0p2",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mistral 7B Instruct V0P2"
-        },
-        {
-            "id": "accounts/fireworks/models/mistral-7b-instruct-v3",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mistral 7B Instruct V3"
-        },
-        {
-            "id": "accounts/fireworks/models/mistral-7b-v0p2",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mistral 7B V0P2"
-        },
-        {
-            "id": "accounts/fireworks/models/mistral-nemo-base-2407",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mistral Nemo Base 2407"
-        },
-        {
-            "id": "accounts/fireworks/models/mistral-nemo-instruct-2407",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mistral Nemo Instruct 2407"
-        },
-        {
-            "id": "accounts/fireworks/models/mixtral-8x22b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mixtral 8X22B"
-        },
-        {
-            "id": "accounts/fireworks/models/mixtral-8x22b-hf",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mixtral 8X22B Hf"
-        },
-        {
-            "id": "accounts/fireworks/models/mixtral-8x22b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mixtral 8X22B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/mixtral-8x22b-instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mixtral 8X22B Instruct Hf"
-        },
-        {
-            "id": "accounts/fireworks/models/mixtral-8x7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mixtral 8X7B"
-        },
-        {
-            "id": "accounts/fireworks/models/mixtral-8x7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mixtral 8X7B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/mixtral-8x7b-instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mixtral 8X7B Instruct Hf"
-        },
-        {
-            "id": "accounts/fireworks/models/mythomax-l2-13b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Mythomax L2 13B"
-        },
-        {
-            "id": "accounts/fireworks/models/nous-capybara-7b-v1p9",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Nous Capybara 7B V1P9"
-        },
-        {
-            "id": "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Nous Hermes 2 Mixtral 8X7B Dpo"
-        },
-        {
-            "id": "accounts/fireworks/models/nous-hermes-2-yi-34b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Nous Hermes 2 Yi 34B"
-        },
-        {
-            "id": "accounts/fireworks/models/nous-hermes-llama2-13b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Nous Hermes Llama2 13B"
-        },
-        {
-            "id": "accounts/fireworks/models/nous-hermes-llama2-70b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Nous Hermes Llama2 70B"
-        },
-        {
-            "id": "accounts/fireworks/models/nous-hermes-llama2-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Nous Hermes Llama2 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/openchat-3p5-0106-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Openchat 3P5 0106 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/openhermes-2-mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Openhermes 2 Mistral 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/openhermes-2p5-mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Openhermes 2P5 Mistral 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/openorca-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Openorca 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/phi-2-3b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Phi 2 3B"
-        },
-        {
-            "id": "accounts/fireworks/models/phi-3-mini-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Phi 3 Mini 128K Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/phi-3-vision-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Phi 3 Vision 128K Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/phind-code-llama-34b-python-v1",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Phind Code Llama 34B Python V1"
-        },
-        {
-            "id": "accounts/fireworks/models/phind-code-llama-34b-v1",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Phind Code Llama 34B V1"
-        },
-        {
-            "id": "accounts/fireworks/models/phind-code-llama-34b-v2",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Phind Code Llama 34B V2"
-        },
-        {
-            "id": "accounts/fireworks/models/playground-v2-1024px-aesthetic",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Playground V2 1024Px Aesthetic"
-        },
-        {
-            "id": "accounts/fireworks/models/playground-v2-5-1024px-aesthetic",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Playground V2 5 1024Px Aesthetic"
-        },
-        {
-            "id": "accounts/fireworks/models/pythia-12b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Pythia 12B"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen-v2p5-14b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen V2P5 14B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen-v2p5-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen V2P5 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen1p5-72b-chat",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen1P5 72B Chat"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2 72B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2 7B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-14b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 14B"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-14b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 14B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-32b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 32B"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-32b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 32B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-72b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 72B"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 72B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 7B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-coder-1p5b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 Coder 1P5B"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-coder-1p5b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 Coder 1P5B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-coder-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 Coder 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-coder-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 Coder 7B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/qwen2p5-math-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Qwen2P5 Math 72B Instruct"
-        },
-        {
-            "id": "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Snorkel Mistral 7B Pairrm Dpo"
-        },
-        {
-            "id": "accounts/fireworks/models/SSD-1B",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Ssd 1B"
-        },
-        {
-            "id": "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Stable Diffusion Xl 1024 V1 0"
-        },
-        {
-            "id": "accounts/fireworks/models/stablecode-3b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Stablecode 3B"
-        },
-        {
-            "id": "accounts/fireworks/models/starcoder-16b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Starcoder 16B"
-        },
-        {
-            "id": "accounts/fireworks/models/starcoder-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Starcoder 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/starcoder2-15b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Starcoder2 15B"
-        },
-        {
-            "id": "accounts/fireworks/models/starcoder2-3b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Starcoder2 3B"
-        },
-        {
-            "id": "accounts/fireworks/models/starcoder2-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Starcoder2 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/toppy-m-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Toppy M 7B"
-        },
-        {
-            "id": "accounts/fireworks/models/yi-34b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Yi 34B"
-        },
-        {
-            "id": "accounts/fireworks/models/yi-34b-200k-capybara",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Yi 34B 200K Capybara"
-        },
-        {
-            "id": "accounts/fireworks/models/yi-34b-chat",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Yi 34B Chat"
-        },
-        {
-            "id": "accounts/fireworks/models/yi-6b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Yi 6B"
-        },
-        {
-            "id": "accounts/fireworks/models/zephyr-7b-beta",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Zephyr 7B Beta"
-        },
-        {
-            "id": "accounts/muhtasham-83b323/models/order-ds-lora",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Models/Order Ds Lora"
-        },
-        {
-            "id": "accounts/stability/models/japanese-stable-vlm-8b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Japanese Stable Vlm 8B"
-        },
-        {
-            "id": "accounts/stability/models/japanese-stablelm-instruct-beta-70b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Japanese Stablelm Instruct Beta 70B"
-        },
-        {
-            "id": "accounts/stability/models/japanese-stablelm-instruct-gamma-7b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Japanese Stablelm Instruct Gamma 7B"
-        },
-        {
-            "id": "accounts/stability/models/sd3",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Sd3"
-        },
-        {
-            "id": "accounts/stability/models/sd3-medium",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Sd3 Medium"
-        },
-        {
-            "id": "accounts/stability/models/sd3-turbo",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Sd3 Turbo"
-        },
-        {
-            "id": "accounts/stability/models/stablecode-3b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Stablecode 3B"
-        },
-        {
-            "id": "accounts/stability/models/stablelm-2-zephyr-2b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Stablelm 2 Zephyr 2B"
-        },
-        {
-            "id": "accounts/stability/models/stablelm-zephyr-3b",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "Stablelm Zephyr 3B"
-        },
-        {
-            "id": "accounts/yi-01-ai/models/yi-large",
-            "object": "model",
-            "provider": {
-                "id": "fireworks-ai"
-            },
-            "name": "I Large"
-        },
-        {
-            "id": "gemini-1.0-pro",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Gemini 1.0 Pro"
-        },
-        {
-            "id": "gemini-1.5-flash",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Gemini 1.5 Flash"
-        },
-        {
-            "id": "gemini-1.5-flash-8b-exp-0827",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Gemini 1.5 Flash 8B (Exp 0827)"
-        },
-        {
-            "id": "gemini-1.5-flash-exp-0827",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Gemini 1.5 Flash (Exp 0827)"
-        },
-        {
-            "id": "gemini-1.5-pro",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Gemini 1.5 Pro"
-        },
-        {
-            "id": "gemini-1.5-pro-exp-0801",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Gemini 1.5 Pro (Exp 0801)"
-        },
-        {
-            "id": "gemini-1.5-pro-exp-0827",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Gemini 1.5 Pro (Exp 0827)"
-        },
-        {
-            "id": "text-embedding-004",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Text Embedding 004"
-        },
-        {
-            "id": "aqa",
-            "object": "model",
-            "provider": {
-                "id": "google"
-            },
-            "name": "Attributed Question-Answering"
-        },
-        {
-            "id": "distil-whisper-large-v3-en",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Distil Whisper Large v3 English"
-        },
-        {
-            "id": "gemma2-9b-it",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Gemma 2 9B Italian"
-        },
-        {
-            "id": "gemma-7b-it",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Gemma 7B Italian"
-        },
-        {
-            "id": "llama3-groq-70b-8192-tool-use-preview",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3 Groq 70B 8192 Tool Use Preview"
-        },
-        {
-            "id": "llama3-groq-8b-8192-tool-use-preview",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3 Groq 8B 8192 Tool Use Preview"
-        },
-        {
-            "id": "llama-3.1-70b-versatile",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3.1 70B Versatile"
-        },
-        {
-            "id": "llama-3.1-8b-instant",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3.1 8B Instant"
-        },
-        {
-            "id": "llama-3.2-1b-preview",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3.2 1B Preview"
-        },
-        {
-            "id": "llama-3.2-3b-preview",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3.2 3B Preview"
-        },
-        {
-            "id": "llama-3.2-11b-vision-preview",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3.2 11B Vision Preview"
-        },
-        {
-            "id": "llama-3.2-90b-vision-preview",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3.2 90B Vision Preview"
-        },
-        {
-            "id": "llama-guard-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama Guard 3 8B"
-        },
-        {
-            "id": "yi-large",
-            "object": "model",
-            "provider": {
-                "id": "lingyi"
-            },
-            "name": "Yi Large"
-        },
-        {
-            "id": "yi-large-fc",
-            "object": "model",
-            "provider": {
-                "id": "lingyi"
-            },
-            "name": "Yi Large FC"
-        },
-        {
-            "id": "yi-large-turbo",
-            "object": "model",
-            "provider": {
-                "id": "lingyi"
-            },
-            "name": "Yi Large Turbo"
-        },
-        {
-            "id": "acolyte-22b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Acolyte 22B I1"
-        },
-        {
-            "id": "all-MiniLM-L6-v2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "All Minilm L6 V2"
-        },
-        {
-            "id": "anjir-8b-l3-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Anjir 8B L3 I1"
-        },
-        {
-            "id": "apollo2-9b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Apollo2 9B"
-        },
-        {
-            "id": "arcee-agent",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Arcee Agent"
-        },
-        {
-            "id": "arcee-spark",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Arcee Spark"
-        },
-        {
-            "id": "arch-function-1.5b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Arch Function 1.5B"
-        },
-        {
-            "id": "arch-function-3b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Arch Function 3B"
-        },
-        {
-            "id": "arch-function-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Arch Function 7B"
-        },
-        {
-            "id": "archangel_sft_pythia2-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Archangel_Sft_Pythia2 8B"
-        },
-        {
-            "id": "arliai-llama-3-8b-dolfin-v0.5",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Arliai Llama 3 8B Dolfin V0.5"
-        },
-        {
-            "id": "arliai-llama-3-8b-formax-v1.0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Arliai Llama 3 8B Formax V1.0"
-        },
-        {
-            "id": "astral-fusion-neural-happy-l3.1-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Astral Fusion Neural Happy L3.1 8B"
-        },
-        {
-            "id": "athena-codegemma-2-2b-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Athena Codegemma 2 2B It"
-        },
-        {
-            "id": "aura-llama-abliterated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Aura Llama Abliterated"
-        },
-        {
-            "id": "aura-uncensored-l3-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Aura Uncensored L3 8B Iq Imatrix"
-        },
-        {
-            "id": "aurora_l3_8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Aurora_L3_8B Iq Imatrix"
-        },
-        {
-            "id": "average_normie_l3_v1_8b-gguf-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Average_Normie_L3_V1_8B Gguf Iq Imatrix"
-        },
-        {
-            "id": "aya-23-35b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Aya 23 35B"
-        },
-        {
-            "id": "aya-23-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Aya 23 8B"
-        },
-        {
-            "id": "azure_dusk-v0.2-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Azure_Dusk V0.2 Iq Imatrix"
-        },
-        {
-            "id": "badger-lambda-llama-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Badger Lambda Llama 3 8B"
-        },
-        {
-            "id": "baldur-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Baldur 8B"
-        },
-        {
-            "id": "bert-embeddings",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Bert Embeddings"
-        },
-        {
-            "id": "big-tiger-gemma-27b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Big Tiger Gemma 27B V1"
-        },
-        {
-            "id": "bigqwen2.5-52b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Bigqwen2.5 52B Instruct"
-        },
-        {
-            "id": "biomistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Biomistral 7B"
-        },
-        {
-            "id": "buddy-2b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Buddy 2B V1"
-        },
-        {
-            "id": "bungo-l3-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Bungo L3 8B Iq Imatrix"
-        },
-        {
-            "id": "bunny-llama-3-8b-v",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Bunny Llama 3 8B V"
-        },
-        {
-            "id": "calme-2.1-phi3.5-4b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Calme 2.1 Phi3.5 4B I1"
-        },
-        {
-            "id": "calme-2.2-qwen2-72b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Calme 2.2 Qwen2 72B"
-        },
-        {
-            "id": "calme-2.2-qwen2.5-72b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Calme 2.2 Qwen2.5 72B I1"
-        },
-        {
-            "id": "calme-2.3-legalkit-8b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Calme 2.3 Legalkit 8B I1"
-        },
-        {
-            "id": "calme-2.3-phi3-4b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Calme 2.3 Phi3 4B"
-        },
-        {
-            "id": "calme-2.4-llama3-70b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Calme 2.4 Llama3 70B"
-        },
-        {
-            "id": "calme-2.8-qwen2-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Calme 2.8 Qwen2 7B"
-        },
-        {
-            "id": "cathallama-70b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Cathallama 70B"
-        },
-        {
-            "id": "chaos-rp_l3_b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Chaos Rp_L3_B Iq Imatrix"
-        },
-        {
-            "id": "codellama-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Codellama 7B"
-        },
-        {
-            "id": "codestral-22b-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Codestral 22B V0.1"
-        },
-        {
-            "id": "command-r-v01:q1_s",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Command R V01:Q1_S"
-        },
-        {
-            "id": "cream-phi-3-14b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Cream Phi 3 14B V1"
-        },
-        {
-            "id": "cursorcore-ds-6.7b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Cursorcore Ds 6.7B I1"
-        },
-        {
-            "id": "cursorcore-qw2.5-1.5b-lc-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Cursorcore Qw2.5 1.5B Lc I1"
-        },
-        {
-            "id": "cursorcore-qw2.5-7b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Cursorcore Qw2.5 7B I1"
-        },
-        {
-            "id": "cursorcore-yi-9b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Cursorcore Yi 9B"
-        },
-        {
-            "id": "dans-personalityengine-v1.0.0-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Dans Personalityengine V1.0.0 8B"
-        },
-        {
-            "id": "darkens-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Darkens 8B"
-        },
-        {
-            "id": "darkidol-llama-3.1-8b-instruct-1.0-uncensored-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Darkidol Llama 3.1 8B Instruct 1.0 Uncensored I1"
-        },
-        {
-            "id": "darkidol-llama-3.1-8b-instruct-1.1-uncensored-iq-imatrix-request",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Darkidol Llama 3.1 8B Instruct 1.1 Uncensored Iq Imatrix Request"
-        },
-        {
-            "id": "datagemma-rag-27b-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Datagemma Rag 27B It"
-        },
-        {
-            "id": "datagemma-rig-27b-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Datagemma Rig 27B It"
-        },
-        {
-            "id": "deepseek-coder-v2-lite-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Deepseek Coder V2 Lite Instruct"
-        },
-        {
-            "id": "doctoraifinetune-3.1-8b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Doctoraifinetune 3.1 8B I1"
-        },
-        {
-            "id": "dolphin-2.9-llama3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Dolphin 2.9 Llama3 8B"
-        },
-        {
-            "id": "dolphin-2.9-llama3-8b:Q6_K",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Dolphin 2.9 Llama3 8B:Q6_K"
-        },
-        {
-            "id": "dolphin-2.9.2-phi-3-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Dolphin 2.9.2 Phi 3 Medium"
-        },
-        {
-            "id": "dolphin-2.9.2-phi-3-Medium-abliterated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Dolphin 2.9.2 Phi 3 Medium Abliterated"
-        },
-        {
-            "id": "dolphin-2.9.2-qwen2-72b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Dolphin 2.9.2 Qwen2 72B"
-        },
-        {
-            "id": "dolphin-2.9.2-qwen2-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Dolphin 2.9.2 Qwen2 7B"
-        },
-        {
-            "id": "dreamshaper",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Dreamshaper"
-        },
-        {
-            "id": "duloxetine-4b-v1-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Duloxetine 4B V1 Iq Imatrix"
-        },
-        {
-            "id": "edgerunner-command-nested-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Edgerunner Command Nested I1"
-        },
-        {
-            "id": "edgerunner-tactical-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Edgerunner Tactical 7B"
-        },
-        {
-            "id": "einstein-v4-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Einstein V4 7B"
-        },
-        {
-            "id": "einstein-v6.1-llama3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Einstein V6.1 Llama3 8B"
-        },
-        {
-            "id": "einstein-v7-qwen2-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Einstein V7 Qwen2 7B"
-        },
-        {
-            "id": "emo-2b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Emo 2B"
-        },
-        {
-            "id": "eva-qwen2.5-14b-v0.1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Eva Qwen2.5 14B V0.1 I1"
-        },
-        {
-            "id": "ezo-common-9b-gemma-2-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Ezo Common 9B Gemma 2 It"
-        },
-        {
-            "id": "fimbulvetr-11b-v2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Fimbulvetr 11B V2"
-        },
-        {
-            "id": "fimbulvetr-11b-v2-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Fimbulvetr 11B V2 Iq Imatrix"
-        },
-        {
-            "id": "fireball-llama-3.11-8b-v1orpo",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Fireball Llama 3.11 8B V1Orpo"
-        },
-        {
-            "id": "fireball-meta-llama-3.2-8b-instruct-agent-003-128k-code-dpo",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Fireball Meta Llama 3.2 8B Instruct Agent 003 128K Code Dpo"
-        },
-        {
-            "id": "firefly-gemma-7b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Firefly Gemma 7B Iq Imatrix"
-        },
-        {
-            "id": "flux.1-dev",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Flux.1 Dev"
-        },
-        {
-            "id": "flux.1-schnell",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Flux.1 Schnell"
-        },
-        {
-            "id": "gemma-1.1-7b-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 1.1 7B It"
-        },
-        {
-            "id": "gemma-2-27b-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2 27B It"
-        },
-        {
-            "id": "gemma-2-2b-arliai-rpmax-v1.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2 2B Arliai Rpmax V1.1"
-        },
-        {
-            "id": "gemma-2-9b-arliai-rpmax-v1.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2 9B Arliai Rpmax V1.1"
-        },
-        {
-            "id": "gemma-2-9b-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2 9B It"
-        },
-        {
-            "id": "gemma-2-9b-it-abliterated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2 9B It Abliterated"
-        },
-        {
-            "id": "gemma-2-9b-it-sppo-iter3",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2 9B It Sppo Iter3"
-        },
-        {
-            "id": "gemma-2-ataraxy-v3i-9b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2 Ataraxy V3I 9B"
-        },
-        {
-            "id": "gemma-2b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2B"
-        },
-        {
-            "id": "gemma-2b-translation-v0.150",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma 2B Translation V0.150"
-        },
-        {
-            "id": "gemma2-9b-daybreak-v0.5",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemma2 9B Daybreak V0.5"
-        },
-        {
-            "id": "gemmasutra-mini-2b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemmasutra Mini 2B V1"
-        },
-        {
-            "id": "gemmasutra-pro-27b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemmasutra Pro 27B V1"
-        },
-        {
-            "id": "gemmoy-9b-g2-mk.3-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Gemmoy 9B G2 Mk.3 I1"
-        },
-        {
-            "id": "genius-llama3.1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Genius Llama3.1 I1"
-        },
-        {
-            "id": "guillaumetell-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Guillaumetell 7B"
-        },
-        {
-            "id": "halomaidrp-v1.33-15b-l3-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Halomaidrp V1.33 15B L3 I1"
-        },
-        {
-            "id": "halu-8b-llama3-blackroot-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Halu 8B Llama3 Blackroot Iq Imatrix"
-        },
-        {
-            "id": "hathor_respawn-l3-8b-v0.8",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hathor_Respawn L3 8B V0.8"
-        },
-        {
-            "id": "hathor_stable-v0.2-l3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hathor_Stable V0.2 L3 8B"
-        },
-        {
-            "id": "hathor_tahsin-l3-8b-v0.85",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hathor_Tahsin L3 8B V0.85"
-        },
-        {
-            "id": "hathor-l3-8b-v.01-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hathor L3 8B V.01 Iq Imatrix"
-        },
-        {
-            "id": "helpingai-9b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Helpingai 9B"
-        },
-        {
-            "id": "hercules-5.0-qwen2-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hercules 5.0 Qwen2 7B"
-        },
-        {
-            "id": "hermes-2-pro-llama-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 2 Pro Llama 3 8B"
-        },
-        {
-            "id": "hermes-2-pro-llama-3-8b:Q5_K_M",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 2 Pro Llama 3 8B:Q5_K_M"
-        },
-        {
-            "id": "hermes-2-pro-llama-3-8b:Q8_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 2 Pro Llama 3 8B:Q8_0"
-        },
-        {
-            "id": "hermes-2-pro-mistral",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 2 Pro Mistral"
-        },
-        {
-            "id": "hermes-2-pro-mistral:Q6_K",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 2 Pro Mistral:Q6_K"
-        },
-        {
-            "id": "hermes-2-pro-mistral:Q8_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 2 Pro Mistral:Q8_0"
-        },
-        {
-            "id": "hermes-2-theta-llama-3-70b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 2 Theta Llama 3 70B"
-        },
-        {
-            "id": "hermes-2-theta-llama-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 2 Theta Llama 3 8B"
-        },
-        {
-            "id": "hermes-3-llama-3.1-405b:vllm",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 405B:Vllm"
-        },
-        {
-            "id": "hermes-3-llama-3.1-70b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 70B"
-        },
-        {
-            "id": "hermes-3-llama-3.1-70b-lorablated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 70B Lorablated"
-        },
-        {
-            "id": "hermes-3-llama-3.1-70b:Q5_K_M",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 70B:Q5_K_M"
-        },
-        {
-            "id": "hermes-3-llama-3.1-70b:vllm",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 70B:Vllm"
-        },
-        {
-            "id": "hermes-3-llama-3.1-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 8B"
-        },
-        {
-            "id": "hermes-3-llama-3.1-8b-lorablated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 8B Lorablated"
-        },
-        {
-            "id": "hermes-3-llama-3.1-8b:Q8",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 8B:Q8"
-        },
-        {
-            "id": "hermes-3-llama-3.1-8b:vllm",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hermes 3 Llama 3.1 8B:Vllm"
-        },
-        {
-            "id": "hodachi-ezo-humanities-9b-gemma-2-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hodachi Ezo Humanities 9B Gemma 2 It"
-        },
-        {
-            "id": "hubble-4b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Hubble 4B V1"
-        },
-        {
-            "id": "humanish-roleplay-llama-3.1-8b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Humanish Roleplay Llama 3.1 8B I1"
-        },
-        {
-            "id": "infinity-instruct-7m-gen-llama3_1-70b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Infinity Instruct 7M Gen Llama3_1 70B"
-        },
-        {
-            "id": "internlm2_5-7b-chat-1m",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Internlm2_5 7B Chat 1M"
-        },
-        {
-            "id": "jsl-medllama-3-8b-v2.0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Jsl Medllama 3 8B V2.0"
-        },
-        {
-            "id": "kumiho-v1-rp-uwu-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Kumiho V1 Rp Uwu 8B"
-        },
-        {
-            "id": "kunocchini-7b-128k-test-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Kunocchini 7B 128K Test Imatrix"
-        },
-        {
-            "id": "l3-15b-etherealmaid-t0.0001-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 15B Etherealmaid T0.0001 I1"
-        },
-        {
-            "id": "l3-15b-mythicalmaid-t0.0001",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 15B Mythicalmaid T0.0001"
-        },
-        {
-            "id": "l3-8b-celeste-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Celeste V1"
-        },
-        {
-            "id": "l3-8b-celeste-v1.2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Celeste V1.2"
-        },
-        {
-            "id": "l3-8b-everything-cot",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Everything Cot"
-        },
-        {
-            "id": "l3-8b-lunaris-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Lunaris V1"
-        },
-        {
-            "id": "l3-8b-niitama-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Niitama V1"
-        },
-        {
-            "id": "l3-8b-niitama-v1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Niitama V1 I1"
-        },
-        {
-            "id": "l3-8b-stheno-horny-v3.3-32k-q5_k_m",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Stheno Horny V3.3 32K Q5_K_M"
-        },
-        {
-            "id": "l3-8b-stheno-v3.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Stheno V3.1"
-        },
-        {
-            "id": "l3-8b-stheno-v3.2-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 8B Stheno V3.2 Iq Imatrix"
-        },
-        {
-            "id": "l3-aethora-15b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 Aethora 15B"
-        },
-        {
-            "id": "l3-aethora-15b-v2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 Aethora 15B V2"
-        },
-        {
-            "id": "l3-chaoticsoliloquy-v1.5-4x8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 Chaoticsoliloquy V1.5 4X8B"
-        },
-        {
-            "id": "l3-ms-astoria-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 Ms Astoria 8B"
-        },
-        {
-            "id": "l3-solana-8b-v1-gguf",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 Solana 8B V1 Gguf"
-        },
-        {
-            "id": "l3-stheno-maid-blackroot-grand-horror-16b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 Stheno Maid Blackroot Grand Horror 16B"
-        },
-        {
-            "id": "l3-umbral-mind-rp-v1.0-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 Umbral Mind Rp V1.0 8B Iq Imatrix"
-        },
-        {
-            "id": "l3-uncen-merger-omelette-rp-v0.2-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3 Uncen Merger Omelette Rp V0.2 8B"
-        },
-        {
-            "id": "l3.1-70b-glitz-v0.2-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3.1 70B Glitz V0.2 I1"
-        },
-        {
-            "id": "l3.1-8b-celeste-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3.1 8B Celeste V1.5"
-        },
-        {
-            "id": "l3.1-8b-llamoutcast-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3.1 8B Llamoutcast I1"
-        },
-        {
-            "id": "l3.1-8b-niitama-v1.1-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3.1 8B Niitama V1.1 Iq Imatrix"
-        },
-        {
-            "id": "l3.1-etherealrainbow-v1.0-rc1-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "L3.1 Etherealrainbow V1.0 Rc1 8B"
-        },
-        {
-            "id": "leetcodewizard_7b_v1.1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Leetcodewizard_7B_V1.1 I1"
-        },
-        {
-            "id": "lexi-llama-3-8b-uncensored",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Lexi Llama 3 8B Uncensored"
-        },
-        {
-            "id": "llama-3_8b_unaligned_alpha",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3_8B_Unaligned_Alpha"
-        },
-        {
-            "id": "llama-3_8b_unaligned_alpha_rp_soup-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3_8B_Unaligned_Alpha_Rp_Soup I1"
-        },
-        {
-            "id": "llama-3_8b_unaligned_beta",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3_8B_Unaligned_Beta"
-        },
-        {
-            "id": "llama-3-11.5b-v2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 11.5B V2"
-        },
-        {
-            "id": "llama-3-13b-instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 13B Instruct V0.1"
-        },
-        {
-            "id": "llama-3-8b-instruct-abliterated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 8B Instruct Abliterated"
-        },
-        {
-            "id": "llama-3-8b-instruct-coder",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 8B Instruct Coder"
-        },
-        {
-            "id": "llama-3-8b-instruct-dpo-v0.3-32k",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 8B Instruct Dpo V0.3 32K"
-        },
-        {
-            "id": "llama-3-8b-instruct-mopeymule",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 8B Instruct Mopeymule"
-        },
-        {
-            "id": "llama-3-8b-lexifun-uncensored-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 8B Lexifun Uncensored V1"
-        },
-        {
-            "id": "llama-3-8b-openhermes-dpo",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 8B Openhermes Dpo"
-        },
-        {
-            "id": "llama-3-alpha-centauri-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Alpha Centauri V0.1"
-        },
-        {
-            "id": "llama-3-cursedstock-v1.8-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Cursedstock V1.8 8B Iq Imatrix"
-        },
-        {
-            "id": "llama-3-ezo-8b-common-it",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Ezo 8B Common It"
-        },
-        {
-            "id": "llama-3-hercules-5.0-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Hercules 5.0 8B"
-        },
-        {
-            "id": "llama-3-instruct-8b-SimPO-ExPO",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Instruct 8B Simpo Expo"
-        },
-        {
-            "id": "llama-3-lewdplay-8b-evo",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Lewdplay 8B Evo"
-        },
-        {
-            "id": "llama-3-llamilitary",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Llamilitary"
-        },
-        {
-            "id": "llama-3-lumimaid-8b-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Lumimaid 8B V0.1"
-        },
-        {
-            "id": "llama-3-lumimaid-8b-v0.1-oas-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Lumimaid 8B V0.1 Oas Iq Imatrix"
-        },
-        {
-            "id": "llama-3-lumimaid-v2-8b-v0.1-oas-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Lumimaid V2 8B V0.1 Oas Iq Imatrix"
-        },
-        {
-            "id": "llama-3-patronus-lynx-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Patronus Lynx 70B Instruct"
-        },
-        {
-            "id": "llama-3-perky-pat-instruct-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Perky Pat Instruct 8B"
-        },
-        {
-            "id": "llama-3-refueled",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Refueled"
-        },
-        {
-            "id": "llama-3-sauerkrautlm-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Sauerkrautlm 8B Instruct"
-        },
-        {
-            "id": "llama-3-sec-chat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Sec Chat"
-        },
-        {
-            "id": "llama-3-smaug-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Smaug 8B"
-        },
-        {
-            "id": "llama-3-soliloquy-8b-v2-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Soliloquy 8B V2 Iq Imatrix"
-        },
-        {
-            "id": "llama-3-sqlcoder-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Sqlcoder 8B"
-        },
-        {
-            "id": "llama-3-stheno-mahou-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Stheno Mahou 8B"
-        },
-        {
-            "id": "llama-3-tulu-2-8b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Tulu 2 8B I1"
-        },
-        {
-            "id": "llama-3-tulu-2-dpo-70b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Tulu 2 Dpo 70B I1"
-        },
-        {
-            "id": "llama-3-ultron",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Ultron"
-        },
-        {
-            "id": "llama-3-unholy-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Unholy 8B"
-        },
-        {
-            "id": "llama-3-unholy-8b:Q8_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Unholy 8B:Q8_0"
-        },
-        {
-            "id": "Llama-3-Yggdrasil-2.0-8B",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3 Yggdrasil 2.0 8B"
-        },
-        {
-            "id": "llama-3.1-70b-japanese-instruct-2407",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 70B Japanese Instruct 2407"
-        },
-        {
-            "id": "llama-3.1-8b-arliai-formax-v1.0-iq-arm-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 8B Arliai Formax V1.0 Iq Arm Imatrix"
-        },
-        {
-            "id": "llama-3.1-8b-arliai-rpmax-v1.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 8B Arliai Rpmax V1.1"
-        },
-        {
-            "id": "llama-3.1-8b-instruct-fei-v1-uncensored",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 8B Instruct Fei V1 Uncensored"
-        },
-        {
-            "id": "llama-3.1-8b-stheno-v3.4-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 8B Stheno V3.4 Iq Imatrix"
-        },
-        {
-            "id": "llama-3.1-nemotron-70b-instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 Nemotron 70B Instruct Hf"
-        },
-        {
-            "id": "llama-3.1-storm-8b-q4_k_m",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 Storm 8B Q4_K_M"
-        },
-        {
-            "id": "llama-3.1-supernova-lite",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 Supernova Lite"
-        },
-        {
-            "id": "llama-3.1-supernova-lite-reflection-v1.0-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 Supernova Lite Reflection V1.0 I1"
-        },
-        {
-            "id": "llama-3.1-swallow-70b-v0.1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 Swallow 70B V0.1 I1"
-        },
-        {
-            "id": "llama-3.1-techne-rp-8b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.1 Techne Rp 8B V1"
-        },
-        {
-            "id": "llama-3.2-1b-instruct:q4_k_m",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.2 1B Instruct:Q4_K_M"
-        },
-        {
-            "id": "llama-3.2-1b-instruct:q8_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.2 1B Instruct:Q8_0"
-        },
-        {
-            "id": "llama-3.2-3b-agent007",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.2 3B Agent007"
-        },
-        {
-            "id": "llama-3.2-3b-agent007-coder",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.2 3B Agent007 Coder"
-        },
-        {
-            "id": "llama-3.2-3b-instruct:q4_k_m",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.2 3B Instruct:Q4_K_M"
-        },
-        {
-            "id": "llama-3.2-3b-instruct:q8_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.2 3B Instruct:Q8_0"
-        },
-        {
-            "id": "llama-3.2-3b-reasoning-time",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.2 3B Reasoning Time"
-        },
-        {
-            "id": "llama-3.2-chibi-3b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama 3.2 Chibi 3B"
-        },
-        {
-            "id": "llama-guard-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama Guard 3 8B"
-        },
-        {
-            "id": "llama-salad-8x8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama Salad 8X8B"
-        },
-        {
-            "id": "llama-spark",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama Spark"
-        },
-        {
-            "id": "llama3-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 70B Instruct"
-        },
-        {
-            "id": "llama3-70b-instruct:IQ1_M",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 70B Instruct:Iq1_M"
-        },
-        {
-            "id": "llama3-70b-instruct:IQ1_S",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 70B Instruct:Iq1_S"
-        },
-        {
-            "id": "llama3-8B-aifeifei-1.0-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Aifeifei 1.0 Iq Imatrix"
-        },
-        {
-            "id": "llama3-8B-aifeifei-1.2-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Aifeifei 1.2 Iq Imatrix"
-        },
-        {
-            "id": "llama3-8b-darkidol-1.1-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Darkidol 1.1 Iq Imatrix"
-        },
-        {
-            "id": "llama3-8b-darkidol-1.2-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Darkidol 1.2 Iq Imatrix"
-        },
-        {
-            "id": "llama3-8b-darkidol-2.1-uncensored-1048k-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Darkidol 2.1 Uncensored 1048K Iq Imatrix"
-        },
-        {
-            "id": "llama3-8b-darkidol-2.2-uncensored-1048k-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Darkidol 2.2 Uncensored 1048K Iq Imatrix"
-        },
-        {
-            "id": "llama3-8b-feifei-1.0-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Feifei 1.0 Iq Imatrix"
-        },
-        {
-            "id": "llama3-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Instruct"
-        },
-        {
-            "id": "llama3-8b-instruct-replete-adapted",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Instruct Replete Adapted"
-        },
-        {
-            "id": "llama3-8b-instruct:Q6_K",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 8B Instruct:Q6_K"
-        },
-        {
-            "id": "llama3-iterative-dpo-final",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 Iterative Dpo Final"
-        },
-        {
-            "id": "llama3-turbcat-instruct-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3 Turbcat Instruct 8B"
-        },
-        {
-            "id": "llama3.1-70b-chinese-chat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3.1 70B Chinese Chat"
-        },
-        {
-            "id": "llama3.1-8b-chinese-chat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3.1 8B Chinese Chat"
-        },
-        {
-            "id": "llama3.1-8b-fireplace2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3.1 8B Fireplace2"
-        },
-        {
-            "id": "llama3.1-8b-shiningvaliant2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3.1 8B Shiningvaliant2"
-        },
-        {
-            "id": "llama3.1-flammades-70b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3.1 Flammades 70B"
-        },
-        {
-            "id": "llama3.1-gutenberg-doppel-70b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3.1 Gutenberg Doppel 70B"
-        },
-        {
-            "id": "llama3.2-3b-enigma",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3.2 3B Enigma"
-        },
-        {
-            "id": "llama3.2-3b-esper2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llama3.2 3B Esper2"
-        },
-        {
-            "id": "llamantino-3-anita-8b-inst-dpo-ita",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llamantino 3 Anita 8B Inst Dpo Ita"
-        },
-        {
-            "id": "llamax3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llamax3 8B"
-        },
-        {
-            "id": "llamax3-8b-alpaca",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llamax3 8B Alpaca"
-        },
-        {
-            "id": "llava-1.5",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llava 1.5"
-        },
-        {
-            "id": "llava-1.6-mistral",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llava 1.6 Mistral"
-        },
-        {
-            "id": "llava-1.6-vicuna",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llava 1.6 Vicuna"
-        },
-        {
-            "id": "llava-llama-3-8b-v1_1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llava Llama 3 8B V1_1"
-        },
-        {
-            "id": "llm-compiler-13b-ftd",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llm Compiler 13B Ftd"
-        },
-        {
-            "id": "llm-compiler-13b-imat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llm Compiler 13B Imat"
-        },
-        {
-            "id": "llm-compiler-7b-ftd-imat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llm Compiler 7B Ftd Imat"
-        },
-        {
-            "id": "llm-compiler-7b-imat-GGUF",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Llm Compiler 7B Imat Gguf"
-        },
-        {
-            "id": "LocalAI-llama3-8b-function-call-v0.2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Localai Llama3 8B Function Call V0.2"
-        },
-        {
-            "id": "loki-base-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Loki Base I1"
-        },
-        {
-            "id": "lumimaid-v0.2-12b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Lumimaid V0.2 12B"
-        },
-        {
-            "id": "lumimaid-v0.2-70b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Lumimaid V0.2 70B I1"
-        },
-        {
-            "id": "lumimaid-v0.2-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Lumimaid V0.2 8B"
-        },
-        {
-            "id": "magnum-32b-v1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Magnum 32B V1 I1"
-        },
-        {
-            "id": "magnum-72b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Magnum 72B V1"
-        },
-        {
-            "id": "magnum-v3-34b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Magnum V3 34B"
-        },
-        {
-            "id": "magnusintellectus-12b-v1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Magnusintellectus 12B V1 I1"
-        },
-        {
-            "id": "mahou-1.2-llama3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mahou 1.2 Llama3 8B"
-        },
-        {
-            "id": "mahou-1.3-llama3.1-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mahou 1.3 Llama3.1 8B"
-        },
-        {
-            "id": "mahou-1.3d-mistral-7b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mahou 1.3D Mistral 7B I1"
-        },
-        {
-            "id": "mahou-1.5-llama3.1-70b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mahou 1.5 Llama3.1 70B I1"
-        },
-        {
-            "id": "master-yi-9b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Master Yi 9B"
-        },
-        {
-            "id": "mathstral-7b-v0.1-imat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mathstral 7B V0.1 Imat"
-        },
-        {
-            "id": "meissa-qwen2.5-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meissa Qwen2.5 7B Instruct"
-        },
-        {
-            "id": "meta-llama-3-instruct-12.2b-brainstorm-20x-form-8",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3 Instruct 12.2B Brainstorm 20X Form 8"
-        },
-        {
-            "id": "meta-llama-3-instruct-8.9b-brainstorm-5x-form-11",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3 Instruct 8.9B Brainstorm 5X Form 11"
-        },
-        {
-            "id": "meta-llama-3.1-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3.1 70B Instruct"
-        },
-        {
-            "id": "meta-llama-3.1-8b-claude-imat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3.1 8B Claude Imat"
-        },
-        {
-            "id": "meta-llama-3.1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "meta-llama-3.1-8b-instruct-abliterated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3.1 8B Instruct Abliterated"
-        },
-        {
-            "id": "meta-llama-3.1-8b-instruct:grammar-functioncall",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3.1 8B Instruct:Grammar Functioncall"
-        },
-        {
-            "id": "meta-llama-3.1-8b-instruct:Q8_grammar-functioncall",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3.1 8B Instruct:Q8_Grammar Functioncall"
-        },
-        {
-            "id": "meta-llama-3.1-instruct-9.99b-brainstorm-10x-form-3",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Meta Llama 3.1 Instruct 9.99B Brainstorm 10X Form 3"
-        },
-        {
-            "id": "minicpm-llama3-v-2_5",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Minicpm Llama3 V 2_5"
-        },
-        {
-            "id": "mirai-nova-llama3-LocalAI-8b-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mirai Nova Llama3 Localai 8B V0.1"
-        },
-        {
-            "id": "mistral-7b-instruct-v0.3",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mistral 7B Instruct V0.3"
-        },
-        {
-            "id": "mistral-nemo-instruct-2407",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mistral Nemo Instruct 2407"
-        },
-        {
-            "id": "ml-ms-etheris-123b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Ml Ms Etheris 123B"
-        },
-        {
-            "id": "mn-12b-celeste-v1.9",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mn 12B Celeste V1.9"
-        },
-        {
-            "id": "mn-12b-lyra-v4-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mn 12B Lyra V4 Iq Imatrix"
-        },
-        {
-            "id": "mn-backyardai-party-12b-v1-iq-arm-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mn Backyardai Party 12B V1 Iq Arm Imatrix"
-        },
-        {
-            "id": "mn-lulanum-12b-fix-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Mn Lulanum 12B Fix I1"
-        },
-        {
-            "id": "moe-girl-1ba-7bt-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Moe Girl 1Ba 7Bt I1"
-        },
-        {
-            "id": "moondream2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Moondream2"
-        },
-        {
-            "id": "neural-sovlish-devil-8b-l3-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Neural Sovlish Devil 8B L3 Iq Imatrix"
-        },
-        {
-            "id": "neuraldaredevil-8b-abliterated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Neuraldaredevil 8B Abliterated"
-        },
-        {
-            "id": "new-dawn-llama-3-70b-32K-v1.0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "New Dawn Llama 3 70B 32K V1.0"
-        },
-        {
-            "id": "nightygurps-14b-v1.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Nightygurps 14B V1.1"
-        },
-        {
-            "id": "nihappy-l3.1-8b-v0.09",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Nihappy L3.1 8B V0.09"
-        },
-        {
-            "id": "noromaid-13b-0.4-DPO",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Noromaid 13B 0.4 Dpo"
-        },
-        {
-            "id": "nymph_8b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Nymph_8B I1"
-        },
-        {
-            "id": "nyun-llama3-62b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Nyun Llama3 62B"
-        },
-        {
-            "id": "openbiollm-llama3-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openbiollm Llama3 8B"
-        },
-        {
-            "id": "openbuddy-llama3.1-8b-v22.1-131k",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openbuddy Llama3.1 8B V22.1 131K"
-        },
-        {
-            "id": "openvino-all-MiniLM-L6-v2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openvino All Minilm L6 V2"
-        },
-        {
-            "id": "openvino-hermes2pro-llama3",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openvino Hermes2Pro Llama3"
-        },
-        {
-            "id": "openvino-llama-3-8b-instruct-ov-int8",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openvino Llama 3 8B Instruct Ov Int8"
-        },
-        {
-            "id": "openvino-llama3-aloe",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openvino Llama3 Aloe"
-        },
-        {
-            "id": "openvino-multilingual-e5-base",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openvino Multilingual E5 Base"
-        },
-        {
-            "id": "openvino-phi3",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openvino Phi3"
-        },
-        {
-            "id": "openvino-starling-lm-7b-beta-openvino-int8",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openvino Starling Lm 7B Beta Openvino Int8"
-        },
-        {
-            "id": "openvino-wizardlm2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Openvino Wizardlm2"
-        },
-        {
-            "id": "orthocopter_8b-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Orthocopter_8B Imatrix"
-        },
-        {
-            "id": "pantheon-rp-1.6-12b-nemo",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Pantheon Rp 1.6 12B Nemo"
-        },
-        {
-            "id": "parler-tts-mini-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Parler Tts Mini V0.1"
-        },
-        {
-            "id": "phi-2-chat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 2 Chat"
-        },
-        {
-            "id": "phi-2-chat:Q8_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 2 Chat:Q8_0"
-        },
-        {
-            "id": "phi-2-orange",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 2 Orange"
-        },
-        {
-            "id": "phi-3-medium-4k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 3 Medium 4K Instruct"
-        },
-        {
-            "id": "phi-3-mini-4k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 3 Mini 4K Instruct"
-        },
-        {
-            "id": "phi-3-mini-4k-instruct:fp16",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 3 Mini 4K Instruct:Fp16"
-        },
-        {
-            "id": "phi-3-vision:vllm",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 3 Vision:Vllm"
-        },
-        {
-            "id": "phi-3.1-mini-4k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 3.1 Mini 4K Instruct"
-        },
-        {
-            "id": "phi-3.5-mini-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 3.5 Mini Instruct"
-        },
-        {
-            "id": "phi-3.5-mini-titanfusion-0.2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 3.5 Mini Titanfusion 0.2"
-        },
-        {
-            "id": "phi-3.5-vision:vllm",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi 3.5 Vision:Vllm"
-        },
-        {
-            "id": "phi3-4x4b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phi3 4X4B V1"
-        },
-        {
-            "id": "phillama-3.8b-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Phillama 3.8B V0.1"
-        },
-        {
-            "id": "poppy_porpoise-v0.72-l3-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Poppy_Porpoise V0.72 L3 8B Iq Imatrix"
-        },
-        {
-            "id": "poppy_porpoise-v0.85-l3-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Poppy_Porpoise V0.85 L3 8B Iq Imatrix"
-        },
-        {
-            "id": "poppy_porpoise-v1.0-l3-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Poppy_Porpoise V1.0 L3 8B Iq Imatrix"
-        },
-        {
-            "id": "poppy_porpoise-v1.30-l3-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Poppy_Porpoise V1.30 L3 8B Iq Imatrix"
-        },
-        {
-            "id": "poppy_porpoise-v1.4-l3-8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Poppy_Porpoise V1.4 L3 8B Iq Imatrix"
-        },
-        {
-            "id": "qevacot-7b-v2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qevacot 7B V2"
-        },
-        {
-            "id": "qwen2-1.5b-ita",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2 1.5B Ita"
-        },
-        {
-            "id": "qwen2-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2 7B Instruct"
-        },
-        {
-            "id": "qwen2-7b-instruct-v0.8",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2 7B Instruct V0.8"
-        },
-        {
-            "id": "qwen2-wukong-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2 Wukong 7B"
-        },
-        {
-            "id": "qwen2.5-0.5b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 0.5B Instruct"
-        },
-        {
-            "id": "qwen2.5-1.5b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 1.5B Instruct"
-        },
-        {
-            "id": "qwen2.5-14b_uncencored",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 14B_Uncencored"
-        },
-        {
-            "id": "qwen2.5-14b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 14B Instruct"
-        },
-        {
-            "id": "qwen2.5-32b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 32B"
-        },
-        {
-            "id": "qwen2.5-32b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 32B Instruct"
-        },
-        {
-            "id": "qwen2.5-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 72B Instruct"
-        },
-        {
-            "id": "qwen2.5-7b-ins-v3",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 7B Ins V3"
-        },
-        {
-            "id": "qwen2.5-coder-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 Coder 7B Instruct"
-        },
-        {
-            "id": "qwen2.5-math-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 Math 72B Instruct"
-        },
-        {
-            "id": "qwen2.5-math-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Qwen2.5 Math 7B Instruct"
-        },
-        {
-            "id": "rawr_llama3_8b-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Rawr_Llama3_8B Iq Imatrix"
-        },
-        {
-            "id": "reflection-llama-3.1-70b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Reflection Llama 3.1 70B"
-        },
-        {
-            "id": "replete-coder-instruct-8b-merged",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Replete Coder Instruct 8B Merged"
-        },
-        {
-            "id": "replete-llm-v2.5-qwen-14b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Replete Llm V2.5 Qwen 14B"
-        },
-        {
-            "id": "replete-llm-v2.5-qwen-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Replete Llm V2.5 Qwen 7B"
-        },
-        {
-            "id": "rocinante-12b-v1.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Rocinante 12B V1.1"
-        },
-        {
-            "id": "rombos-llm-v2.5.1-qwen-3b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Rombos Llm V2.5.1 Qwen 3B"
-        },
-        {
-            "id": "salamandra-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Salamandra 7B Instruct"
-        },
-        {
-            "id": "samantha-qwen-2-7B",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Samantha Qwen 2 7B"
-        },
-        {
-            "id": "seeker-9b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Seeker 9B"
-        },
-        {
-            "id": "sekhmet_aleph-l3.1-8b-v0.1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Sekhmet_Aleph L3.1 8B V0.1 I1"
-        },
-        {
-            "id": "sfr-iterative-dpo-llama-3-8b-r",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Sfr Iterative Dpo Llama 3 8B R"
-        },
-        {
-            "id": "shieldgemma-9b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Shieldgemma 9B I1"
-        },
-        {
-            "id": "smegmma-9b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Smegmma 9B V1"
-        },
-        {
-            "id": "smegmma-deluxe-9b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Smegmma Deluxe 9B V1"
-        },
-        {
-            "id": "smollm-1.7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Smollm 1.7B Instruct"
-        },
-        {
-            "id": "sovl_llama3_8b-gguf-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Sovl_Llama3_8B Gguf Iq Imatrix"
-        },
-        {
-            "id": "stable-diffusion-3-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Stable Diffusion 3 Medium"
-        },
-        {
-            "id": "stablediffusion-cpp",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Stablediffusion Cpp"
-        },
-        {
-            "id": "stellardong-72b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Stellardong 72B I1"
-        },
-        {
-            "id": "sunfall-simpo-9b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Sunfall Simpo 9B"
-        },
-        {
-            "id": "sunfall-simpo-9b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Sunfall Simpo 9B I1"
-        },
-        {
-            "id": "supernova-medius",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Supernova Medius"
-        },
-        {
-            "id": "suzume-llama-3-8B-multilingual",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Suzume Llama 3 8B Multilingual"
-        },
-        {
-            "id": "suzume-llama-3-8b-multilingual-orpo-borda-top25",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Suzume Llama 3 8B Multilingual Orpo Borda Top25"
-        },
-        {
-            "id": "t.e-8.1-iq-imatrix-request",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "T.E 8.1 Iq Imatrix Request"
-        },
-        {
-            "id": "tarnished-9b-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tarnished 9B I1"
-        },
-        {
-            "id": "tess-2.0-llama-3-8B",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tess 2.0 Llama 3 8B"
-        },
-        {
-            "id": "tess-v2.5-gemma-2-27b-alpha",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tess V2.5 Gemma 2 27B Alpha"
-        },
-        {
-            "id": "tess-v2.5-phi-3-medium-128k-14b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tess V2.5 Phi 3 Medium 128K 14B"
-        },
-        {
-            "id": "theia-llama-3.1-8b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Theia Llama 3.1 8B V1"
-        },
-        {
-            "id": "therapyllama-8b-v1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Therapyllama 8B V1"
-        },
-        {
-            "id": "tiamat-8b-1.2-llama-3-dpo",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tiamat 8B 1.2 Llama 3 Dpo"
-        },
-        {
-            "id": "tifa-7b-qwen2-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tifa 7B Qwen2 V0.1"
-        },
-        {
-            "id": "tiger-gemma-9b-v1-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tiger Gemma 9B V1 I1"
-        },
-        {
-            "id": "tor-8b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tor 8B"
-        },
-        {
-            "id": "tsunami-0.5x-7b-instruct-i1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Tsunami 0.5X 7B Instruct I1"
-        },
-        {
-            "id": "una-thepitbull-21.4b-v2",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Una Thepitbull 21.4B V2"
-        },
-        {
-            "id": "versatillama-llama-3.2-3b-instruct-abliterated",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Versatillama Llama 3.2 3B Instruct Abliterated"
-        },
-        {
-            "id": "violet_twilight-v0.2-iq-imatrix",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Violet_Twilight V0.2 Iq Imatrix"
-        },
-        {
-            "id": "voice-ca-upc_ona-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Ca Upc_Ona X Low"
-        },
-        {
-            "id": "voice-ca-upc_pau-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Ca Upc_Pau X Low"
-        },
-        {
-            "id": "voice-da-nst_talesyntese-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Da Nst_Talesyntese Medium"
-        },
-        {
-            "id": "voice-de-eva_k-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice De Eva_K X Low"
-        },
-        {
-            "id": "voice-de-karlsson-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice De Karlsson Low"
-        },
-        {
-            "id": "voice-de-kerstin-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice De Kerstin Low"
-        },
-        {
-            "id": "voice-de-pavoque-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice De Pavoque Low"
-        },
-        {
-            "id": "voice-de-ramona-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice De Ramona Low"
-        },
-        {
-            "id": "voice-de-thorsten-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice De Thorsten Low"
-        },
-        {
-            "id": "voice-el-gr-rapunzelina-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice El Gr Rapunzelina Low"
-        },
-        {
-            "id": "voice-en-gb-alan-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Gb Alan Low"
-        },
-        {
-            "id": "voice-en-gb-southern_english_female-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Gb Southern_English_Female Low"
-        },
-        {
-            "id": "voice-en-us_lessac",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us_Lessac"
-        },
-        {
-            "id": "voice-en-us-amy-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Amy Low"
-        },
-        {
-            "id": "voice-en-us-danny-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Danny Low"
-        },
-        {
-            "id": "voice-en-us-kathleen-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Kathleen Low"
-        },
-        {
-            "id": "voice-en-us-kathleen-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Kathleen Low"
-        },
-        {
-            "id": "voice-en-us-lessac-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Lessac Low"
-        },
-        {
-            "id": "voice-en-us-lessac-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Lessac Medium"
-        },
-        {
-            "id": "voice-en-us-libritts-high",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Libritts High"
-        },
-        {
-            "id": "voice-en-us-ryan-high",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Ryan High"
-        },
-        {
-            "id": "voice-en-us-ryan-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Ryan Low"
-        },
-        {
-            "id": "voice-en-us-ryan-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice En Us Ryan Medium"
-        },
-        {
-            "id": "voice-es-carlfm-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Es Carlfm X Low"
-        },
-        {
-            "id": "voice-es-mls_10246-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Es Mls_10246 Low"
-        },
-        {
-            "id": "voice-es-mls_9972-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Es Mls_9972 Low"
-        },
-        {
-            "id": "voice-fi-harri-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Fi Harri Low"
-        },
-        {
-            "id": "voice-fr-gilles-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Fr Gilles Low"
-        },
-        {
-            "id": "voice-fr-mls_1840-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Fr Mls_1840 Low"
-        },
-        {
-            "id": "voice-fr-siwis-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Fr Siwis Low"
-        },
-        {
-            "id": "voice-fr-siwis-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Fr Siwis Medium"
-        },
-        {
-            "id": "voice-is-bui-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Is Bui Medium"
-        },
-        {
-            "id": "voice-is-salka-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Is Salka Medium"
-        },
-        {
-            "id": "voice-is-steinn-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Is Steinn Medium"
-        },
-        {
-            "id": "voice-is-ugla-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Is Ugla Medium"
-        },
-        {
-            "id": "voice-it-paola-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice It Paola Medium"
-        },
-        {
-            "id": "voice-it-riccardo_fasol-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice It Riccardo_Fasol X Low"
-        },
-        {
-            "id": "voice-kk-iseke-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Kk Iseke X Low"
-        },
-        {
-            "id": "voice-kk-issai-high",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Kk Issai High"
-        },
-        {
-            "id": "voice-kk-raya-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Kk Raya X Low"
-        },
-        {
-            "id": "voice-ne-google-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Ne Google Medium"
-        },
-        {
-            "id": "voice-ne-google-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Ne Google X Low"
-        },
-        {
-            "id": "voice-nl-mls_5809-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Nl Mls_5809 Low"
-        },
-        {
-            "id": "voice-nl-mls_7432-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Nl Mls_7432 Low"
-        },
-        {
-            "id": "voice-nl-nathalie-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Nl Nathalie X Low"
-        },
-        {
-            "id": "voice-nl-rdh-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Nl Rdh Medium"
-        },
-        {
-            "id": "voice-nl-rdh-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Nl Rdh X Low"
-        },
-        {
-            "id": "voice-no-talesyntese-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice No Talesyntese Medium"
-        },
-        {
-            "id": "voice-pl-mls_6892-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Pl Mls_6892 Low"
-        },
-        {
-            "id": "voice-pt-br-edresson-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Pt Br Edresson Low"
-        },
-        {
-            "id": "voice-ru-irinia-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Ru Irinia Medium"
-        },
-        {
-            "id": "voice-sv-se-nst-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Sv Se Nst Medium"
-        },
-        {
-            "id": "voice-uk-lada-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Uk Lada X Low"
-        },
-        {
-            "id": "voice-vi-25hours-single-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Vi 25Hours Single Low"
-        },
-        {
-            "id": "voice-vi-vivos-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Vi Vivos X Low"
-        },
-        {
-            "id": "voice-zh_CN-huayan-medium",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Zh_Cn Huayan Medium"
-        },
-        {
-            "id": "voice-zh-cn-huayan-x-low",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Voice Zh Cn Huayan X Low"
-        },
-        {
-            "id": "whisper-1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper 1"
-        },
-        {
-            "id": "whisper-base",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Base"
-        },
-        {
-            "id": "whisper-base-en",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Base En"
-        },
-        {
-            "id": "whisper-base-en-q5_1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Base En Q5_1"
-        },
-        {
-            "id": "whisper-base-q5_1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Base Q5_1"
-        },
-        {
-            "id": "whisper-large-q5_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Large Q5_0"
-        },
-        {
-            "id": "whisper-medium-q5_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Medium Q5_0"
-        },
-        {
-            "id": "whisper-small",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Small"
-        },
-        {
-            "id": "whisper-small",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Small"
-        },
-        {
-            "id": "whisper-small-en-q5_1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Small En Q5_1"
-        },
-        {
-            "id": "whisper-small-q5_1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Small Q5_1"
-        },
-        {
-            "id": "whisper-small-q5_1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Small Q5_1"
-        },
-        {
-            "id": "whisper-tiny",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Tiny"
-        },
-        {
-            "id": "whisper-tiny-en",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Tiny En"
-        },
-        {
-            "id": "whisper-tiny-en-q5_1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Tiny En Q5_1"
-        },
-        {
-            "id": "whisper-tiny-en-q8_0",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Tiny En Q8_0"
-        },
-        {
-            "id": "whisper-tiny-q5_1",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Whisper Tiny Q5_1"
-        },
-        {
-            "id": "wizardlm2-7b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Wizardlm2 7B"
-        },
-        {
-            "id": "yi-1.5-6b-chat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Yi 1.5 6B Chat"
-        },
-        {
-            "id": "yi-1.5-9b-chat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Yi 1.5 9B Chat"
-        },
-        {
-            "id": "yi-coder-1.5b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Yi Coder 1.5B"
-        },
-        {
-            "id": "yi-coder-1.5b-chat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Yi Coder 1.5B Chat"
-        },
-        {
-            "id": "yi-coder-9b",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Yi Coder 9B"
-        },
-        {
-            "id": "yi-coder-9b-chat",
-            "object": "model",
-            "provider": {
-                "id": "local-ai"
-            },
-            "name": "Yi Coder 9B Chat"
-        },
-        {
-            "id": "ministral-3b-latest",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Ministral 3B"
-        },
-        {
-            "id": "ministral-8b-latest",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Ministral 8B"
-        },
-        {
-            "id": "mistral-large-latest",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Mistral Large"
-        },
-        {
-            "id": "mistral-small-latest",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Mistral Small"
-        },
-        {
-            "id": "codestral-latest",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Codestral"
-        },
-        {
-            "id": "mistral-embed",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Mistral Embed"
-        },
-        {
-            "id": "pixtral-12b-2409",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Pixtral"
-        },
-        {
-            "id": "open-mistral-nemo",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Mistral Nemo"
-        },
-        {
-            "id": "open-codestral-mamba",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Codestral Mamba"
-        },
-        {
-            "id": "open-mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Mistral 7B"
-        },
-        {
-            "id": "google/gemma-2-9b-it",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Gemma 2 9B It"
-        },
-        {
-            "id": "img2img",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Img2Img"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Meta Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "microsoft/Phi-3-mini-4k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Phi 3 Mini 4K Instruct"
-        },
-        {
-            "id": "mistralai/Mistral-7B-Instruct-v0.2",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Mistral 7B Instruct V0.2"
-        },
-        {
-            "id": "photo-maker",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Photo Maker"
-        },
-        {
-            "id": "pix2pix",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Pix2Pix"
-        },
-        {
-            "id": "sdxl-base",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Sdxl Base"
-        },
-        {
-            "id": "speech2text",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Speech2Text"
-        },
-        {
-            "id": "speech2text-v2",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Speech2Text V2"
-        },
-        {
-            "id": "sunoai-bark",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Sunoai Bark"
-        },
-        {
-            "id": "txt2img",
-            "object": "model",
-            "provider": {
-                "id": "monsterapi"
-            },
-            "name": "Txt2Img"
-        },
-        {
-            "id": "cognitivecomputations/dolphin-mixtral-8x22b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Dolphin Mixtral 8x22B"
-        },
-        {
-            "id": "google/gemma-2-9b-it",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Gemma 2 9B IT"
-        },
-        {
-            "id": "google/gemma-2-9b-it",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Gemma 2 9B IT"
-        },
-        {
-            "id": "gryphe/mythomax-l2-13b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "MythoMax L2 13B"
-        },
-        {
-            "id": "gryphe/mythomax-l2-13b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "MythoMax L2 13B"
-        },
-        {
-            "id": "jondurbin/airoboros-l2-70b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Airoboros L2 70B"
-        },
-        {
-            "id": "lzlv_70b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "LZLV 70B"
-        },
-        {
-            "id": "meta-llama/llama-3-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Llama 3 70B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Llama 3 8B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.1-405b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Llama 3.1 405B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.1-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Llama 3.1 70B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "microsoft/wizardlm-2-7b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "WizardLM 2 7B"
-        },
-        {
-            "id": "microsoft/wizardlm-2-8x22b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "WizardLM 2 8x22B"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Mistral 7B Instruct"
-        },
-        {
-            "id": "mistralai/mistral-nemo",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Mistral Nemo"
-        },
-        {
-            "id": "nousresearch/hermes-2-pro-llama-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Hermes 2 Pro Llama 3 8B"
-        },
-        {
-            "id": "nousresearch/meta-llama-3.1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Meta Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "nousresearch/nous-hermes-llama2-13b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Nous Hermes Llama 2 13B"
-        },
-        {
-            "id": "openchat/openchat-7b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "OpenChat 7B"
-        },
-        {
-            "id": "qwen/qwen-2-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Qwen 2 72B Instruct"
-        },
-        {
-            "id": "qwen/qwen-2-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Qwen 2 7B Instruct"
-        },
-        {
-            "id": "sao10k/l3-70b-euryale-v2.1",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "L3 70B Euryale v2.1"
-        },
-        {
-            "id": "sao10k/l31-70b-euryale-v2.2",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "L31 70B Euryale v2.2"
-        },
-        {
-            "id": "sophosympatheia/midnight-rose-70b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "Midnight Rose 70B"
-        },
-        {
-            "id": "teknium/openhermes-2.5-mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "novita-ai"
-            },
-            "name": "OpenHermes 2.5 Mistral 7B"
-        },
-        {
-            "id": "alfred",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Alfred"
-        },
-        {
-            "id": "all-minilm",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "All Minilm"
-        },
-        {
-            "id": "aya",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Aya"
-        },
-        {
-            "id": "bakllava",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Bakllava"
-        },
-        {
-            "id": "bespoke-minicheck",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Bespoke Minicheck"
-        },
-        {
-            "id": "bge-large",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Bge Large"
-        },
-        {
-            "id": "bge-m3",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Bge M3"
-        },
-        {
-            "id": "codebooga",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Codebooga"
-        },
-        {
-            "id": "codegeex4",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Codegeex4"
-        },
-        {
-            "id": "codegemma",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Codegemma"
-        },
-        {
-            "id": "codellama",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Codellama"
-        },
-        {
-            "id": "codeqwen",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Codeqwen"
-        },
-        {
-            "id": "codestral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Codestral"
-        },
-        {
-            "id": "codeup",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Codeup"
-        },
-        {
-            "id": "command-r",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Command R"
-        },
-        {
-            "id": "command-r-plus",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Command R Plus"
-        },
-        {
-            "id": "dbrx",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Dbrx"
-        },
-        {
-            "id": "deepseek-coder",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Deepseek Coder"
-        },
-        {
-            "id": "deepseek-coder-v2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Deepseek Coder V2"
-        },
-        {
-            "id": "deepseek-llm",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Deepseek Llm"
-        },
-        {
-            "id": "deepseek-v2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Deepseek V2"
-        },
-        {
-            "id": "deepseek-v2.5",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Deepseek V2.5"
-        },
-        {
-            "id": "dolphin-llama3",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Dolphin Llama3"
-        },
-        {
-            "id": "dolphin-mistral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Dolphin Mistral"
-        },
-        {
-            "id": "dolphin-mixtral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Dolphin Mixtral"
-        },
-        {
-            "id": "dolphin-phi",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Dolphin Phi"
-        },
-        {
-            "id": "dolphincoder",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Dolphincoder"
-        },
-        {
-            "id": "duckdb-nsql",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Duckdb Nsql"
-        },
-        {
-            "id": "everythinglm",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Everythinglm"
-        },
-        {
-            "id": "falcon",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Falcon"
-        },
-        {
-            "id": "falcon2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Falcon2"
-        },
-        {
-            "id": "firefunction-v2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Firefunction V2"
-        },
-        {
-            "id": "gemma",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Gemma"
-        },
-        {
-            "id": "gemma2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Gemma2"
-        },
-        {
-            "id": "glm4",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Glm4"
-        },
-        {
-            "id": "goliath",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Goliath"
-        },
-        {
-            "id": "granite-code",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Granite Code"
-        },
-        {
-            "id": "granite3-dense",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Granite3 Dense"
-        },
-        {
-            "id": "granite3-moe",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Granite3 Moe"
-        },
-        {
-            "id": "hermes3",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Hermes3"
-        },
-        {
-            "id": "internlm2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Internlm2"
-        },
-        {
-            "id": "llama-guard3",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama Guard3"
-        },
-        {
-            "id": "llama-pro",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama Pro"
-        },
-        {
-            "id": "llama2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama2"
-        },
-        {
-            "id": "llama2-chinese",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama2 Chinese"
-        },
-        {
-            "id": "llama2-uncensored",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama2 Uncensored"
-        },
-        {
-            "id": "llama3",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama3"
-        },
-        {
-            "id": "llama3-chatqa",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama3 Chatqa"
-        },
-        {
-            "id": "llama3-gradient",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama3 Gradient"
-        },
-        {
-            "id": "llama3-groq-tool-use",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama3 Groq Tool Use"
-        },
-        {
-            "id": "llama3.1",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama3.1"
-        },
-        {
-            "id": "llama3.2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llama3.2"
-        },
-        {
-            "id": "llava",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llava"
-        },
-        {
-            "id": "llava-llama3",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llava Llama3"
-        },
-        {
-            "id": "llava-phi3",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Llava Phi3"
-        },
-        {
-            "id": "magicoder",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Magicoder"
-        },
-        {
-            "id": "mathstral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mathstral"
-        },
-        {
-            "id": "meditron",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Meditron"
-        },
-        {
-            "id": "medllama2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Medllama2"
-        },
-        {
-            "id": "megadolphin",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Megadolphin"
-        },
-        {
-            "id": "minicpm-v",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Minicpm V"
-        },
-        {
-            "id": "mistral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mistral"
-        },
-        {
-            "id": "mistral-large",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mistral Large"
-        },
-        {
-            "id": "mistral-nemo",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mistral Nemo"
-        },
-        {
-            "id": "mistral-openorca",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mistral Openorca"
-        },
-        {
-            "id": "mistral-small",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mistral Small"
-        },
-        {
-            "id": "mistrallite",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mistrallite"
-        },
-        {
-            "id": "mixtral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mixtral"
-        },
-        {
-            "id": "moondream",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Moondream"
-        },
-        {
-            "id": "mxbai-embed-large",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Mxbai Embed Large"
-        },
-        {
-            "id": "nemotron",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Nemotron"
-        },
-        {
-            "id": "nemotron-mini",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Nemotron Mini"
-        },
-        {
-            "id": "neural-chat",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Neural Chat"
-        },
-        {
-            "id": "nexusraven",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Nexusraven"
-        },
-        {
-            "id": "nomic-embed-text",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Nomic Embed Text"
-        },
-        {
-            "id": "notus",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Notus"
-        },
-        {
-            "id": "notux",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Notux"
-        },
-        {
-            "id": "nous-hermes",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Nous Hermes"
-        },
-        {
-            "id": "nous-hermes2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Nous Hermes2"
-        },
-        {
-            "id": "nous-hermes2-mixtral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Nous Hermes2 Mixtral"
-        },
-        {
-            "id": "nuextract",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Nuextract"
-        },
-        {
-            "id": "open-orca-platypus2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Open Orca Platypus2"
-        },
-        {
-            "id": "openchat",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Openchat"
-        },
-        {
-            "id": "openhermes",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Openhermes"
-        },
-        {
-            "id": "orca-mini",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Orca Mini"
-        },
-        {
-            "id": "orca2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Orca2"
-        },
-        {
-            "id": "paraphrase-multilingual",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Paraphrase Multilingual"
-        },
-        {
-            "id": "phi",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Phi"
-        },
-        {
-            "id": "phi3",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Phi3"
-        },
-        {
-            "id": "phi3.5",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Phi3.5"
-        },
-        {
-            "id": "phind-codellama",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Phind Codellama"
-        },
-        {
-            "id": "qwen",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Qwen"
-        },
-        {
-            "id": "qwen2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Qwen2"
-        },
-        {
-            "id": "qwen2-math",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Qwen2 Math"
-        },
-        {
-            "id": "qwen2.5",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Qwen2.5"
-        },
-        {
-            "id": "qwen2.5-coder",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Qwen2.5 Coder"
-        },
-        {
-            "id": "reader-lm",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Reader Lm"
-        },
-        {
-            "id": "reflection",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Reflection"
-        },
-        {
-            "id": "samantha-mistral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Samantha Mistral"
-        },
-        {
-            "id": "shieldgemma",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Shieldgemma"
-        },
-        {
-            "id": "smollm",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Smollm"
-        },
-        {
-            "id": "snowflake-arctic-embed",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Snowflake Arctic Embed"
-        },
-        {
-            "id": "solar",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Solar"
-        },
-        {
-            "id": "solar-pro",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Solar Pro"
-        },
-        {
-            "id": "sqlcoder",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Sqlcoder"
-        },
-        {
-            "id": "stable-beluga",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Stable Beluga"
-        },
-        {
-            "id": "stable-code",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Stable Code"
-        },
-        {
-            "id": "stablelm-zephyr",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Stablelm Zephyr"
-        },
-        {
-            "id": "stablelm2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Stablelm2"
-        },
-        {
-            "id": "starcoder",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Starcoder"
-        },
-        {
-            "id": "starcoder2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Starcoder2"
-        },
-        {
-            "id": "starling-lm",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Starling Lm"
-        },
-        {
-            "id": "tinydolphin",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Tinydolphin"
-        },
-        {
-            "id": "tinyllama",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Tinyllama"
-        },
-        {
-            "id": "vicuna",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Vicuna"
-        },
-        {
-            "id": "wizard-math",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Wizard Math"
-        },
-        {
-            "id": "wizard-vicuna",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Wizard Vicuna"
-        },
-        {
-            "id": "wizard-vicuna-uncensored",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Wizard Vicuna Uncensored"
-        },
-        {
-            "id": "wizardcoder",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Wizardcoder"
-        },
-        {
-            "id": "wizardlm",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Wizardlm"
-        },
-        {
-            "id": "wizardlm-uncensored",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Wizardlm Uncensored"
-        },
-        {
-            "id": "wizardlm2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Wizardlm2"
-        },
-        {
-            "id": "xwinlm",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Xwinlm"
-        },
-        {
-            "id": "yarn-llama2",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Yarn Llama2"
-        },
-        {
-            "id": "yarn-mistral",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Yarn Mistral"
-        },
-        {
-            "id": "yi",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Yi"
-        },
-        {
-            "id": "yi-coder",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Yi Coder"
-        },
-        {
-            "id": "zephyr",
-            "object": "model",
-            "provider": {
-                "id": "ollama"
-            },
-            "name": "Zephyr"
-        },
-        {
-            "id": "babbage-002",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Babbage 002"
-        },
-        {
-            "id": "chatgpt-4o-latest",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Chatgpt 4o Latest"
-        },
-        {
-            "id": "dall-e-2",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Dall-E 2"
-        },
-        {
-            "id": "dall-e-3",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Dall-E 3"
-        },
-        {
-            "id": "davinci-002",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Davinci 002"
-        },
-        {
-            "id": "gpt-3.5-turbo",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 3.5 Turbo"
-        },
-        {
-            "id": "gpt-3.5-turbo-0125",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 3.5 Turbo 0125"
-        },
-        {
-            "id": "gpt-3.5-turbo-1106",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 3.5 Turbo 1106"
-        },
-        {
-            "id": "gpt-3.5-turbo-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 3.5 Turbo Instruct"
-        },
-        {
-            "id": "gpt-4",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4"
-        },
-        {
-            "id": "gpt-4-0125-preview",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4 0125 Preview"
-        },
-        {
-            "id": "gpt-4-0314",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4 0314"
-        },
-        {
-            "id": "gpt-4-0613",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4 0613"
-        },
-        {
-            "id": "gpt-4-1106-preview",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4 1106 Preview"
-        },
-        {
-            "id": "gpt-4-turbo",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4 Turbo"
-        },
-        {
-            "id": "gpt-4-turbo-2024-04-09",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4 Turbo 2024 04 09"
-        },
-        {
-            "id": "gpt-4-turbo-preview",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4 Turbo Preview"
-        },
-        {
-            "id": "gpt-4o",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT 4o"
-        },
-        {
-            "id": "gpt-4o-2024-05-13",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT-4o 2024 05 13"
-        },
-        {
-            "id": "gpt-4o-2024-08-06",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT-4o 2024 08 06"
-        },
-        {
-            "id": "gpt-4o-audio-preview",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT-4o Audio Preview"
-        },
-        {
-            "id": "gpt-4o-audio-preview-2024-10-01",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT-4o Audio Preview 2024 10 01"
-        },
-        {
-            "id": "gpt-4o-mini",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT-4o Mini"
-        },
-        {
-            "id": "gpt-4o-mini-2024-07-18",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT-4o Mini 2024 07 18"
-        },
-        {
-            "id": "gpt-4o-realtime-preview",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT-4o Realtime Preview"
-        },
-        {
-            "id": "gpt-4o-realtime-preview-2024-10-01",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "GPT-4o Realtime Preview 2024 10 01"
-        },
-        {
-            "id": "hd/1024-x-1024/dall-e-3",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "HD/1024 X 1024/Dall-E 3"
-        },
-        {
-            "id": "o1-mini",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "O1 Mini"
-        },
-        {
-            "id": "o1-mini-2024-09-12",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "O1 Mini 2024-09-12"
-        },
-        {
-            "id": "o1-preview",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "O1 Preview"
-        },
-        {
-            "id": "o1-preview-2024-09-12",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "O1 Preview 2024-09-12"
-        },
-        {
-            "id": "omni-moderation-2024-09-26",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Omni Moderation 2024-09-26"
-        },
-        {
-            "id": "omni-moderation-latest",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Omni Moderation Latest"
-        },
-        {
-            "id": "standard/1024-x-1024/dall-e-3",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Standard/1024 X 1024/Dall-E 3"
-        },
-        {
-            "id": "standard/1024-x-1792/dall-e-3",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Standard/1024 X 1792/Dall-E 3"
-        },
-        {
-            "id": "standard/1792-x-1024/dall-e-3",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Standard/1792 X 1024/Dall-E 3"
-        },
-        {
-            "id": "text-embedding-3-large",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Text Embedding 3 Large"
-        },
-        {
-            "id": "text-embedding-3-small",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Text Embedding 3 Small"
-        },
-        {
-            "id": "text-embedding-ada-002",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Text Embedding Ada 002"
-        },
-        {
-            "id": "text-moderation-007",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Text Moderation 007"
-        },
-        {
-            "id": "text-moderation-latest",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Text Moderation Latest"
-        },
-        {
-            "id": "text-moderation-stable",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Text Moderation Stable"
-        },
-        {
-            "id": "tts-1",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Tts 1"
-        },
-        {
-            "id": "tts-1",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Tts 1"
-        },
-        {
-            "id": "tts-1-hd",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Tts 1 Hd"
-        },
-        {
-            "id": "tts-1-hd",
-            "object": "model",
-            "provider": {
-                "id": "openai"
-            },
-            "name": "Tts 1 Hd"
-        },
-        {
-            "id": "aetherwiing/mn-starcannon-12b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral Nemo 12B Starcannon"
-        },
-        {
-            "id": "ai21/jamba-1-5-large",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "AI21: Jamba 1.5 Large"
-        },
-        {
-            "id": "ai21/jamba-1-5-mini",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "AI21: Jamba 1.5 Mini"
-        },
-        {
-            "id": "ai21/jamba-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "AI21: Jamba Instruct"
-        },
-        {
-            "id": "alpindale/goliath-120b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Goliath 120B"
-        },
-        {
-            "id": "alpindale/magnum-72b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Magnum 72B"
-        },
-        {
-            "id": "anthracite-org/magnum-v2-72b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Magnum v2 72B"
-        },
-        {
-            "id": "anthropic/claude-1",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude v1"
-        },
-        {
-            "id": "anthropic/claude-1.2",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude v1.2"
-        },
-        {
-            "id": "anthropic/claude-2",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude v2"
-        },
-        {
-            "id": "anthropic/claude-2:beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude v2 (self-moderated)"
-        },
-        {
-            "id": "anthropic/claude-2.0",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude v2.0"
-        },
-        {
-            "id": "anthropic/claude-2.0:beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude v2.0 (self-moderated)"
-        },
-        {
-            "id": "anthropic/claude-2.1",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude v2.1"
-        },
-        {
-            "id": "anthropic/claude-2.1:beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude v2.1 (self-moderated)"
-        },
-        {
-            "id": "anthropic/claude-3-haiku",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude 3 Haiku"
-        },
-        {
-            "id": "anthropic/claude-3-haiku:beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude 3 Haiku (self-moderated)"
-        },
-        {
-            "id": "anthropic/claude-3-opus",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude 3 Opus"
-        },
-        {
-            "id": "anthropic/claude-3-opus:beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude 3 Opus (self-moderated)"
-        },
-        {
-            "id": "anthropic/claude-3-sonnet",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude 3 Sonnet"
-        },
-        {
-            "id": "anthropic/claude-3-sonnet:beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude 3 Sonnet (self-moderated)"
-        },
-        {
-            "id": "anthropic/claude-3.5-sonnet",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude 3.5 Sonnet"
-        },
-        {
-            "id": "anthropic/claude-3.5-sonnet:beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude 3.5 Sonnet (self-moderated)"
-        },
-        {
-            "id": "anthropic/claude-instant-1",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude Instant v1"
-        },
-        {
-            "id": "anthropic/claude-instant-1:beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude Instant v1 (self-moderated)"
-        },
-        {
-            "id": "anthropic/claude-instant-1.0",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude Instant v1.0"
-        },
-        {
-            "id": "anthropic/claude-instant-1.1",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Anthropic: Claude Instant v1.1"
-        },
-        {
-            "id": "cognitivecomputations/dolphin-mixtral-8x22b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Dolphin 2.9.2 Mixtral 8x22B \ud83d\udc2c"
-        },
-        {
-            "id": "cognitivecomputations/dolphin-mixtral-8x7b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Dolphin 2.6 Mixtral 8x7B \ud83d\udc2c"
-        },
-        {
-            "id": "cohere/command",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Cohere: Command"
-        },
-        {
-            "id": "cohere/command-r",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Cohere: Command R"
-        },
-        {
-            "id": "cohere/command-r-03-2024",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Cohere: Command R (03-2024)"
-        },
-        {
-            "id": "cohere/command-r-08-2024",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Cohere: Command R (08-2024)"
-        },
-        {
-            "id": "cohere/command-r-plus",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Cohere: Command R+"
-        },
-        {
-            "id": "cohere/command-r-plus-04-2024",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Cohere: Command R+ (04-2024)"
-        },
-        {
-            "id": "cohere/command-r-plus-08-2024",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Cohere: Command R+ (08-2024)"
-        },
-        {
-            "id": "databricks/dbrx-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Databricks: DBRX 132B Instruct"
-        },
-        {
-            "id": "deepseek/deepseek-chat",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "DeepSeek V2.5"
-        },
-        {
-            "id": "eva-unit-01/eva-qwen-2.5-14b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "EVA Qwen2.5 14B"
-        },
-        {
-            "id": "google/gemini-flash-1.5",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemini Flash 1.5"
-        },
-        {
-            "id": "google/gemini-flash-1.5-8b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemini 1.5 Flash-8B"
-        },
-        {
-            "id": "google/gemini-flash-1.5-8b-exp",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemini Flash 8B 1.5 Experimental"
-        },
-        {
-            "id": "google/gemini-flash-1.5-exp",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemini Flash 1.5 Experimental"
-        },
-        {
-            "id": "google/gemini-pro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemini Pro 1.0"
-        },
-        {
-            "id": "google/gemini-pro-1.5",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemini Pro 1.5"
-        },
-        {
-            "id": "google/gemini-pro-1.5-exp",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemini Pro 1.5 Experimental"
-        },
-        {
-            "id": "google/gemini-pro-vision",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemini Pro Vision 1.0"
-        },
-        {
-            "id": "google/gemma-2-27b-it",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemma 2 27B"
-        },
-        {
-            "id": "google/gemma-2-9b-it",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemma 2 9B"
-        },
-        {
-            "id": "google/gemma-2-9b-it:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: Gemma 2 9B (free)"
-        },
-        {
-            "id": "google/palm-2-chat-bison",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: PaLM 2 Chat"
-        },
-        {
-            "id": "google/palm-2-chat-bison-32k",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: PaLM 2 Chat 32k"
-        },
-        {
-            "id": "google/palm-2-codechat-bison",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: PaLM 2 Code Chat"
-        },
-        {
-            "id": "google/palm-2-codechat-bison-32k",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Google: PaLM 2 Code Chat 32k"
-        },
-        {
-            "id": "gryphe/mythomax-l2-13b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "MythoMax 13B"
-        },
-        {
-            "id": "gryphe/mythomax-l2-13b:extended",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "MythoMax 13B (extended)"
-        },
-        {
-            "id": "gryphe/mythomax-l2-13b:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "MythoMax 13B (free)"
-        },
-        {
-            "id": "gryphe/mythomax-l2-13b:nitro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "MythoMax 13B (nitro)"
-        },
-        {
-            "id": "gryphe/mythomist-7b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "MythoMist 7B"
-        },
-        {
-            "id": "gryphe/mythomist-7b:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "MythoMist 7B (free)"
-        },
-        {
-            "id": "huggingfaceh4/zephyr-7b-beta:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Hugging Face: Zephyr 7B (free)"
-        },
-        {
-            "id": "inflection/inflection-3-pi",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Inflection: Inflection 3 Pi"
-        },
-        {
-            "id": "inflection/inflection-3-productivity",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Inflection: Inflection 3 Productivity"
-        },
-        {
-            "id": "jondurbin/airoboros-l2-70b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Airoboros 70B"
-        },
-        {
-            "id": "liquid/lfm-40b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Liquid: LFM 40B MoE"
-        },
-        {
-            "id": "liquid/lfm-40b:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Liquid: LFM 40B MoE (free)"
-        },
-        {
-            "id": "lizpreciatior/lzlv-70b-fp16-hf",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "lzlv 70B"
-        },
-        {
-            "id": "mancer/weaver",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mancer: Weaver (alpha)"
-        },
-        {
-            "id": "meta-llama/llama-2-13b-chat",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama v2 13B Chat"
-        },
-        {
-            "id": "meta-llama/llama-3-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3 70B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3-70b-instruct:nitro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3 70B Instruct (nitro)"
-        },
-        {
-            "id": "meta-llama/llama-3-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3 8B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3-8b-instruct:extended",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3 8B Instruct (extended)"
-        },
-        {
-            "id": "meta-llama/llama-3-8b-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3 8B Instruct (free)"
-        },
-        {
-            "id": "meta-llama/llama-3-8b-instruct:nitro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3 8B Instruct (nitro)"
-        },
-        {
-            "id": "meta-llama/llama-3.1-405b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 405B (base)"
-        },
-        {
-            "id": "meta-llama/llama-3.1-405b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 405B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.1-405b-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 405B Instruct (free)"
-        },
-        {
-            "id": "meta-llama/llama-3.1-405b-instruct:nitro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 405B Instruct (nitro)"
-        },
-        {
-            "id": "meta-llama/llama-3.1-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 70B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.1-70b-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 70B Instruct (free)"
-        },
-        {
-            "id": "meta-llama/llama-3.1-70b-instruct:nitro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 70B Instruct (nitro)"
-        },
-        {
-            "id": "meta-llama/llama-3.1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.1-8b-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.1 8B Instruct (free)"
-        },
-        {
-            "id": "meta-llama/llama-3.2-11b-vision-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.2 11B Vision Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.2-11b-vision-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.2 11B Vision Instruct (free)"
-        },
-        {
-            "id": "meta-llama/llama-3.2-1b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.2 1B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.2-1b-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.2 1B Instruct (free)"
-        },
-        {
-            "id": "meta-llama/llama-3.2-3b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.2 3B Instruct"
-        },
-        {
-            "id": "meta-llama/llama-3.2-3b-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.2 3B Instruct (free)"
-        },
-        {
-            "id": "meta-llama/llama-3.2-90b-vision-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: Llama 3.2 90B Vision Instruct"
-        },
-        {
-            "id": "meta-llama/llama-guard-2-8b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Meta: LlamaGuard 2 8B"
-        },
-        {
-            "id": "microsoft/phi-3-medium-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Phi-3 Medium 128K Instruct"
-        },
-        {
-            "id": "microsoft/phi-3-medium-128k-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Phi-3 Medium 128K Instruct (free)"
-        },
-        {
-            "id": "microsoft/phi-3-mini-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Phi-3 Mini 128K Instruct"
-        },
-        {
-            "id": "microsoft/phi-3-mini-128k-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Phi-3 Mini 128K Instruct (free)"
-        },
-        {
-            "id": "microsoft/phi-3.5-mini-128k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Phi-3.5 Mini 128K Instruct"
-        },
-        {
-            "id": "microsoft/wizardlm-2-7b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "WizardLM-2 7B"
-        },
-        {
-            "id": "microsoft/wizardlm-2-8x22b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "WizardLM-2 8x22B"
-        },
-        {
-            "id": "mistralai/codestral-mamba",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Codestral Mamba"
-        },
-        {
-            "id": "mistralai/ministral-3b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Ministral 3B"
-        },
-        {
-            "id": "mistralai/ministral-8b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Ministral 8B"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Mistral 7B Instruct"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Mistral 7B Instruct v0.1"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct-v0.2",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Mistral 7B Instruct v0.2"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct-v0.3",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Mistral 7B Instruct v0.3"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Mistral 7B Instruct (free)"
-        },
-        {
-            "id": "mistralai/mistral-7b-instruct:nitro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Mistral 7B Instruct (nitro)"
-        },
-        {
-            "id": "mistralai/mistral-large",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral Large"
-        },
-        {
-            "id": "mistralai/mistral-medium",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral Medium"
-        },
-        {
-            "id": "mistralai/mistral-nemo",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Mistral Nemo"
-        },
-        {
-            "id": "mistralai/mistral-small",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral Small"
-        },
-        {
-            "id": "mistralai/mistral-tiny",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral Tiny"
-        },
-        {
-            "id": "mistralai/mixtral-8x22b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Mixtral 8x22B Instruct"
-        },
-        {
-            "id": "mistralai/mixtral-8x7b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mixtral 8x7B (base)"
-        },
-        {
-            "id": "mistralai/mixtral-8x7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mixtral 8x7B Instruct"
-        },
-        {
-            "id": "mistralai/mixtral-8x7b-instruct:nitro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mixtral 8x7B Instruct (nitro)"
-        },
-        {
-            "id": "mistralai/pixtral-12b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral: Pixtral 12B"
-        },
-        {
-            "id": "neversleep/llama-3-lumimaid-70b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Llama 3 Lumimaid 70B"
-        },
-        {
-            "id": "neversleep/llama-3-lumimaid-8b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Llama 3 Lumimaid 8B"
-        },
-        {
-            "id": "neversleep/llama-3-lumimaid-8b:extended",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Llama 3 Lumimaid 8B (extended)"
-        },
-        {
-            "id": "neversleep/llama-3.1-lumimaid-8b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Lumimaid v0.2 8B"
-        },
-        {
-            "id": "neversleep/noromaid-20b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Noromaid 20B"
-        },
-        {
-            "id": "nothingiisreal/mn-celeste-12b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Mistral Nemo 12B Celeste"
-        },
-        {
-            "id": "nousresearch/hermes-2-pro-llama-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "NousResearch: Hermes 2 Pro - Llama-3 8B"
-        },
-        {
-            "id": "nousresearch/hermes-2-theta-llama-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Nous: Hermes 2 Theta 8B"
-        },
-        {
-            "id": "nousresearch/hermes-3-llama-3.1-405b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Nous: Hermes 3 405B Instruct"
-        },
-        {
-            "id": "nousresearch/hermes-3-llama-3.1-405b:extended",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Nous: Hermes 3 405B Instruct (extended)"
-        },
-        {
-            "id": "nousresearch/hermes-3-llama-3.1-405b:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Nous: Hermes 3 405B Instruct (free)"
-        },
-        {
-            "id": "nousresearch/hermes-3-llama-3.1-70b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Nous: Hermes 3 70B Instruct"
-        },
-        {
-            "id": "nousresearch/nous-hermes-2-mixtral-8x7b-dpo",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Nous: Hermes 2 Mixtral 8x7B DPO"
-        },
-        {
-            "id": "nousresearch/nous-hermes-llama2-13b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Nous: Hermes 13B"
-        },
-        {
-            "id": "nvidia/llama-3.1-nemotron-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "NVIDIA: Llama 3.1 Nemotron 70B Instruct"
-        },
-        {
-            "id": "openai/chatgpt-4o-latest",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: ChatGPT-4o"
-        },
-        {
-            "id": "openai/gpt-3.5-turbo",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-3.5 Turbo"
-        },
-        {
-            "id": "openai/gpt-3.5-turbo-0125",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-3.5 Turbo 16k"
-        },
-        {
-            "id": "openai/gpt-3.5-turbo-0613",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-3.5 Turbo (older v0613)"
-        },
-        {
-            "id": "openai/gpt-3.5-turbo-1106",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-3.5 Turbo 16k (older v1106)"
-        },
-        {
-            "id": "openai/gpt-3.5-turbo-16k",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-3.5 Turbo 16k"
-        },
-        {
-            "id": "openai/gpt-3.5-turbo-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-3.5 Turbo Instruct"
-        },
-        {
-            "id": "openai/gpt-4",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4"
-        },
-        {
-            "id": "openai/gpt-4-0314",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4 (older v0314)"
-        },
-        {
-            "id": "openai/gpt-4-1106-preview",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4 Turbo (older v1106)"
-        },
-        {
-            "id": "openai/gpt-4-32k",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4 32k"
-        },
-        {
-            "id": "openai/gpt-4-32k-0314",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4 32k (older v0314)"
-        },
-        {
-            "id": "openai/gpt-4-turbo",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4 Turbo"
-        },
-        {
-            "id": "openai/gpt-4-turbo-preview",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4 Turbo Preview"
-        },
-        {
-            "id": "openai/gpt-4-vision-preview",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4 Vision"
-        },
-        {
-            "id": "openai/gpt-4o",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4o"
-        },
-        {
-            "id": "openai/gpt-4o-2024-05-13",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4o (2024-05-13)"
-        },
-        {
-            "id": "openai/gpt-4o-2024-08-06",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4o (2024-08-06)"
-        },
-        {
-            "id": "openai/gpt-4o-mini",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4o-mini"
-        },
-        {
-            "id": "openai/gpt-4o-mini-2024-07-18",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4o-mini (2024-07-18)"
-        },
-        {
-            "id": "openai/gpt-4o:extended",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: GPT-4o (extended)"
-        },
-        {
-            "id": "openai/o1-mini",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: o1-mini"
-        },
-        {
-            "id": "openai/o1-mini-2024-09-12",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: o1-mini (2024-09-12)"
-        },
-        {
-            "id": "openai/o1-preview",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: o1-preview"
-        },
-        {
-            "id": "openai/o1-preview-2024-09-12",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenAI: o1-preview (2024-09-12)"
-        },
-        {
-            "id": "openchat/openchat-7b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenChat 3.5 7B"
-        },
-        {
-            "id": "openchat/openchat-7b:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenChat 3.5 7B (free)"
-        },
-        {
-            "id": "openrouter/auto",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Auto (best for prompt)"
-        },
-        {
-            "id": "perplexity/llama-3-sonar-large-32k-chat",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Perplexity: Llama3 Sonar 70B"
-        },
-        {
-            "id": "perplexity/llama-3-sonar-large-32k-online",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Perplexity: Llama3 Sonar 70B Online"
-        },
-        {
-            "id": "perplexity/llama-3-sonar-small-32k-chat",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Perplexity: Llama3 Sonar 8B"
-        },
-        {
-            "id": "perplexity/llama-3.1-sonar-huge-128k-online",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Perplexity: Llama 3.1 Sonar 405B Online"
-        },
-        {
-            "id": "perplexity/llama-3.1-sonar-large-128k-chat",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Perplexity: Llama 3.1 Sonar 70B"
-        },
-        {
-            "id": "perplexity/llama-3.1-sonar-large-128k-online",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Perplexity: Llama 3.1 Sonar 70B Online"
-        },
-        {
-            "id": "perplexity/llama-3.1-sonar-small-128k-chat",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Perplexity: Llama 3.1 Sonar 8B"
-        },
-        {
-            "id": "perplexity/llama-3.1-sonar-small-128k-online",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Perplexity: Llama 3.1 Sonar 8B Online"
-        },
-        {
-            "id": "pygmalionai/mythalion-13b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Pygmalion: Mythalion 13B"
-        },
-        {
-            "id": "qwen/qwen-110b-chat",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen 1.5 110B Chat"
-        },
-        {
-            "id": "qwen/qwen-2-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen 2 72B Instruct"
-        },
-        {
-            "id": "qwen/qwen-2-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen 2 7B Instruct"
-        },
-        {
-            "id": "qwen/qwen-2-7b-instruct:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen 2 7B Instruct (free)"
-        },
-        {
-            "id": "qwen/qwen-2-vl-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen2-VL 72B Instruct"
-        },
-        {
-            "id": "qwen/qwen-2-vl-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen2-VL 7B Instruct"
-        },
-        {
-            "id": "qwen/qwen-2.5-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen2.5 72B Instruct"
-        },
-        {
-            "id": "qwen/qwen-2.5-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen2.5 7B Instruct"
-        },
-        {
-            "id": "qwen/qwen-72b-chat",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Qwen 1.5 72B Chat"
-        },
-        {
-            "id": "sao10k/fimbulvetr-11b-v2",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Fimbulvetr 11B v2"
-        },
-        {
-            "id": "sao10k/l3-euryale-70b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Llama 3 Euryale 70B v2.1"
-        },
-        {
-            "id": "sao10k/l3-lunaris-8b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Llama 3 8B Lunaris"
-        },
-        {
-            "id": "sao10k/l3.1-euryale-70b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Llama 3.1 Euryale 70B v2.2"
-        },
-        {
-            "id": "sophosympatheia/midnight-rose-70b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Midnight Rose 70B"
-        },
-        {
-            "id": "teknium/openhermes-2.5-mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "OpenHermes 2.5 Mistral 7B"
-        },
-        {
-            "id": "thedrummer/rocinante-12b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Rocinante 12B"
-        },
-        {
-            "id": "undi95/remm-slerp-l2-13b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "ReMM SLERP 13B"
-        },
-        {
-            "id": "undi95/remm-slerp-l2-13b:extended",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "ReMM SLERP 13B (extended)"
-        },
-        {
-            "id": "undi95/toppy-m-7b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Toppy M 7B"
-        },
-        {
-            "id": "undi95/toppy-m-7b:free",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Toppy M 7B (free)"
-        },
-        {
-            "id": "undi95/toppy-m-7b:nitro",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Toppy M 7B (nitro)"
-        },
-        {
-            "id": "x-ai/grok-beta",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "xAI: Grok Beta"
-        },
-        {
-            "id": "xwin-lm/xwin-lm-70b",
-            "object": "model",
-            "provider": {
-                "id": "openrouter"
-            },
-            "name": "Xwin 70B"
-        },
-        {
-            "id": "llama-3.1-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "perplexity"
-            },
-            "name": "Llama 3.1 70B Instruct"
-        },
-        {
-            "id": "llama-3.1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "perplexity"
-            },
-            "name": "Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "llama-3.1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "perplexity"
-            },
-            "name": "Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "llama-3.1-sonar-huge-128k-online",
-            "object": "model",
-            "provider": {
-                "id": "perplexity"
-            },
-            "name": "Llama 3.1 Sonar Huge 128k Online"
-        },
-        {
-            "id": "llama-3.1-sonar-large-128k-chat",
-            "object": "model",
-            "provider": {
-                "id": "perplexity"
-            },
-            "name": "Llama 3.1 Sonar Large 128k Chat"
-        },
-        {
-            "id": "llama-3.1-sonar-large-128k-online",
-            "object": "model",
-            "provider": {
-                "id": "perplexity"
-            },
-            "name": "Llama 3.1 Sonar Large 128k Online"
-        },
-        {
-            "id": "llama-3.1-sonar-small-128k-chat",
-            "object": "model",
-            "provider": {
-                "id": "perplexity"
-            },
-            "name": "Llama 3.1 Sonar Small 128k Chat"
-        },
-        {
-            "id": "llama-3.1-sonar-small-128k-online",
-            "object": "model",
-            "provider": {
-                "id": "perplexity"
-            },
-            "name": "Llama 3.1 Sonar Small 128k Online"
-        },
-        {
-            "id": "codellama-13b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Codellama 13B Instruct"
-        },
-        {
-            "id": "codellama-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Codellama 70B Instruct"
-        },
-        {
-            "id": "codellama-7b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Codellama 7B"
-        },
-        {
-            "id": "codellama-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Codellama 7B Instruct"
-        },
-        {
-            "id": "gemma-2-27b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Gemma 2 27B"
-        },
-        {
-            "id": "gemma-2-27b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Gemma 2 27B Instruct"
-        },
-        {
-            "id": "gemma-2-9b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Gemma 2 9B"
-        },
-        {
-            "id": "gemma-2-9b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Gemma 2 9B Instruct"
-        },
-        {
-            "id": "gemma-2b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Gemma 2B"
-        },
-        {
-            "id": "gemma-2b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Gemma 2B Instruct"
-        },
-        {
-            "id": "gemma-7b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Gemma 7B"
-        },
-        {
-            "id": "gemma-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Gemma 7B Instruct"
-        },
-        {
-            "id": "llama-2-13b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 2 13B"
-        },
-        {
-            "id": "llama-2-13b-chat",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 2 13B Chat"
-        },
-        {
-            "id": "llama-2-70b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 2 70B"
-        },
-        {
-            "id": "llama-2-70b-chat",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 2 70B Chat"
-        },
-        {
-            "id": "llama-2-7b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 2 7B"
-        },
-        {
-            "id": "llama-2-7b-chat",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 2 7B Chat"
-        },
-        {
-            "id": "llama-3-1-8b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 3 1 8B"
-        },
-        {
-            "id": "llama-3-1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 3 1 8B Instruct"
-        },
-        {
-            "id": "llama-3-70b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 3 70B"
-        },
-        {
-            "id": "llama-3-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 3 70B Instruct"
-        },
-        {
-            "id": "llama-3-8b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 3 8B"
-        },
-        {
-            "id": "llama-3-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Llama 3 8B Instruct"
-        },
-        {
-            "id": "mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Mistral 7B"
-        },
-        {
-            "id": "mistral-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Mistral 7B Instruct"
-        },
-        {
-            "id": "mistral-7b-instruct-v0-2",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Mistral 7B Instruct V0 2"
-        },
-        {
-            "id": "mistral-7b-instruct-v0-3",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Mistral 7B Instruct V0 3"
-        },
-        {
-            "id": "mistral-nemo-12b-2407",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Mistral Nemo 12B 2407"
-        },
-        {
-            "id": "mistral-nemo-12b-instruct-2407",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Mistral Nemo 12B Instruct 2407"
-        },
-        {
-            "id": "mixtral-8x7b-instruct-v0-1",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Mixtral 8X7B Instruct V0 1"
-        },
-        {
-            "id": "mixtral-8x7b-v0-1",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Mixtral 8X7B V0 1"
-        },
-        {
-            "id": "phi-2",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Phi 2"
-        },
-        {
-            "id": "phi-3-5-mini-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Phi 3 5 Mini Instruct"
-        },
-        {
-            "id": "phi-3-mini-4k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Phi 3 Mini 4K Instruct"
-        },
-        {
-            "id": "qwen2-1-5b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Qwen2 1 5B"
-        },
-        {
-            "id": "qwen2-1-5b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Qwen2 1 5B Instruct"
-        },
-        {
-            "id": "qwen2-72b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Qwen2 72B"
-        },
-        {
-            "id": "qwen2-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Qwen2 72B Instruct"
-        },
-        {
-            "id": "qwen2-7b",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Qwen2 7B"
-        },
-        {
-            "id": "qwen2-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Qwen2 7B Instruct"
-        },
-        {
-            "id": "solar-1-mini-chat-240612",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Solar 1 Mini Chat 240612"
-        },
-        {
-            "id": "solar-pro-preview-instruct",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Solar Pro Preview Instruct"
-        },
-        {
-            "id": "zephyr-7b-beta",
-            "object": "model",
-            "provider": {
-                "id": "predibase"
-            },
-            "name": "Zephyr 7B Beta"
-        },
-        {
-            "id": "reka-core",
-            "object": "model",
-            "provider": {
-                "id": "reka"
-            },
-            "name": "Reka Core"
-        },
-        {
-            "id": "reka-edge",
-            "object": "model",
-            "provider": {
-                "id": "reka"
-            },
-            "name": "Reka Edge"
-        },
-        {
-            "id": "reka-flash",
-            "object": "model",
-            "provider": {
-                "id": "reka"
-            },
-            "name": "Reka Flash"
-        },
-        {
-            "id": "rerank-2",
-            "object": "model",
-            "provider": {
-                "id": "voyage"
-            },
-            "name": "Rerank 2"
-        },
-        {
-            "id": "rerank-2-lite",
-            "object": "model",
-            "provider": {
-                "id": "voyage"
-            },
-            "name": "Rerank 2 Lite"
-        },
-        {
-            "id": "voyage-3",
-            "object": "model",
-            "provider": {
-                "id": "voyage"
-            },
-            "name": "Voyage 3"
-        },
-        {
-            "id": "voyage-3-lite",
-            "object": "model",
-            "provider": {
-                "id": "voyage"
-            },
-            "name": "Voyage 3 Lite"
-        },
-        {
-            "id": "voyage-code-2",
-            "object": "model",
-            "provider": {
-                "id": "voyage"
-            },
-            "name": "Voyage Code 2"
-        },
-        {
-            "id": "voyage-finance-2",
-            "object": "model",
-            "provider": {
-                "id": "voyage"
-            },
-            "name": "Voyage Finance 2"
-        },
-        {
-            "id": "voyage-law-2",
-            "object": "model",
-            "provider": {
-                "id": "voyage"
-            },
-            "name": "Voyage Law 2"
-        },
-        {
-            "id": "voyage-multilingual-2",
-            "object": "model",
-            "provider": {
-                "id": "voyage"
-            },
-            "name": "Voyage Multilingual 2"
-        },
-        {
-            "id": "bart-large-cnn",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Bart Large Cnn"
-        },
-        {
-            "id": "bge-base-en-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Bge Base En V1.5"
-        },
-        {
-            "id": "bge-large-en-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Bge Large En V1.5"
-        },
-        {
-            "id": "bge-small-en-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Bge Small En V1.5"
-        },
-        {
-            "id": "deepseek-coder-6.7b-base-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Deepseek Coder 6.7B Base Awq"
-        },
-        {
-            "id": "deepseek-coder-6.7b-instruct-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Deepseek Coder 6.7B Instruct Awq"
-        },
-        {
-            "id": "deepseek-math-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Deepseek Math 7B Instruct"
-        },
-        {
-            "id": "detr-resnet-50",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Detr Resnet 50"
-        },
-        {
-            "id": "discolm-german-7b-v1-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Discolm German 7B V1 Awq"
-        },
-        {
-            "id": "distilbert-sst-2-int8",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Distilbert Sst 2 Int8"
-        },
-        {
-            "id": "dreamshaper-8-lcm",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Dreamshaper 8 Lcm"
-        },
-        {
-            "id": "falcon-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Falcon 7B Instruct"
-        },
-        {
-            "id": "flux-1-schnell",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Flux 1 Schnell"
-        },
-        {
-            "id": "gemma-2b-it-lora",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Gemma 2B It Lora"
-        },
-        {
-            "id": "gemma-7b-it",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Gemma 7B It"
-        },
-        {
-            "id": "gemma-7b-it-lora",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Gemma 7B It Lora"
-        },
-        {
-            "id": "hermes-2-pro-mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Hermes 2 Pro Mistral 7B"
-        },
-        {
-            "id": "llama-2-13b-chat-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 2 13B Chat Awq"
-        },
-        {
-            "id": "llama-2-7b-chat-fp16",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 2 7B Chat Fp16"
-        },
-        {
-            "id": "llama-2-7b-chat-hf-lora",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 2 7B Chat Hf Lora"
-        },
-        {
-            "id": "llama-2-7b-chat-int8",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 2 7B Chat Int8"
-        },
-        {
-            "id": "llama-3-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3 8B Instruct"
-        },
-        {
-            "id": "llama-3-8b-instruct-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3 8B Instruct Awq"
-        },
-        {
-            "id": "llama-3.1-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3.1 70B Instruct"
-        },
-        {
-            "id": "llama-3.1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "llama-3.1-8b-instruct-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3.1 8B Instruct Awq"
-        },
-        {
-            "id": "llama-3.1-8b-instruct-fast",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3.1 8B Instruct Fast"
-        },
-        {
-            "id": "llama-3.1-8b-instruct-fp8",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3.1 8B Instruct Fp8"
-        },
-        {
-            "id": "llama-3.2-11b-vision-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3.2 11B Vision Instruct"
-        },
-        {
-            "id": "llama-3.2-1b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3.2 1B Instruct"
-        },
-        {
-            "id": "llama-3.2-3b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llama 3.2 3B Instruct"
-        },
-        {
-            "id": "llamaguard-7b-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llamaguard 7B Awq"
-        },
-        {
-            "id": "llava-1.5-7b-hf",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Llava 1.5 7B Hf"
-        },
-        {
-            "id": "m2m100-1.2b",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "M2M100 1.2B"
-        },
-        {
-            "id": "meta-llama-3-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Meta Llama 3 8B Instruct"
-        },
-        {
-            "id": "mistral-7b-instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Mistral 7B Instruct V0.1"
-        },
-        {
-            "id": "mistral-7b-instruct-v0.1-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Mistral 7B Instruct V0.1 Awq"
-        },
-        {
-            "id": "mistral-7b-instruct-v0.2",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Mistral 7B Instruct V0.2"
-        },
-        {
-            "id": "mistral-7b-instruct-v0.2-lora",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Mistral 7B Instruct V0.2 Lora"
-        },
-        {
-            "id": "neural-chat-7b-v3-1-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Neural Chat 7B V3 1 Awq"
-        },
-        {
-            "id": "openchat-3.5-0106",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Openchat 3.5 0106"
-        },
-        {
-            "id": "openhermes-2.5-mistral-7b-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Openhermes 2.5 Mistral 7B Awq"
-        },
-        {
-            "id": "phi-2",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Phi 2"
-        },
-        {
-            "id": "qwen1.5-0.5b-chat",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Qwen1.5 0.5B Chat"
-        },
-        {
-            "id": "qwen1.5-1.8b-chat",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Qwen1.5 1.8B Chat"
-        },
-        {
-            "id": "qwen1.5-14b-chat-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Qwen1.5 14B Chat Awq"
-        },
-        {
-            "id": "qwen1.5-7b-chat-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Qwen1.5 7B Chat Awq"
-        },
-        {
-            "id": "resnet-50",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Resnet 50"
-        },
-        {
-            "id": "sqlcoder-7b-2",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Sqlcoder 7B 2"
-        },
-        {
-            "id": "stable-diffusion-v1-5-img2img",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Stable Diffusion V1 5 Img2Img"
-        },
-        {
-            "id": "stable-diffusion-v1-5-inpainting",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Stable Diffusion V1 5 Inpainting"
-        },
-        {
-            "id": "stable-diffusion-xl-base-1.0",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Stable Diffusion Xl Base 1.0"
-        },
-        {
-            "id": "stable-diffusion-xl-lightning",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Stable Diffusion Xl Lightning"
-        },
-        {
-            "id": "starling-lm-7b-beta",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Starling Lm 7B Beta"
-        },
-        {
-            "id": "tinyllama-1.1b-chat-v1.0",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Tinyllama 1.1B Chat V1.0"
-        },
-        {
-            "id": "uform-gen2-qwen-500m",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Uform Gen2 Qwen 500M"
-        },
-        {
-            "id": "una-cybertron-7b-v2-bf16",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Una Cybertron 7B V2 Bf16"
-        },
-        {
-            "id": "whisper",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Whisper"
-        },
-        {
-            "id": "whisper-tiny-en",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Whisper Tiny En"
-        },
-        {
-            "id": "zephyr-7b-beta-awq",
-            "object": "model",
-            "provider": {
-                "id": "workers-ai"
-            },
-            "name": "Zephyr 7B Beta Awq"
-        },
-        {
-            "id": "glm-3-turbo",
-            "object": "model",
-            "provider": {
-                "id": "zhipu"
-            },
-            "name": "GLM-3 Turbo"
-        },
-        {
-            "id": "glm-4",
-            "object": "model",
-            "provider": {
-                "id": "zhipu"
-            },
-            "name": "GLM-4"
-        },
-        {
-            "id": "glm-4-0520",
-            "object": "model",
-            "provider": {
-                "id": "zhipu"
-            },
-            "name": "GLM-4 0520"
-        },
-        {
-            "id": "glm-4-air",
-            "object": "model",
-            "provider": {
-                "id": "zhipu"
-            },
-            "name": "GLM-4 Air"
-        },
-        {
-            "id": "glm-4-airx",
-            "object": "model",
-            "provider": {
-                "id": "zhipu"
-            },
-            "name": "GLM-4 AirX"
-        },
-        {
-            "id": "glm-4-flashx",
-            "object": "model",
-            "provider": {
-                "id": "zhipu"
-            },
-            "name": "GLM-4 FlashX"
-        },
-        {
-            "id": "glm-4-long",
-            "object": "model",
-            "provider": {
-                "id": "zhipu"
-            },
-            "name": "GLM-4 Long"
-        },
-        {
-            "id": "glm-4-plus",
-            "object": "model",
-            "provider": {
-                "id": "zhipu"
-            },
-            "name": "GLM-4 Plus"
-        },
-        {
-            "id": "mistralai/Mixtral-8x22B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "anyscale"
-            },
-            "name": "Mixtral 8x22B Instruct v0.1"
-        },
-        {
-            "id": "Llama-3.2-3B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 3.2 3B Instruct"
-        },
-        {
-            "id": "Llama-3.2-1B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 3.2 1B Instruct"
-        },
-        {
-            "id": "Llama-Guard-3-11B-Vision",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama Guard 3 11B Vision"
-        },
-        {
-            "id": "Llama-3.2-11B-Vision-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 3.2 11B Vision Instruct"
-        },
-        {
-            "id": "Llama-Guard-3-1B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama Guard 3 1B"
-        },
-        {
-            "id": "Llama-3.2-90B-Vision-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 3.2 90B Vision Instruct"
-        },
-        {
-            "id": "Llama-2-7b",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 2 7B"
-        },
-        {
-            "id": "Llama-2-70b",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 2 70B"
-        },
-        {
-            "id": "Llama-2-13b",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 2 13B"
-        },
-        {
-            "id": "Llama-2-7b-chat",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 2 7B Chat"
-        },
-        {
-            "id": "Llama-2-70b-chat",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 2 70B Chat"
-        },
-        {
-            "id": "Llama-2-13b-chat",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Llama 2 13B Chat"
-        },
-        {
-            "id": "CodeLlama-7b-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 7B HF"
-        },
-        {
-            "id": "CodeLlama-7b-Python-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 7B Python HF"
-        },
-        {
-            "id": "CodeLlama-7b-Instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 7B Instruct HF"
-        },
-        {
-            "id": "CodeLlama-34b-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 34B HF"
-        },
-        {
-            "id": "CodeLlama-34b-Python-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 34B Python HF"
-        },
-        {
-            "id": "CodeLlama-34b-Instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 34B Instruct HF"
-        },
-        {
-            "id": "CodeLlama-13b-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 13B HF"
-        },
-        {
-            "id": "CodeLlama-13b-Python-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 13B Python HF"
-        },
-        {
-            "id": "CodeLlama-13b-Instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 13B Instruct HF"
-        },
-        {
-            "id": "Prompt-Guard-86M",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Prompt Guard 86M"
-        },
-        {
-            "id": "Meta-Llama-3.1-405B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Meta Llama 3.1 405B Instruct"
-        },
-        {
-            "id": "Ministral-3B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Ministral 3B"
-        },
-        {
-            "id": "Mistral-large-2407",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mistral Large 2407"
-        },
-        {
-            "id": "Mistral-Nemo",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mistral Nemo"
-        },
-        {
-            "id": "mistralai-Mixtral-8x7B-v01",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mixtral 8x7B v01"
-        },
-        {
-            "id": "mistralai-Mixtral-8x7B-Instruct-v01",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mixtral 8x7B Instruct v01"
-        },
-        {
-            "id": "mistralai-Mixtral-8x22B-v0-1",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mixtral 8x22B v0-1"
-        },
-        {
-            "id": "mistralai-Mixtral-8x22B-Instruct-v0-1",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mixtral 8x22B Instruct v0-1"
-        },
-        {
-            "id": "mistralai-Mistral-7B-v01",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mistral 7B v01"
-        },
-        {
-            "id": "mistralai-Mistral-7B-Instruct-v0-2",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mistral 7B Instruct v0-2"
-        },
-        {
-            "id": "mistral-community-Mixtral-8x22B-v0-1",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mixtral 8x22B v0-1"
-        },
-        {
-            "id": "mistralai-Mistral-7B-Instruct-v01",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mistral 7B Instruct v01"
-        },
-        {
-            "id": "Mistral-small",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mistral Small"
-        },
-        {
-            "id": "Mistral-large",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Mistral Large"
-        },
-        {
-            "id": "Nemotron-3-8B-Chat-SteerLM",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Nemotron 3 8B Chat SteerLM"
-        },
-        {
-            "id": "Nemotron-3-8B-Chat-RLHF",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Nemotron 3 8B Chat RLHF"
-        },
-        {
-            "id": "Nemotron-3-8B-Chat-SFT",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Nemotron 3 8B Chat SFT"
-        },
-        {
-            "id": "AI21-Jamba-1.5-Mini",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "AI21 Jamba 1.5 Mini"
-        },
-        {
-            "id": "AI21-Jamba-1.5-Large",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "AI21 Jamba 1.5 Large"
-        },
-        {
-            "id": "Deci-DeciLM-7B-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DeciLM 7B Instruct"
-        },
-        {
-            "id": "Deci-DeciLM-7B",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DeciLM 7B"
-        },
-        {
-            "id": "Deci-DeciCoder-1b",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DeciCoder 1B"
-        },
-        {
-            "id": "TimeGEN-1",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "TimeGEN 1"
-        },
-        {
-            "id": "jais-30b-chat",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Jais 30B Chat"
-        },
-        {
-            "id": "Cohere-command-r-plus-08-2024",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Cohere Command R+ 08-2024"
-        },
-        {
-            "id": "Cohere-command-r-08-2024",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Cohere Command R 08-2024"
-        },
-        {
-            "id": "Cohere-rerank-v3-multilingual",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Cohere Rerank v3 Multilingual"
-        },
-        {
-            "id": "Cohere-rerank-v3-english",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Cohere Rerank v3 English"
-        },
-        {
-            "id": "Cohere-embed-v3-multilingual",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Cohere Embed v3 Multilingual"
-        },
-        {
-            "id": "Cohere-embed-v3-english",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Cohere Embed v3 English"
-        },
-        {
-            "id": "Cohere-command-r-plus",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Cohere Command R+"
-        },
-        {
-            "id": "Cohere-command-r",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Cohere Command R"
-        },
-        {
-            "id": "databricks-dolly-v2-12b",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Dolly v2 12B"
-        },
-        {
-            "id": "snowflake-arctic-base",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Snowflake Arctic Base"
-        },
-        {
-            "id": "ALLaM-2-7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "ALLaM 2 7B Instruct"
-        },
-        {
-            "id": "MedImageParse",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "MedImageParse"
-        },
-        {
-            "id": "MedImageInsight",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "MedImageInsight"
-        },
-        {
-            "id": "CxrReportGen",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CxrReportGen"
-        },
-        {
-            "id": "Virchow2",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Virchow2"
-        },
-        {
-            "id": "Prism",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Prism"
-        },
-        {
-            "id": "Virchow",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Virchow"
-        },
-        {
-            "id": "BiomedCLIP-PubMedBERT_256-vit_base_patch16_224",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "BiomedCLIP PubMedBERT_256-vit_base_patch16_224"
-        },
-        {
-            "id": "microsoft-llava-med-v1.5-mistral-7b",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Microsoft LLaMA-Med v1.5 Mistral 7B"
-        },
-        {
-            "id": "snowflake-arctic-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Snowflake Arctic Instruct"
-        },
-        {
-            "id": "facebook-dinov2-base-imagenet1k-1-layer",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DinoV2 Base ImageNet1K 1-Layer"
-        },
-        {
-            "id": "CodeLlama-70b-Python-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 70B Python HF"
-        },
-        {
-            "id": "microsoft-phi-1-5",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Microsoft Phi-1.5"
-        },
-        {
-            "id": "CodeLlama-70b-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 70B HF"
-        },
-        {
-            "id": "CodeLlama-70b-Instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "CodeLlama 70B Instruct HF"
-        },
-        {
-            "id": "deci-decidiffusion-v1-0",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Deci Diffusion v1.0"
-        },
-        {
-            "id": "facebook-deit-base-patch16-224",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DEiT Base Patch16 224"
-        },
-        {
-            "id": "openai-clip-vit-large-patch14",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "OpenAI CLIP ViT-Large Patch14"
-        },
-        {
-            "id": "openai-clip-vit-base-patch32",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "OpenAI CLIP ViT-Base Patch32"
-        },
-        {
-            "id": "facebook-sam-vit-large",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "SAM ViT-Large"
-        },
-        {
-            "id": "facebook-sam-vit-huge",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "SAM ViT-Huge"
-        },
-        {
-            "id": "facebook-sam-vit-base",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "SAM ViT-Base"
-        },
-        {
-            "id": "OpenAI-CLIP-Image-Text-Embeddings-vit-base-patch32",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "OpenAI CLIP Image Text Embeddings ViT-Base Patch32"
-        },
-        {
-            "id": "microsoft-phi-2",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Microsoft Phi-2"
-        },
-        {
-            "id": "microsoft-swinv2-base-patch4-window12-192-22k",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "SwinV2 Base Patch4 Window12 192 22K"
-        },
-        {
-            "id": "microsoft-beit-base-patch16-224-pt22k-ft22k",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "BEiT Base Patch16 224 PT22K FT22K"
-        },
-        {
-            "id": "OpenAI-CLIP-Image-Text-Embeddings-ViT-Large-Patch14-336",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "OpenAI CLIP Image Text Embeddings ViT-Large Patch14 336"
-        },
-        {
-            "id": "Facebook-DinoV2-Image-Embeddings-ViT-Giant",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DinoV2 Image Embeddings ViT-Giant"
-        },
-        {
-            "id": "Facebook-DinoV2-Image-Embeddings-ViT-Base",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DinoV2 Image Embeddings ViT-Base"
-        },
-        {
-            "id": "microsoft-Orca-2-7b",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Microsoft Orca 2 7B"
-        },
-        {
-            "id": "microsoft-Orca-2-13b",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "Microsoft Orca 2 13B"
-        },
-        {
-            "id": "databricks-dbrx-instruct",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DBRX Instruct"
-        },
-        {
-            "id": "databricks-dbrx-base",
-            "object": "model",
-            "provider": {
-                "id": "azure"
-            },
-            "name": "DBRX Base"
-        },
-        {
-            "id": "stable-diffusion-3.5-turbo-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 3.5 Turbo Text-to-Image"
-        },
-        {
-            "id": "llama3-70b-8192",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3 70B 8192"
-        },
-        {
-            "id": "llama3-8b-8192",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Llama 3 8B 8192"
-        },
-        {
-            "id": "mixtral-8x7b-32768",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Mixtral 8x7B 32768"
-        },
-        {
-            "id": "whisper-large-v3",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Whisper Large v3"
-        },
-        {
-            "id": "whisper-large-v3-turbo",
-            "object": "model",
-            "provider": {
-                "id": "groq"
-            },
-            "name": "Whisper Large v3 Turbo"
-        },
-        {
-            "id": "yi-vision",
-            "object": "model",
-            "provider": {
-                "id": "lingyi"
-            },
-            "name": "Yi Vision"
-        },
-        {
-            "id": "open-mixtral-8x7b",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Mixtral 8x7B"
-        },
-        {
-            "id": "open-mixtral-8x22b",
-            "object": "model",
-            "provider": {
-                "id": "mistral-ai"
-            },
-            "name": "Mixtral 8x22B"
-        },
-        {
-            "id": "stable-diffusion-3.5-large-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 3.5 Large Text-to-Image"
-        },
-        {
-            "id": "flux-1.1-pro",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux 1.1 Pro"
-        },
-        {
-            "id": "Simple_Vector_Flux",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Simple Vector Flux"
-        },
-        {
-            "id": "ideogram-txt-2-img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Ideogram Text-to-Image"
-        },
-        {
-            "id": "fast-flux-schnell",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Fast Flux Schnell"
-        },
-        {
-            "id": "flux-realism-lora",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux Realism LoRA"
-        },
-        {
-            "id": "flux-dev",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux Dev"
-        },
-        {
-            "id": "flux-schnell",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux Schnell"
-        },
-        {
-            "id": "flux-pro",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux Pro"
-        },
-        {
-            "id": "sdxl1.0-realdream-pony-v9",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 RealDream Pony v9"
-        },
-        {
-            "id": "sdxl1.0-realdream-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 RealDream Lightning"
-        },
-        {
-            "id": "playground-v2.5",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Playground v2.5"
-        },
-        {
-            "id": "background-eraser",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Background Eraser"
-        },
-        {
-            "id": "stable-diffusion-3-medium-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 3 Medium Text-to-Image"
-        },
-        {
-            "id": "sdxl1.0-yamers-realistic",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Yamers Realistic"
-        },
-        {
-            "id": "sdxl1.0-newreality-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 NewReality Lightning"
-        },
-        {
-            "id": "sdxl1.0-dreamshaper-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Dreamshaper Lightning"
-        },
-        {
-            "id": "sdxl1.0-colossus-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Colossus Lightning"
-        },
-        {
-            "id": "sdxl1.0-samaritan-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Samaritan Lightning"
-        },
-        {
-            "id": "sdxl1.0-realism-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Realism Lightning"
-        },
-        {
-            "id": "sdxl1.0-protovis-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Protovis Lightning"
-        },
-        {
-            "id": "sdxl1.0-nightvis-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Nightvis Lightning"
-        },
-        {
-            "id": "sdxl1.0-wildcard-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Wildcard Lightning"
-        },
-        {
-            "id": "sdxl1.0-dyanvis-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Dyanvis Lightning"
-        },
-        {
-            "id": "sdxl1.0-juggernaut-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Juggernaut Lightning"
-        },
-        {
-            "id": "sdxl1.0-realvis-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Realvis Lightning"
-        },
-        {
-            "id": "sdxl1.0-samaritan-3d",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Samaritan 3D"
-        },
-        {
-            "id": "segmind-vega",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Segmind Vega"
-        },
-        {
-            "id": "segmind-vega-rt-v1",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Segmind Vega RT v1"
-        },
-        {
-            "id": "ssd-1b",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SSD 1B"
-        },
-        {
-            "id": "sdxl1.0-timeless",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Timeless"
-        },
-        {
-            "id": "sdxl1.0-zavychroma",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Zavychroma"
-        },
-        {
-            "id": "sdxl1.0-realvis",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Realvis"
-        },
-        {
-            "id": "sdxl1.0-dreamshaper",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Dreamshaper"
-        },
-        {
-            "id": "sd2.1-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 2.1 Text-to-Image"
-        },
-        {
-            "id": "sdxl-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL Text-to-Image"
-        },
-        {
-            "id": "tinysd1.5-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "TinySD 1.5 Text-to-Image"
-        },
-        {
-            "id": "smallsd1.5-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SmallSD 1.5 Text-to-Image"
-        },
-        {
-            "id": "sdxl1.0-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL 1.0 Text-to-Image"
-        },
-        {
-            "id": "sd1.5-scifi",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Sci-Fi"
-        },
-        {
-            "id": "sd1.5-samaritan_3d",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Samaritan 3D"
-        },
-        {
-            "id": "sd1.5-rpg",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 RPG"
-        },
-        {
-            "id": "sd1.5-reliberate",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 ReLiberate"
-        },
-        {
-            "id": "sd1.5-realisticvision",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Realistic Vision"
-        },
-        {
-            "id": "sd1.5-rcnz",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 RCNZ"
-        },
-        {
-            "id": "sd1.5-paragon",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Paragon"
-        },
-        {
-            "id": "sd1.5-manmarumix",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Manmarumix"
-        },
-        {
-            "id": "sd1.5-majicmix",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Majicmix"
-        },
-        {
-            "id": "sd1.5-juggernaut",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Juggernaut"
-        },
-        {
-            "id": "sd1.5-fruitfusion",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 FruitFusion"
-        },
-        {
-            "id": "sd1.5-flat2d",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Flat2D"
-        },
-        {
-            "id": "sd1.5-fantassifiedicons",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 FantassifiedIcons"
-        },
-        {
-            "id": "sd1.5-epicrealism",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Epic Realism"
-        },
-        {
-            "id": "sd1.5-edgeofrealism",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Edge of Realism"
-        },
-        {
-            "id": "sd1.5-dvrach",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Dvrach"
-        },
-        {
-            "id": "sd1.5-dreamshaper",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Dreamshaper"
-        },
-        {
-            "id": "sd1.5-deepspacediffusion",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 DeepSpaceDiffusion"
-        },
-        {
-            "id": "sd1.5-cyberrealistic",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 CyberRealistic"
-        },
-        {
-            "id": "sd1.5-cuterichstyle",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 CuteRichStyle"
-        },
-        {
-            "id": "sd1.5-colorful",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Colorful"
-        },
-        {
-            "id": "sd1.5-allinonepixel",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 AllInOnePixel"
-        },
-        {
-            "id": "sd1.5-526mix",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 526mix"
-        },
-        {
-            "id": "qrsd1.5-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "QRS 1.5 Text-to-Image"
-        },
-        {
-            "id": "potraitsd1.5-txt2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "PortraitSD 1.5 Text-to-Image"
-        },
-        {
-            "id": "kandinsky2.1-txt2im",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Kandinsky 2.1 Text-to-Image"
-        },
-        {
-            "id": "sd1.5-revanimated",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Reanimated"
-        },
-        {
-            "id": "face-detailer",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Face Detailer"
-        },
-        {
-            "id": "expression-editor",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Expression Editor"
-        },
-        {
-            "id": "consistent-character-with-pose",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Consistent Character with Pose"
-        },
-        {
-            "id": "consistent-character-AI-neolemon-v3",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Consistent Character AI Neolemon v3"
-        },
-        {
-            "id": "flux-pulid",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux Pulid"
-        },
-        {
-            "id": "flux-ipadapter",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux IPAdapter"
-        },
-        {
-            "id": "flux-inpaint",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux Inpaint"
-        },
-        {
-            "id": "flux-controlnet",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux ControlNet"
-        },
-        {
-            "id": "text-overlay",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Text Overlay"
-        },
-        {
-            "id": "consistent-character-AI-neolemon-v2",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Consistent Character AI Neolemon v2"
-        },
-        {
-            "id": "sam-v2-image",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SAM v2 Image"
-        },
-        {
-            "id": "consistent-character-ai-neolemon",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Consistent Character AI Neolemon"
-        },
-        {
-            "id": "flux-img2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Flux Img2Img"
-        },
-        {
-            "id": "ai-product-photo-editor",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "AI Product Photo Editor"
-        },
-        {
-            "id": "sd3-med-tile",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SD 3 Med Tile"
-        },
-        {
-            "id": "sd3-med-canny",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SD 3 Med Canny"
-        },
-        {
-            "id": "sd3-med-pose",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SD 3 Med Pose"
-        },
-        {
-            "id": "superimpose-v2",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Superimpose v2"
-        },
-        {
-            "id": "aura-flow",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Aura Flow"
-        },
-        {
-            "id": "kolors",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Kolors"
-        },
-        {
-            "id": "superimpose",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Superimpose"
-        },
-        {
-            "id": "sdxl-img2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL Img2Img"
-        },
-        {
-            "id": "sdxl-controlnet",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL ControlNet"
-        },
-        {
-            "id": "storydiffusion",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "StoryDiffusion"
-        },
-        {
-            "id": "omni-zero",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Omni Zero"
-        },
-        {
-            "id": "ic-light",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "IC Light"
-        },
-        {
-            "id": "automatic-mask-generator",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Automatic Mask Generator"
-        },
-        {
-            "id": "magic-eraser",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Magic Eraser"
-        },
-        {
-            "id": "inpaint-mask-maker",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Inpaint Mask Maker"
-        },
-        {
-            "id": "clarity-upscaler",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Clarity Upscaler"
-        },
-        {
-            "id": "consistent-character",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Consistent Character"
-        },
-        {
-            "id": "idm-vton",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "IDM-VTON"
-        },
-        {
-            "id": "fooocus",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Fooocus"
-        },
-        {
-            "id": "style-transfer",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Style Transfer"
-        },
-        {
-            "id": "become-image",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Become Image"
-        },
-        {
-            "id": "illusion-diffusion-hq",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Illusion Diffusion HQ"
-        },
-        {
-            "id": "pulid-base",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Pulid Base"
-        },
-        {
-            "id": "pulid-lightning",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Pulid Lightning"
-        },
-        {
-            "id": "fashion-ai",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Fashion AI"
-        },
-        {
-            "id": "face-to-many",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Face-to-Many"
-        },
-        {
-            "id": "face-to-sticker",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Face-to-Sticker"
-        },
-        {
-            "id": "material-transfer",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Material Transfer"
-        },
-        {
-            "id": "faceswap-v2",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "FaceSwap v2"
-        },
-        {
-            "id": "insta-depth",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Insta Depth"
-        },
-        {
-            "id": "bg-removal-v2",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "BG Removal v2"
-        },
-        {
-            "id": "focus-outpaint",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Focus Outpaint"
-        },
-        {
-            "id": "instantid",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Instantid"
-        },
-        {
-            "id": "ip-sdxl-openpose",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "IP-SDXL OpenPose"
-        },
-        {
-            "id": "ip-sdxl-canny",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "IP-SDXL Canny"
-        },
-        {
-            "id": "ip-sdxl-depth",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "IP-SDXL Depth"
-        },
-        {
-            "id": "ssd-img2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SSD Img2Img"
-        },
-        {
-            "id": "sdxl-openpose",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SDXL OpenPose"
-        },
-        {
-            "id": "ssd-depth",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SSD Depth"
-        },
-        {
-            "id": "ssd-canny",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SSD Canny"
-        },
-        {
-            "id": "w2imgsd1.5-img2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "W2ImgSD 1.5 Img2Img"
-        },
-        {
-            "id": "sd1.5-img2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Img2Img"
-        },
-        {
-            "id": "sd1.5-outpaint",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 Outpaint"
-        },
-        {
-            "id": "sd1.5-controlnet-softedge",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 ControlNet Softedge"
-        },
-        {
-            "id": "sd1.5-controlnet-scribble",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 ControlNet Scribble"
-        },
-        {
-            "id": "sd1.5-controlnet-depth",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 ControlNet Depth"
-        },
-        {
-            "id": "sd1.5-controlnet-canny",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 ControlNet Canny"
-        },
-        {
-            "id": "codeformer",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "CodeFormer"
-        },
-        {
-            "id": "sam-img2img",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "SAM Img2Img"
-        },
-        {
-            "id": "sd2.1-faceswapper",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 2.1 FaceSwapper"
-        },
-        {
-            "id": "bg-removal",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "BG Removal"
-        },
-        {
-            "id": "esrgan",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "ESRGAN"
-        },
-        {
-            "id": "sd1.5-controlnet-openpose",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Stable Diffusion 1.5 ControlNet OpenPose"
-        },
-        {
-            "id": "o1-preview",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "O1 Preview"
-        },
-        {
-            "id": "llama-v3p1-405b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Llama V3P1 405B Instruct"
-        },
-        {
-            "id": "llama-v3p1-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Llama V3P1 70B Instruct"
-        },
-        {
-            "id": "llama-v3p1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Llama V3P1 8B Instruct"
-        },
-        {
-            "id": "claude-3-haiku",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Claude 3 Haiku"
-        },
-        {
-            "id": "claude-3-opus",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Claude 3 Opus"
-        },
-        {
-            "id": "gemini-1.5-pro",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Gemini 1.5 Pro"
-        },
-        {
-            "id": "gemini-1.5-flash",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Gemini 1.5 Flash"
-        },
-        {
-            "id": "claude-3.5-sonnet",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Claude 3.5 Sonnet"
-        },
-        {
-            "id": "llava-13b",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "LLaMA 13B"
-        },
-        {
-            "id": "gpt-4-turbo",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "GPT-4 Turbo"
-        },
-        {
-            "id": "gpt-4o",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "GPT-4 0"
-        },
-        {
-            "id": "gpt-4",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "GPT-4"
-        },
-        {
-            "id": "mixtral-8x7b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Mixtral 8x7B Instruct"
-        },
-        {
-            "id": "mixtral-8x22b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Mixtral 8x22B Instruct"
-        },
-        {
-            "id": "llama-v3-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Llama V3 8B Instruct"
-        },
-        {
-            "id": "llama-v3-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "Segmind"
-            },
-            "name": "Llama V3 70B Instruct"
-        },
-        {
-            "id": "moonshot-v1-8k",
-            "object": "model",
-            "provider": {
-                "id": "moonshot"
-            },
-            "name": "Moonshot (8k Context)"
-        },
-        {
-            "id": "moonshot-v1-32k",
-            "object": "model",
-            "provider": {
-                "id": "moonshot"
-            },
-            "name": "Moonshot (132k Context)"
-        },
-        {
-            "id": "moonshot-v1-128k",
-            "object": "model",
-            "provider": {
-                "id": "moonshot"
-            },
-            "name": "Moonshot (128k Context)"
-        },
-        {
-            "id": "nomic-embed-vision-v1",
-            "object": "model",
-            "provider": {
-                "id": "nomic"
-            },
-            "name": "Nomic Embed vision v1"
-        },
-        {
-            "id": "nomic-embed-vision-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "nomic"
-            },
-            "name": "Nomic Embed vision v1.5"
-        },
-        {
-            "id": "nomic-embed-text-v1",
-            "object": "model",
-            "provider": {
-                "id": "nomic"
-            },
-            "name": "Nomic Embed v1"
-        },
-        {
-            "id": "nomic-embed-text-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "nomic"
-            },
-            "name": "Nomic Embed v1.5"
-        },
-        {
-            "id": "deepseek-coder-v2-lite-instruct",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "DeepSeek Coder v2 Lite Instruct"
-        },
-        {
-            "id": "Meta-Llama-3.2-1B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "sambanova"
-            },
-            "name": "Llama 3.2 1B"
-        },
-        {
-            "id": "Meta-Llama-3.2-3B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "sambanova"
-            },
-            "name": "Llama 3.2 3B"
-        },
-        {
-            "id": "Llama-3.2-11B-Vision-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "sambanova"
-            },
-            "name": "Llama 3.2 11B"
-        },
-        {
-            "id": "Llama-3.2-90B-Vision-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "sambanova"
-            },
-            "name": "Llama 3.2 90B"
-        },
-        {
-            "id": "Meta-Llama-3.1-8B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "sambanova"
-            },
-            "name": "Llama 3.1 8B"
-        },
-        {
-            "id": "Meta-Llama-3.1-70B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "sambanova"
-            },
-            "name": "Llama 3.1 70B"
-        },
-        {
-            "id": "Meta-Llama-3.1-405B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "sambanova"
-            },
-            "name": "Llama 3.1 405B"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3.1 8B Instruct Turbo"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3.1 70B Instruct Turbo"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3.1 405B Instruct Turbo"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3-8B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3 8B Instruct Turbo"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3-70B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3 70B Instruct Turbo"
-        },
-        {
-            "id": "meta-llama/Llama-3.2-3B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3.2 3B Instruct Turbo"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3-8B-Instruct-Lite",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3 8B Instruct Lite"
-        },
-        {
-            "id": "meta-llama/Meta-Llama-3-70B-Instruct-Lite",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3 70B Instruct Lite"
-        },
-        {
-            "id": "meta-llama/Llama-3-8b-chat-hf",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3 8B Instruct Reference"
-        },
-        {
-            "id": "meta-llama/Llama-3-70b-chat-hf",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3 70B Instruct Reference"
-        },
-        {
-            "id": "microsoft/WizardLM-2-8x22B",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "WizardLM-2 8x22B"
-        },
-        {
-            "id": "google/gemma-2-27b-it",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Gemma 2 27B"
-        },
-        {
-            "id": "google/gemma-2-9b-it",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Gemma 2 9B"
-        },
-        {
-            "id": "databricks/dbrx-instruct",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "DBRX Instruct"
-        },
-        {
-            "id": "deepseek-ai/deepseek-llm-67b-chat",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "DeepSeek LLM Chat (67B)"
-        },
-        {
-            "id": "google/gemma-2b-it",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Gemma Instruct (2B)"
-        },
-        {
-            "id": "Gryphe/MythoMax-L2-13b",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "MythoMax-L2 (13B)"
-        },
-        {
-            "id": "meta-llama/Llama-2-13b-chat-hf",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "LLaMA-2 Chat (13B)"
-        },
-        {
-            "id": "mistralai/Mistral-7B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Mistral (7B) Instruct"
-        },
-        {
-            "id": "mistralai/Mistral-7B-Instruct-v0.2",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Mistral (7B) Instruct v0.2"
-        },
-        {
-            "id": "mistralai/Mistral-7B-Instruct-v0.3",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Mistral (7B) Instruct v0.3"
-        },
-        {
-            "id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Mixtral-8x7B Instruct (46.7B)"
-        },
-        {
-            "id": "mistralai/Mixtral-8x22B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Mixtral-8x22B Instruct (141B)"
-        },
-        {
-            "id": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Nous Hermes 2 - Mixtral 8x7B-DPO (46.7B)"
-        },
-        {
-            "id": "Qwen/Qwen2.5-7B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Qwen 2.5 7B Instruct Turbo"
-        },
-        {
-            "id": "Qwen/Qwen2.5-72B-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Qwen 2.5 72B Instruct Turbo"
-        },
-        {
-            "id": "Qwen/Qwen2-72B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Qwen 2 Instruct (72B)"
-        },
-        {
-            "id": "togethercomputer/StripedHyena-Nous-7B",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "StripedHyena Nous (7B)"
-        },
-        {
-            "id": "upstage/SOLAR-10.7B-Instruct-v1.0",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Upstage SOLAR Instruct v1 (11B)"
-        },
-        {
-            "id": "black-forest-labs/FLUX.1-schnell-Free",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Flux.1 [schnell] (free)*"
-        },
-        {
-            "id": "black-forest-labs/FLUX.1-schnell",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Flux.1 [schnell] (Turbo)"
-        },
-        {
-            "id": "black-forest-labs/FLUX.1.1-pro",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Flux1.1 [pro]"
-        },
-        {
-            "id": "black-forest-labs/FLUX.1-pro",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Flux.1 [pro]"
-        },
-        {
-            "id": "stabilityai/stable-diffusion-xl-base-1.0",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Stable Diffusion XL 1.0"
-        },
-        {
-            "id": "togethercomputer/m2-bert-80M-2k-retrieval",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "M2-BERT-80M-2K-Retrieval"
-        },
-        {
-            "id": "togethercomputer/m2-bert-80M-8k-retrieval",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "M2-BERT-80M-8K-Retrieval"
-        },
-        {
-            "id": "togethercomputer/m2-bert-80M-32k-retrieval",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "M2-BERT-80M-32K-Retrieval"
-        },
-        {
-            "id": "WhereIsAI/UAE-Large-V1",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "UAE-Large-v1"
-        },
-        {
-            "id": "BAAI/bge-large-en-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "BGE-Large-EN-v1.5"
-        },
-        {
-            "id": "BAAI/bge-base-en-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "BGE-Base-EN-v1.5"
-        },
-        {
-            "id": "sentence-transformers/msmarco-bert-base-dot-v5",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Sentence-BERT"
-        },
-        {
-            "id": "bert-base-uncased",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "BERT"
-        },
-        {
-            "id": "meta-llama/Llama-Vision-Free",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "(Free) Llama 3.2 11B Vision Instruct Turbo*"
-        },
-        {
-            "id": "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3.2 11B Vision Instruct Turbo"
-        },
-        {
-            "id": "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama 3.2 90B Vision Instruct Turbo"
-        },
-        {
-            "id": "meta-llama/Llama-2-70b-hf",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "LLaMA-2 (70B)"
-        },
-        {
-            "id": "mistralai/Mistral-7B-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Mistral (7B)"
-        },
-        {
-            "id": "mistralai/Mixtral-8x7B-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Mixtral-8x7B (46.7B)"
-        },
-        {
-            "id": "Meta-Llama/Llama-Guard-7b",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "Llama Guard (7B)"
-        },
-        {
-            "id": "Salesforce/Llama-Rank-v1",
-            "object": "model",
-            "provider": {
-                "id": "together-ai"
-            },
-            "name": "LlamaRank"
-        },
-        {
-            "id": "dracarys2-72b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Dracarys 2 72B Instruct"
-        },
-        {
-            "id": "hermes3-405b",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Hermes 3 405B"
-        },
-        {
-            "id": "hermes3-405b-fp8-128k",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Hermes 3 405B FP8 128K"
-        },
-        {
-            "id": "hermes3-70b",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Hermes 3 70B"
-        },
-        {
-            "id": "hermes3-8b",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Hermes 3 8B"
-        },
-        {
-            "id": "lfm-40b",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "LFM 40B"
-        },
-        {
-            "id": "llama3.1-405b-instruct-fp8",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Llama 3.1 405B Instruct FP8"
-        },
-        {
-            "id": "llama3.1-70b-instruct-fp8",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Llama 3.1 70B Instruct FP8"
-        },
-        {
-            "id": "llama3.1-8b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Llama 3.1 8B Instruct"
-        },
-        {
-            "id": "llama3.2-3b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Llama 3.2 3B Instruct"
-        },
-        {
-            "id": "llama3.1-nemotron-70b-instruct",
-            "object": "model",
-            "provider": {
-                "id": "lambda"
-            },
-            "name": "Llama 3.1 Nemotron 70B Instruct"
-        },
-        {
-            "id": "llama-8b-chat",
-            "object": "model",
-            "provider": {
-                "id": "lemonfox-ai"
-            },
-            "name": "Llama 3.1 8B"
-        },
-        {
-            "id": "llama-70b-chat",
-            "object": "model",
-            "provider": {
-                "id": "lemonfox-ai"
-            },
-            "name": "Llama 3.1 70B"
-        },
-        {
-            "id": "mixtral-chat",
-            "object": "model",
-            "provider": {
-                "id": "lemonfox-ai"
-            },
-            "name": "Mixtral Chat"
-        },
-        {
-            "id": "embedding-query",
-            "object": "model",
-            "provider": {
-                "id": "upstage"
-            },
-            "name": "Embedding Query"
-        },
-        {
-            "id": "embedding-passage",
-            "object": "model",
-            "provider": {
-                "id": "upstage"
-            },
-            "name": "Embedding Passage"
-        },
-        {
-            "id": "solar-pro-preview-240910",
-            "object": "model",
-            "provider": {
-                "id": "upstage"
-            },
-            "name": "Solar Pro Preview"
-        },
-        {
-            "id": "solar-mini-240612",
-            "object": "model",
-            "provider": {
-                "id": "upstage"
-            },
-            "name": "Solar Mini"
-        },
-        {
-            "id": "solar-mini-ja-240612",
-            "object": "model",
-            "provider": {
-                "id": "upstage"
-            },
-            "name": "Solar Mini Japanese"
-        },
-        {
-            "id": "stable-diffusion-3.5-medium",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Diffusion 3.5 Medium"
-        },
-        {
-            "id": "stable-diffusion-3.5-large",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Diffusion 3.5 Large"
-        },
-        {
-            "id": "stable-diffusion-3.5-large-turbo",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Diffusion 3.5 Large Turbo"
-        },
-        {
-            "id": "stable-diffusion-3-medium",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Diffusion 3 Medium"
-        },
-        {
-            "id": "sdxl-turbo",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Diffusion XL Turbo"
-        },
-        {
-            "id": "sd-turbo",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Diffusion Turbo"
-        },
-        {
-            "id": "stable-video-diffusion-img2vid",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Video Diffusion Img2Vid"
-        },
-        {
-            "id": "stable-video-diffusion-img2vid-xt",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Video Diffusion Img2Vid XT"
-        },
-        {
-            "id": "stable-video-diffusion-img2vid-xt-1-1",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Video Diffusion Img2Vid XT 1.1"
-        },
-        {
-            "id": "japanese-stable-diffusion-xl",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Japanese Stable Diffusion XL"
-        },
-        {
-            "id": "japanese-stable-clip-vit-l-16",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Japanese Stable Diffusion CLIP Vit-L-16"
-        },
-        {
-            "id": "stablelm-2-12b",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "StableLM 2 12B"
-        },
-        {
-            "id": "lityai/stablelm-2-1_6b-zephyr",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "StableLM 2 1.6B Zephyr"
-        },
-        {
-            "id": "stablelm-zephyr-3b",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "StableLM Zephyr 3B"
-        },
-        {
-            "id": "japanese-stablelm-2-instruct-1_6b",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Japanese StableLM 2 Instruct 1.6B"
-        },
-        {
-            "id": "japanese-stable-vlm",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Japanese StableVLM"
-        },
-        {
-            "id": "stable-code-3b",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Code 3B"
-        },
-        {
-            "id": "stable-fast-3d",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Fast 3D"
-        },
-        {
-            "id": "stable-zero123",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Zero123"
-        },
-        {
-            "id": "sv3d",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable 3D"
-        },
-        {
-            "id": "stable-audio-open-1.0",
-            "object": "model",
-            "provider": {
-                "id": "stability-ai"
-            },
-            "name": "Stable Audio Open 1.0"
-        },
-        {
-            "id": "gemini-1.5-pro-002",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Gemini 1.5 Pro"
-        },
-        {
-            "id": "gemini-1.5-flash-002",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Gemini 1.5 Flash"
-        },
-        {
-            "id": "gemini-pro",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Gemini 1.0 Pro"
-        },
-        {
-            "id": "gemini-pro-vision",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Gemini 1.0 Pro Vision"
-        },
-        {
-            "id": "imagen-3.0-generate-001",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Imagen for Generation and Editing"
-        },
-        {
-            "id": "imagegeneration",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Imagen 2 for Generation and Editing"
-        },
-        {
-            "id": "claude-3-5-sonnet-v2",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Claude 3.5 Sonnet v2"
-        },
-        {
-            "id": "claude-3-opus",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Claude 3 Opus"
-        },
-        {
-            "id": "claude-3-haiku",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Claude 3 Haiku"
-        },
-        {
-            "id": "gemma2",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Gemma 2"
-        },
-        {
-            "id": "paligemma",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "PaliGemma"
-        },
-        {
-            "id": "gemma",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Gemma"
-        },
-        {
-            "id": "codegemma",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "CodeGemma"
-        },
-        {
-            "id": "llama-3.1-405b-instruct-maas",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Llama 3.1 API Service"
-        },
-        {
-            "id": "llama-3.2-90b-vision-instruct-maas",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Llama 3.2 API Service"
-        },
-        {
-            "id": "llama3_1",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Llama 3.1"
-        },
-        {
-            "id": "llama3-2",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Llama 3.2"
-        },
-        {
-            "id": "llama3",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Llama 3"
-        },
-        {
-            "id": "llama-guard",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Llama Guard"
-        },
-        {
-            "id": "prompt-guard",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Prompt Guard"
-        },
-        {
-            "id": "llama2",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Llama 2"
-        },
-        {
-            "id": "mistral-large",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Mistral Large (2407)"
-        },
-        {
-            "id": "mistral-nemo",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Mistral Nemo"
-        },
-        {
-            "id": "codestral",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Codestral"
-        },
-        {
-            "id": "jamba-1.5-large",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Jamba 1.5 Large (Preview)"
-        },
-        {
-            "id": "jamba-1.5-mini",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Jamba 1.5 Mini (Preview)"
-        },
-        {
-            "id": "mixtral",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Mixtral"
-        },
-        {
-            "id": "chat-bison",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "PaLM 2 Chat Bison"
-        },
-        {
-            "id": "text-bison",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "PaLM 2 Text Bison"
-        },
-        {
-            "id": "claude-3-5-sonnet",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Claude 3.5 Sonnet"
-        },
-        {
-            "id": "claude-3-sonnet",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Claude 3 Sonnet"
-        },
-        {
-            "id": "whisper-large",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Whisper Large"
-        },
-        {
-            "id": "chirp-2",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Chirp 2"
-        },
-        {
-            "id": "image-segmentation-001",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Vertex Image Segmentation"
-        },
-        {
-            "id": "flux1-schnell",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Flux"
-        },
-        {
-            "id": "phi3",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Phi-3"
-        },
-        {
-            "id": "qwen2",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Qwen2"
-        },
-        {
-            "id": "mammut",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "MaMMUT"
-        },
-        {
-            "id": "e5",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "E5 Text Embedding"
-        },
-        {
-            "id": "timesfm",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "TimesFM 1.0"
-        },
-        {
-            "id": "stable-diffusion-xl-lightning",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Stable Diffusion XL Lightning"
-        },
-        {
-            "id": "instant-id",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Instant ID"
-        },
-        {
-            "id": "stable-diffusion-xl-lcm",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Stable Diffusion XL LCM"
-        },
-        {
-            "id": "pytorch-llava",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "LLaVA 1.5"
-        },
-        {
-            "id": "lama",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "LaMa (Large Mask Inpainting)"
-        },
-        {
-            "id": "lmsys-vicuna-7b",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Vicuna"
-        },
-        {
-            "id": "bio-gpt",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "BioGPT"
-        },
-        {
-            "id": "jax-owl-vit-v2",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "OWL-ViT v2"
-        },
-        {
-            "id": "dito",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "DITO"
-        },
-        {
-            "id": "microsoft-biomedclip",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "BiomedCLIP"
-        },
-        {
-            "id": "mistral",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Mistral Self-host (7B & Nemo)"
-        },
-        {
-            "id": "nllb",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "NLLB"
-        },
-        {
-            "id": "codellama-7b-hf",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Code Llama"
-        },
-        {
-            "id": "stable-diffusion-xl-base",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Stable Diffusion XL"
-        },
-        {
-            "id": "openclip",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "OpenCLIP"
-        },
-        {
-            "id": "f-vlm-jax",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "F-VLM"
-        },
-        {
-            "id": "llama-2-quantized",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Llama 2 (Quantized)"
-        },
-        {
-            "id": "stable-diffusion-2-1",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Stable Diffusion v2.1"
-        },
-        {
-            "id": "bert-base-uncased",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "BERT (PEFT)"
-        },
-        {
-            "id": "falcon-instruct-7b-peft",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Falcon-instruct (PEFT)"
-        },
-        {
-            "id": "openllama",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "OpenLLaMA (PEFT)"
-        },
-        {
-            "id": "roberta-large",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "RoBERTa-large (PEFT)"
-        },
-        {
-            "id": "xlm-roberta-large",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "XLM-RoBERTa-large (PEFT)"
-        },
-        {
-            "id": "stable-diffusion-4x-upscaler",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Stable-diffusion-4x-upscaler"
-        },
-        {
-            "id": "segment-anything",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Segment Anything (SAM)"
-        },
-        {
-            "id": "bart-large-cnn",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Bart-large-cnn"
-        },
-        {
-            "id": "dolly-v2",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Dolly-v2"
-        },
-        {
-            "id": "imagetext",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Imagen for Captioning & VQA"
-        },
-        {
-            "id": "stable-diffusion-v1-4",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Stable Diffusion 1.4 (Keras)"
-        },
-        {
-            "id": "chirp-rnnt1",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Chirp"
-        },
-        {
-            "id": "label-detector-pali-001",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Label detector (PaLI zero-shot)"
-        },
-        {
-            "id": "codechat-bison",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Codey for Code Chat"
-        },
-        {
-            "id": "code-bison",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Codey for Code Generation"
-        },
-        {
-            "id": "code-gecko",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Codey for Code Completion"
-        },
-        {
-            "id": "text-unicorn",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "PaLM 2 Text Unicorn"
-        },
-        {
-            "id": "textembedding-gecko",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Embeddings for Text"
-        },
-        {
-            "id": "t5-flan",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "T5-FLAN"
-        },
-        {
-            "id": "t5-1.1",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "T5-1.1"
-        },
-        {
-            "id": "blip2-opt-2.7-b",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "BLIP2"
-        },
-        {
-            "id": "instruct-pix2pix",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "InstructPix2Pix"
-        },
-        {
-            "id": "stable-diffusion-inpainting",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Stable Diffusion Inpainting"
-        },
-        {
-            "id": "control-net",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "ControlNet"
-        },
-        {
-            "id": "bert-base",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "BERT"
-        },
-        {
-            "id": "layoutlm-document-qa",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "LayoutLM for VQA"
-        },
-        {
-            "id": "vilt-b32-finetuned-vqa",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "ViLT VQA"
-        },
-        {
-            "id": "vit-gpt2-image-captioning",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "ViT GPT2"
-        },
-        {
-            "id": "owlvit-base-patch32",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "OWL-ViT"
-        },
-        {
-            "id": "clip-vit-base-patch32",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "CLIP"
-        },
-        {
-            "id": "blip-vqa-base",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "BLIP VQA"
-        },
-        {
-            "id": "blip-image-captioning-base",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "BLIP image captioning"
-        },
-        {
-            "id": "multimodalembedding",
-            "object": "model",
-            "provider": {
-                "id": "vertex-ai"
-            },
-            "name": "Embeddings for Multimodal"
-        },
-        {
-            "id": "Gryphe/MythoMax-L2-13b",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "MythoMax L2 13B"
-        },
-        {
-            "id": "Gryphe/MythoMax-L2-13b-turbo",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "MythoMax L2 13B Turbo"
-        },
-        {
-            "id": "HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Zephyr Orpo 141B A35b v0.1"
-        },
-        {
-            "id": "KoboldAI/LLaMA2-13B-Tiefighter",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "LLaMA 2 13B Tiefighter"
-        },
-        {
-            "id": "NousResearch/Hermes-3-Llama-3.1-405B",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Hermes 3 Llama 3.1 405B"
-        },
-        {
-            "id": "Phind/Phind-CodeLlama-34B-v2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Phind CodeLlama 34B v2"
-        },
-        {
-            "id": "Qwen/Qwen2-72B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Qwen 2 72B Instruct"
-        },
-        {
-            "id": "Qwen/Qwen2.5-Coder-7B",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Qwen 2.5 Coder 7B"
-        },
-        {
-            "id": "Sao10K/L3-70B-Euryale-v2.1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "L3 70B Euryale v2.1"
-        },
-        {
-            "id": "Sao10K/L3.1-70B-Euryale-v2.2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "L3.1 70B Euryale v2.2"
-        },
-        {
-            "id": "bigcode/starcoder2-15b",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Starcoder 2 15B"
-        },
-        {
-            "id": "bigcode/starcoder2-15b-instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Starcoder 2 15B Instruct v0.1"
-        },
-        {
-            "id": "codellama/CodeLlama-34b-Instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "CodeLlama 34B Instruct HF"
-        },
-        {
-            "id": "codellama/CodeLlama-70b-Instruct-hf",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "CodeLlama 70B Instruct HF"
-        },
-        {
-            "id": "cognitivecomputations/dolphin-2.6-mixtral-8x7b",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Dolphin 2.6 Mixtral 8x7B"
-        },
-        {
-            "id": "cognitivecomputations/dolphin-2.9.1-llama-3-70b",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Dolphin 2.9.1 Llama 3 70B"
-        },
-        {
-            "id": "databricks/dbrx-instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "DBRX Instruct"
-        },
-        {
-            "id": "deepinfra/airoboros-70b",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Airoboros 70B"
-        },
-        {
-            "id": "google/codegemma-7b-it",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "CodeGemma 7B IT"
-        },
-        {
-            "id": "google/gemma-1.1-7b-it",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Gemma 1.1 7B IT"
-        },
-        {
-            "id": "google/gemma-2-27b-it",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Gemma 2 27B IT"
-        },
-        {
-            "id": "google/gemma-2-9b-it",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Gemma 2 9B IT"
-        },
-        {
-            "id": "lizpreciatior/lzlv_70b_fp16_hf",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "LzLV 70B FP16 HF"
-        },
-        {
-            "id": "mattshumer/Reflection-Llama-3.1-70B",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Reflection Llama 3.1 70B"
-        },
-        {
-            "id": "Llama-2-13b-chat-hf",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Llama 2 13B Chat HF"
-        },
-        {
-            "id": "Llama-2-70b-chat-hf",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Llama 2 70B Chat HF"
-        },
-        {
-            "id": "Llama-2-7b-chat-hf",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Llama 2 7B Chat HF"
-        },
-        {
-            "id": "Llama-3.2-1B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Llama 3.2 1B Instruct"
-        },
-        {
-            "id": "Llama-3.2-3B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Llama 3.2 3B Instruct"
-        },
-        {
-            "id": "Meta-Llama-3-70B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Meta Llama 3 70B Instruct"
-        },
-        {
-            "id": "Meta-Llama-3-8B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Meta Llama 3 8B Instruct"
-        },
-        {
-            "id": "Phi-3-medium-4k-instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Phi 3 Medium 4K Instruct"
-        },
-        {
-            "id": "WizardLM-2-7B",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "WizardLM 2 7B"
-        },
-        {
-            "id": "Mistral-7B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Mistral 7B Instruct v0.1"
-        },
-        {
-            "id": "Mistral-7B-Instruct-v0.2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Mistral 7B Instruct v0.2"
-        },
-        {
-            "id": "Mistral-7B-Instruct-v0.3",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Mistral 7B Instruct v0.3"
-        },
-        {
-            "id": "Mistral-Nemo-Instruct-2407",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Mistral Nemo Instruct 2407"
-        },
-        {
-            "id": "Mixtral-8x22B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Mixtral 8x22B Instruct v0.1"
-        },
-        {
-            "id": "Mixtral-8x22B-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Mixtral 8x22B v0.1"
-        },
-        {
-            "id": "Mixtral-8x7B-Instruct-v0.1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Mixtral 8x7B Instruct v0.1"
-        },
-        {
-            "id": "Nemotron-4-340B-Instruct",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Nemotron 4 340B Instruct"
-        },
-        {
-            "id": "MiniCPM-Llama3-V-2_5",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "MiniCPM Llama3 V 2.5"
-        },
-        {
-            "id": "openchat/openchat_3.5",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "OpenChat 3.5"
-        },
-        {
-            "id": "openchat/openchat-3.6-8b",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "OpenChat 3.6 8B"
-        },
-        {
-            "id": "stabilityai/sd3.5",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Stable Diffusion 3.5"
-        },
-        {
-            "id": "black-forest-labs/FLUX-1.1-pro",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "FLUX 1.1 Pro"
-        },
-        {
-            "id": "black-forest-labs/FLUX-1-schnell",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "FLUX 1 Schnell"
-        },
-        {
-            "id": "black-forest-labs/FLUX-1-dev",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "FLUX 1 Dev"
-        },
-        {
-            "id": "black-forest-labs/FLUX-pro",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "FLUX Pro"
-        },
-        {
-            "id": "stabilityai/sd3.5-medium",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Stable Diffusion 3.5 Medium"
-        },
-        {
-            "id": "CompVis/stable-diffusion-v1-4",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Stable Diffusion v1-4"
-        },
-        {
-            "id": "XpucT/Deliberate",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Deliberate"
-        },
-        {
-            "id": "prompthero/openjourney",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "OpenJourney"
-        },
-        {
-            "id": "runwayml/stable-diffusion-v1-5",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Stable Diffusion v1-5"
-        },
-        {
-            "id": "stabilityai/sdxl-turbo",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "SDXL Turbo"
-        },
-        {
-            "id": "stabilityai/stable-diffusion-2-1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Stable Diffusion 2.1"
-        },
-        {
-            "id": "openai/whisper-large-v3-turbo",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Large v3 Turbo"
-        },
-        {
-            "id": "openai/whisper-large-v3",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Large v3"
-        },
-        {
-            "id": "distil-whisper/distil-large-v3",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Distil Whisper Large v3"
-        },
-        {
-            "id": "openai/whisper-base",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Base"
-        },
-        {
-            "id": "openai/whisper-base.en",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Base English"
-        },
-        {
-            "id": "openai/whisper-large",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Large"
-        },
-        {
-            "id": "openai/whisper-medium",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Medium"
-        },
-        {
-            "id": "openai/whisper-medium.en",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Medium English"
-        },
-        {
-            "id": "openai/whisper-small",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Small"
-        },
-        {
-            "id": "openai/whisper-small.en",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Small English"
-        },
-        {
-            "id": "openai/whisper-timestamped-medium",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Timestamped Medium"
-        },
-        {
-            "id": "openai/whisper-timestamped-medium.en",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Timestamped Medium English"
-        },
-        {
-            "id": "openai/whisper-tiny",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Tiny"
-        },
-        {
-            "id": "openai/whisper-tiny.en",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Whisper Tiny English"
-        },
-        {
-            "id": "BAAI/bge-base-en-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "BGE Base EN v1.5"
-        },
-        {
-            "id": "BAAI/bge-large-en-v1.5",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "BGE Large EN v1.5"
-        },
-        {
-            "id": "BAAI/bge-m3",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "BGE M3"
-        },
-        {
-            "id": "intfloat/e5-base-v2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "E5 Base v2"
-        },
-        {
-            "id": "intfloat/e5-large-v2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "E5 Large v2"
-        },
-        {
-            "id": "intfloat/multilingual-e5-large",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Multilingual E5 Large"
-        },
-        {
-            "id": "sentence-transformers/all-MiniLM-L12-v2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "All-MiniLM-L12-v2"
-        },
-        {
-            "id": "sentence-transformers/all-MiniLM-L6-v2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "All-MiniLM-L6-v2"
-        },
-        {
-            "id": "sentence-transformers/all-mpnet-base-v2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "All-MPNet-base-v2"
-        },
-        {
-            "id": "sentence-transformers/clip-ViT-B-32",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "CLIP ViT-B-32"
-        },
-        {
-            "id": "sentence-transformers/clip-ViT-B-32-multilingual-v1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "CLIP ViT-B-32 Multilingual v1"
-        },
-        {
-            "id": "sentence-transformers/multi-qa-mpnet-base-dot-v1",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Multi-QA-MPNet-base-dot-v1"
-        },
-        {
-            "id": "sentence-transformers/paraphrase-MiniLM-L6-v2",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Paraphrase-MiniLM-L6-v2"
-        },
-        {
-            "id": "shibing624/text2vec-base-chinese",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "Text2Vec-Base-Chinese"
-        },
-        {
-            "id": "thenlper/gte-base",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "GTE Base"
-        },
-        {
-            "id": "thenlper/gte-large",
-            "object": "model",
-            "provider": {
-                "id": "deepinfra"
-            },
-            "name": "GTE Large"
-        },
-        {
-            "id": "jina-embeddings-v2-base-en",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Embeddings v2 Base English"
-        },
-        {
-            "id": "jina-embeddings-v2-base-zh",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Embeddings v2 Base Chinese"
-        },
-        {
-            "id": "jina-embeddings-v2-base-de",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Embeddings v2 Base German"
-        },
-        {
-            "id": "jina-embeddings-v2-base-code",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Embeddings v2 Base Code"
-        },
-        {
-            "id": "jina-embeddings-v2-base-es",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Embeddings v2 Base Spanish"
-        },
-        {
-            "id": "jina-colbert-v1-en",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Colbert v1 English"
-        },
-        {
-            "id": "jina-reranker-v1-base-en",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Reranker v1 Base English"
-        },
-        {
-            "id": "jina-reranker-v1-turbo-en",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Reranker v1 Turbo English"
-        },
-        {
-            "id": "jina-reranker-v1-tiny-en",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Reranker v1 Tiny English"
-        },
-        {
-            "id": "jina-clip-v1",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina CLIP v1"
-        },
-        {
-            "id": "jina-reranker-v2-base-multilingual",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Reranker v2 Base Multilingual"
-        },
-        {
-            "id": "jina-colbert-v2",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Colbert v2"
-        },
-        {
-            "id": "jina-embeddings-v3",
-            "object": "model",
-            "provider": {
-                "id": "jina"
-            },
-            "name": "Jina Embeddings v3"
-        }
-    ]
+  "object": "list",
+  "version": "1.0.0",
+  "data": [
+    {
+      "id": "meta-llama/llama-3.1-70b-instruct/fp-8",
+      "object": "model",
+      "provider": {
+        "id": "inference-net"
+      },
+      "name": "Llama 3.1 70B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.1-8b-instruct/fp-8",
+      "object": "model",
+      "provider": {
+        "id": "inference-net"
+      },
+      "name": "Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "jamba-1.5-large",
+      "object": "model",
+      "provider": {
+        "id": "ai21"
+      },
+      "name": "Jamba 1.5 Large"
+    },
+    {
+      "id": "jamba-1.5-mini",
+      "object": "model",
+      "provider": {
+        "id": "ai21"
+      },
+      "name": "Jamba 1.5 Mini"
+    },
+    {
+      "id": "jamba-instruct",
+      "object": "model",
+      "provider": {
+        "id": "ai21"
+      },
+      "name": "Jamba Instruct"
+    },
+    {
+      "id": "jurassic-light",
+      "object": "model",
+      "provider": {
+        "id": "ai21"
+      },
+      "name": "Jurassic Light"
+    },
+    {
+      "id": "jurassic-mid",
+      "object": "model",
+      "provider": {
+        "id": "ai21"
+      },
+      "name": "Jurassic Mid"
+    },
+    {
+      "id": "jurassic-ultra",
+      "object": "model",
+      "provider": {
+        "id": "ai21"
+      },
+      "name": "Jurassic Ultra"
+    },
+    {
+      "id": "claude-2.0",
+      "object": "model",
+      "provider": {
+        "id": "anthropic"
+      },
+      "name": "Claude 2.0"
+    },
+    {
+      "id": "claude-2.1",
+      "object": "model",
+      "provider": {
+        "id": "anthropic"
+      },
+      "name": "Claude 2.1"
+    },
+    {
+      "id": "claude-3-5-sonnet-latest",
+      "object": "model",
+      "provider": {
+        "id": "anthropic"
+      },
+      "name": "Claude 3.5 Sonnet"
+    },
+    {
+      "id": "claude-3-haiku-20240307",
+      "object": "model",
+      "provider": {
+        "id": "anthropic"
+      },
+      "name": "Claude 3 Haiku (March 7, 2024)"
+    },
+    {
+      "id": "claude-3-opus-20240229",
+      "object": "model",
+      "provider": {
+        "id": "anthropic"
+      },
+      "name": "Claude 3 Opus (February 29, 2024)"
+    },
+    {
+      "id": "claude-3-sonnet-20240229",
+      "object": "model",
+      "provider": {
+        "id": "anthropic"
+      },
+      "name": "Claude 3 Sonnet (February 29, 2024)"
+    },
+    {
+      "id": "claude-instant-1.2",
+      "object": "model",
+      "provider": {
+        "id": "anthropic"
+      },
+      "name": "Claude Instant 1.2"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3-8B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "anyscale"
+      },
+      "name": "Meta Llama 3 70B Instruct"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3-70B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "anyscale"
+      },
+      "name": "Meta Llama 3 8B Instruct"
+    },
+    {
+      "id": "mistralai/Mistral-7B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "anyscale"
+      },
+      "name": "Mistral 7B Instruct v0.1"
+    },
+    {
+      "id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "anyscale"
+      },
+      "name": "Mixtral 8x7B Instruct v0.1"
+    },
+    {
+      "id": "gpt-4o-realtime-preview",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "GPT-4 Realtime Preview"
+    },
+    {
+      "id": "openai-whisper-large-v3",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Whisper Large v3"
+    },
+    {
+      "id": "openai-whisper-large",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Whisper Large"
+    },
+    {
+      "id": "gpt-4",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "GPT-4"
+    },
+    {
+      "id": "gpt-35-turbo",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "GPT-3.5 Turbo"
+    },
+    {
+      "id": "o1-preview",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "O1 Preview"
+    },
+    {
+      "id": "o1-mini",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "O1 Mini"
+    },
+    {
+      "id": "gpt-4o-mini",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "GPT-4 0 Mini"
+    },
+    {
+      "id": "gpt-4o",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "GPT-4 0"
+    },
+    {
+      "id": "gpt-4-32k",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "GPT-4 32K"
+    },
+    {
+      "id": "gpt-35-turbo-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "GPT-3.5 Turbo Instruct"
+    },
+    {
+      "id": "gpt-35-turbo-16k",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "GPT-3.5 Turbo 16K"
+    },
+    {
+      "id": "dall-e-3",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DALL-E 3"
+    },
+    {
+      "id": "dall-e-2",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DALL-E 2"
+    },
+    {
+      "id": "whisper",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Whisper"
+    },
+    {
+      "id": "tts-hd",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "TTS-HD"
+    },
+    {
+      "id": "tts",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "TTS"
+    },
+    {
+      "id": "text-embedding-3-small",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Text Embedding 3 Small"
+    },
+    {
+      "id": "text-embedding-3-large",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Text Embedding 3 Large"
+    },
+    {
+      "id": "davinci-002",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Davinci 002"
+    },
+    {
+      "id": "text-embedding-ada-002",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Text Embedding Ada 002"
+    },
+    {
+      "id": "babbage-002",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Babbage 002"
+    },
+    {
+      "id": "Phi-3.5-mini-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3.5 Mini Instruct"
+    },
+    {
+      "id": "Phi-3.5-MoE-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3.5 MoE Instruct"
+    },
+    {
+      "id": "Phi-3-medium-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3 Medium 128K Instruct"
+    },
+    {
+      "id": "Phi-3-mini-4k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3 Mini 4K Instruct"
+    },
+    {
+      "id": "Phi-3-medium-4k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3 Medium 4K Instruct"
+    },
+    {
+      "id": "Phi-3-mini-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3 Mini 128K Instruct"
+    },
+    {
+      "id": "Phi-3-small-8k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3 Small 8K Instruct"
+    },
+    {
+      "id": "Phi-3-small-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3 Small 128K Instruct"
+    },
+    {
+      "id": "Phi-3.5-vision-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3.5 Vision Instruct"
+    },
+    {
+      "id": "Phi-3-vision-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Phi-3 Vision 128K Instruct"
+    },
+    {
+      "id": "Meta-Llama-3.1-8B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "Meta-Llama-3.1-8B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3.1 8B"
+    },
+    {
+      "id": "Meta-Llama-3.1-70B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3.1 70B Instruct"
+    },
+    {
+      "id": "Meta-Llama-3.1-70B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3.1 70B"
+    },
+    {
+      "id": "Meta-Llama-3-8B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3 8B Instruct"
+    },
+    {
+      "id": "Meta-Llama-3-8B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3 8B"
+    },
+    {
+      "id": "Meta-Llama-3-70B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3 70B Instruct"
+    },
+    {
+      "id": "Meta-Llama-3-70B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3 70B"
+    },
+    {
+      "id": "Llama-3.2-1B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 3.2 1B"
+    },
+    {
+      "id": "Llama-3.2-3B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 3.2 3B"
+    },
+    {
+      "id": "Llama-Guard-3-8B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama Guard 3 8B"
+    },
+    {
+      "id": "ai21.j2-mid-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "AI21 J2 Mid v1"
+    },
+    {
+      "id": "ai21.j2-ultra-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "AI21 J2 Ultra v1"
+    },
+    {
+      "id": "ai21.j2-ultra-v1:0:8k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "AI21 J2 Ultra v1 (8K context)"
+    },
+    {
+      "id": "ai21.jamba-1-5-large-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "AI21 Jamba 1.5 Large v1"
+    },
+    {
+      "id": "ai21.jamba-1-5-mini-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "AI21 Jamba 1.5 Mini v1"
+    },
+    {
+      "id": "ai21.jamba-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "AI21 Jamba Instruct v1"
+    },
+    {
+      "id": "amazon.titan-embed-image-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Embed Image v1"
+    },
+    {
+      "id": "amazon.titan-embed-image-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Embed Image v1"
+    },
+    {
+      "id": "amazon.titan-embed-text-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Embed Text v1"
+    },
+    {
+      "id": "amazon.titan-embed-text-v1:2:8k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Embed Text v1.2 (8K context)"
+    },
+    {
+      "id": "amazon.titan-embed-text-v2:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Embed Text v2"
+    },
+    {
+      "id": "amazon.titan-embed-text-v2:0:8k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Embed Text v2 (8K context)"
+    },
+    {
+      "id": "amazon.titan-image-generator-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Image Generator v1"
+    },
+    {
+      "id": "amazon.titan-image-generator-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Image Generator v1"
+    },
+    {
+      "id": "amazon.titan-image-generator-v2:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Image Generator v2"
+    },
+    {
+      "id": "amazon.titan-image-generator-v2:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Image Generator v2"
+    },
+    {
+      "id": "amazon.titan-text-express-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Text Express v1"
+    },
+    {
+      "id": "amazon.titan-text-express-v1:0:8k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Text Express v1 (8K context)"
+    },
+    {
+      "id": "amazon.titan-text-lite-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Text Lite v1"
+    },
+    {
+      "id": "amazon.titan-text-lite-v1:0:4k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Text Lite v1 (4K context)"
+    },
+    {
+      "id": "amazon.titan-text-premier-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Text Premier v1"
+    },
+    {
+      "id": "amazon.titan-text-premier-v1:0:32K",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Amazon Titan Text Premier v1 (32K context)"
+    },
+    {
+      "id": "anthropic.claude-3-5-sonnet-20240620-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3.5 Sonnet (June 20, 2024)"
+    },
+    {
+      "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:18k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3.5 Sonnet (18K context)"
+    },
+    {
+      "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:200k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3.5 Sonnet (200K context)"
+    },
+    {
+      "id": "anthropic.claude-3-5-sonnet-20240620-v1:0:51k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3.5 Sonnet (51K context)"
+    },
+    {
+      "id": "anthropic.claude-3-haiku-20240307-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3 Haiku (March 7, 2024)"
+    },
+    {
+      "id": "anthropic.claude-3-haiku-20240307-v1:0:200k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3 Haiku (200K context)"
+    },
+    {
+      "id": "anthropic.claude-3-haiku-20240307-v1:0:48k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3 Haiku (48K context)"
+    },
+    {
+      "id": "anthropic.claude-3-opus-20240229-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3 Opus (February 29, 2024)"
+    },
+    {
+      "id": "anthropic.claude-3-sonnet-20240229-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3 Sonnet (February 29, 2024)"
+    },
+    {
+      "id": "anthropic.claude-3-sonnet-20240229-v1:0:200k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3 Sonnet (200K context)"
+    },
+    {
+      "id": "anthropic.claude-3-sonnet-20240229-v1:0:28k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude 3 Sonnet (28K context)"
+    },
+    {
+      "id": "anthropic.claude-instant-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude Instant v1"
+    },
+    {
+      "id": "anthropic.claude-instant-v1:2:100k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude Instant v1.2 (100K context)"
+    },
+    {
+      "id": "anthropic.claude-v2",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude v2"
+    },
+    {
+      "id": "anthropic.claude-v2:0:100k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude v2 (100K context)"
+    },
+    {
+      "id": "anthropic.claude-v2:0:18k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude v2 (18K context)"
+    },
+    {
+      "id": "anthropic.claude-v2:1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude v2.1"
+    },
+    {
+      "id": "anthropic.claude-v2:1:18k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude v2.1 (18K context)"
+    },
+    {
+      "id": "anthropic.claude-v2:1:200k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Anthropic Claude v2.1 (200K context)"
+    },
+    {
+      "id": "cohere.command-light-text-v14",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Command Light Text v14"
+    },
+    {
+      "id": "cohere.command-light-text-v14:7:4k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Command Light Text v14.7 (4K context)"
+    },
+    {
+      "id": "cohere.command-r-plus-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Command R Plus v1"
+    },
+    {
+      "id": "cohere.command-r-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Command R v1"
+    },
+    {
+      "id": "cohere.command-text-v14",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Command Text v14"
+    },
+    {
+      "id": "cohere.command-text-v14:7:4k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Command Text v14.7 (4K context)"
+    },
+    {
+      "id": "cohere.embed-english-v3",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Embed English v3"
+    },
+    {
+      "id": "cohere.embed-english-v3:0:512",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Embed English v3 (512 context)"
+    },
+    {
+      "id": "cohere.embed-multilingual-v3",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Embed Multilingual v3"
+    },
+    {
+      "id": "cohere.embed-multilingual-v3:0:512",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Cohere Embed Multilingual v3 (512 context)"
+    },
+    {
+      "id": "meta.llama2-13b-chat-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 2 13B Chat v1"
+    },
+    {
+      "id": "meta.llama2-13b-chat-v1:0:4k",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 2 13B Chat v1 (4K context)"
+    },
+    {
+      "id": "meta.llama2-70b-chat-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 2 70B Chat v1"
+    },
+    {
+      "id": "meta.llama3-1-405b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3.1 405B Instruct v1"
+    },
+    {
+      "id": "meta.llama3-1-70b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3.1 70B Instruct v1"
+    },
+    {
+      "id": "meta.llama3-1-8b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3.1 8B Instruct v1"
+    },
+    {
+      "id": "meta.llama3-2-11b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3.2 11B Instruct v1"
+    },
+    {
+      "id": "meta.llama3-2-1b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3.2 1B Instruct v1"
+    },
+    {
+      "id": "meta.llama3-2-3b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3.2 3B Instruct v1"
+    },
+    {
+      "id": "meta.llama3-2-90b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3.2 90B Instruct v1"
+    },
+    {
+      "id": "meta.llama3-70b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3 70B Instruct v1"
+    },
+    {
+      "id": "meta.llama3-8b-instruct-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Meta LLaMA 3 8B Instruct v1"
+    },
+    {
+      "id": "mistral.mistral-7b-instruct-v0:2",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Mistral 7B Instruct v0.2"
+    },
+    {
+      "id": "mistral.mistral-large-2402-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Mistral Large (February 2024)"
+    },
+    {
+      "id": "mistral.mistral-large-2407-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Mistral Large (July 2024)"
+    },
+    {
+      "id": "mistral.mistral-small-2402-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Mistral Small (February 2024)"
+    },
+    {
+      "id": "mistral.mixtral-8x7b-instruct-v0:1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Mixtral 8x7B Instruct v0.1"
+    },
+    {
+      "id": "stability.sd3-large-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Stability AI SD3 Large v1"
+    },
+    {
+      "id": "stability.stable-diffusion-xl-v0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Stability AI Stable Diffusion XL v0"
+    },
+    {
+      "id": "stability.stable-diffusion-xl-v1",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Stability AI Stable Diffusion XL v1"
+    },
+    {
+      "id": "stability.stable-diffusion-xl-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Stability AI Stable Diffusion XL v1"
+    },
+    {
+      "id": "stability.stable-image-core-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Stability AI Stable Image Core v1"
+    },
+    {
+      "id": "stability.stable-image-ultra-v1:0",
+      "object": "model",
+      "provider": {
+        "id": "bedrock"
+      },
+      "name": "Stability AI Stable Image Ultra v1"
+    },
+    {
+      "id": "llama3.1-70b",
+      "object": "model",
+      "provider": {
+        "id": "cerebras"
+      },
+      "name": "70B"
+    },
+    {
+      "id": "llama3.1-8b",
+      "object": "model",
+      "provider": {
+        "id": "cerebras"
+      },
+      "name": "8B"
+    },
+    {
+      "id": "c4ai-aya-23-35b",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "C4AI Aya 23 35B"
+    },
+    {
+      "id": "c4ai-aya-23-8b",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "C4AI Aya 23 8B"
+    },
+    {
+      "id": "command",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command"
+    },
+    {
+      "id": "command-light",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command Light"
+    },
+    {
+      "id": "command-light-nightly",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command Light Nightly"
+    },
+    {
+      "id": "command-nightly",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command Nightly"
+    },
+    {
+      "id": "command-r",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command R"
+    },
+    {
+      "id": "command-r-03-2024",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command R"
+    },
+    {
+      "id": "command-r-08-2024",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command R (August 2024)"
+    },
+    {
+      "id": "command-r-plus",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command R Plus"
+    },
+    {
+      "id": "command-r-plus-08-2024",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Command R Plus (August 2024)"
+    },
+    {
+      "id": "embed-english-light-v2.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Embed English Light v2.0"
+    },
+    {
+      "id": "embed-english-light-v3.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Embed English Light v3.0"
+    },
+    {
+      "id": "embed-english-v2.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Embed English v2.0"
+    },
+    {
+      "id": "embed-english-v3.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Embed English v3.0"
+    },
+    {
+      "id": "embed-multilingual-light-v3.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Embed Multilingual Light v3.0"
+    },
+    {
+      "id": "embed-multilingual-v2.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Embed Multilingual v2.0"
+    },
+    {
+      "id": "embed-multilingual-v3.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Embed Multilingual v3.0"
+    },
+    {
+      "id": "rerank-english-v2.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Rerank English v2.0"
+    },
+    {
+      "id": "rerank-english-v3.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Rerank English v3.0"
+    },
+    {
+      "id": "rerank-multilingual-v2.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Rerank Multilingual v2.0"
+    },
+    {
+      "id": "rerank-multilingual-v3.0",
+      "object": "model",
+      "provider": {
+        "id": "cohere"
+      },
+      "name": "Cohere Rerank Multilingual v3.0"
+    },
+    {
+      "id": "Claude-3.5-Sonnet",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Claude 3.5 Sonnet"
+    },
+    {
+      "id": "dall-e-3",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Dall E 3"
+    },
+    {
+      "id": "GPT-3.5-turbo",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Gpt 3.5 Turbo"
+    },
+    {
+      "id": "GPT-3.5-turbo-instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Gpt 3.5 Turbo Instruct"
+    },
+    {
+      "id": "GPT-4-turbo",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Gpt 4 Turbo"
+    },
+    {
+      "id": "GPT-4o",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Gpt 4O"
+    },
+    {
+      "id": "GPT-4o-2024-08-06",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Gpt 4O 2024 08 06"
+    },
+    {
+      "id": "GPT-4o-mini",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Gpt 4O Mini"
+    },
+    {
+      "id": "LLama-3-70b",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Llama 3 70B"
+    },
+    {
+      "id": "LLama-3.1-405b",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Llama 3.1 405B"
+    },
+    {
+      "id": "LLama-3.1-70b",
+      "object": "model",
+      "provider": {
+        "id": "deepbricks"
+      },
+      "name": "Llama 3.1 70B"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3.1-70B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Meta Llama 3.1 70B Instruct"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Meta Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3.1-405B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Meta Llama 3.1 405B Instruct"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Meta Llama 3.1 70B Instruct Turbo"
+    },
+    {
+      "id": "nvidia/Llama-3.1-Nemotron-70B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Llama 3.1 Nemotron 70B Instruct"
+    },
+    {
+      "id": "Qwen/Qwen2.5-72B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Qwen 2.5 72B Instruct"
+    },
+    {
+      "id": "meta-llama/Llama-3.2-90B-Vision-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Llama 3.2 90B Vision Instruct"
+    },
+    {
+      "id": "meta-llama/Llama-3.2-11B-Vision-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Llama 3.2 11B Vision Instruct"
+    },
+    {
+      "id": "microsoft/WizardLM-2-8x22B",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "WizardLM 2 8x22B"
+    },
+    {
+      "id": "01-ai/Yi-34B-Chat",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Yi 34B Chat"
+    },
+    {
+      "id": "Austism/chronos-hermes-13b-v2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Chronos Hermes 13B v2"
+    },
+    {
+      "id": "deepseek-chat",
+      "object": "model",
+      "provider": {
+        "id": "deepseek"
+      },
+      "name": "Deepseek Chat"
+    },
+    {
+      "id": "deepseek-coder",
+      "object": "model",
+      "provider": {
+        "id": "deepseek"
+      },
+      "name": "Deepseek Coder"
+    },
+    {
+      "id": "accounts/fireworks/models/chronos-hermes-13b-v2",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Chronos Hermes 13B V2"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-13b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 13B"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-13b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 13B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-13b-python",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 13B Python"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-34b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 34B"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-34b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 34B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-34b-python",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 34B Python"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-70b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 70B"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 70B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-70b-python",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 70B Python"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 7B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/code-llama-7b-python",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Llama 7B Python"
+    },
+    {
+      "id": "accounts/fireworks/models/code-qwen-1p5-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Code Qwen 1P5 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/codegemma-2b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Codegemma 2B"
+    },
+    {
+      "id": "accounts/fireworks/models/codegemma-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Codegemma 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/dbrx-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Dbrx Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-coder-1b-base",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek Coder 1B Base"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-coder-33b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek Coder 33B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-coder-7b-base",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek Coder 7B Base"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-coder-7b-base-v1p5",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek Coder 7B Base V1P5"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-coder-7b-instruct-v1p5",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek Coder 7B Instruct V1P5"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-coder-v2-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek Coder V2 Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-coder-v2-lite-base",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek Coder V2 Lite Base"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-coder-v2-lite-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek Coder V2 Lite Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/deepseek-v2p5",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Deepseek V2P5"
+    },
+    {
+      "id": "accounts/fireworks/models/dolphin-2-9-2-qwen2-72b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Dolphin 2 9 2 Qwen2 72B"
+    },
+    {
+      "id": "accounts/fireworks/models/dolphin-2p6-mixtral-8x7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Dolphin 2P6 Mixtral 8X7B"
+    },
+    {
+      "id": "accounts/fireworks/models/elyza-japanese-llama-2-7b-fast-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Elyza Japanese Llama 2 7B Fast Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/firefunction-v1",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Firefunction V1"
+    },
+    {
+      "id": "accounts/fireworks/models/firefunction-v2",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Firefunction V2"
+    },
+    {
+      "id": "accounts/fireworks/models/firellava-13b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Firellava 13B"
+    },
+    {
+      "id": "accounts/fireworks/models/flux-1-dev-fp8",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Flux 1 Dev Fp8"
+    },
+    {
+      "id": "accounts/fireworks/models/flux-1-schnell-fp8",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Flux 1 Schnell Fp8"
+    },
+    {
+      "id": "accounts/fireworks/models/gemma-2b-it",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Gemma 2B It"
+    },
+    {
+      "id": "accounts/fireworks/models/gemma-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Gemma 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/gemma-7b-it",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Gemma 7B It"
+    },
+    {
+      "id": "accounts/fireworks/models/hermes-2-pro-mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Hermes 2 Pro Mistral 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/japanese-stable-diffusion-xl",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Japanese Stable Diffusion Xl"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-guard-2-8b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama Guard 2 8B"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v2-13b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V2 13B"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v2-13b-chat",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V2 13B Chat"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v2-70b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V2 70B"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v2-70b-chat",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V2 70B Chat"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v2-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V2 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v2-7b-chat",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V2 7B Chat"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3 70B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3-70b-instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3 70B Instruct Hf"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3-8b-hf",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3 8B Hf"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3 8B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3-8b-instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3 8B Instruct Hf"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3p1-405b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3P1 405B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3p1-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3P1 70B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3p1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3P1 8B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3p2-11b-vision-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3P2 11B Vision Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3p2-1b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3P2 1B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3p2-3b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3P2 3B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llama-v3p2-90b-vision-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llama V3P2 90B Vision Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/llamaguard-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llamaguard 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/llava-yi-34b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Llava Yi 34B"
+    },
+    {
+      "id": "accounts/fireworks/models/mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mistral 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/mistral-7b-instruct-4k",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mistral 7B Instruct 4K"
+    },
+    {
+      "id": "accounts/fireworks/models/mistral-7b-instruct-v0p2",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mistral 7B Instruct V0P2"
+    },
+    {
+      "id": "accounts/fireworks/models/mistral-7b-instruct-v3",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mistral 7B Instruct V3"
+    },
+    {
+      "id": "accounts/fireworks/models/mistral-7b-v0p2",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mistral 7B V0P2"
+    },
+    {
+      "id": "accounts/fireworks/models/mistral-nemo-base-2407",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mistral Nemo Base 2407"
+    },
+    {
+      "id": "accounts/fireworks/models/mistral-nemo-instruct-2407",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mistral Nemo Instruct 2407"
+    },
+    {
+      "id": "accounts/fireworks/models/mixtral-8x22b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mixtral 8X22B"
+    },
+    {
+      "id": "accounts/fireworks/models/mixtral-8x22b-hf",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mixtral 8X22B Hf"
+    },
+    {
+      "id": "accounts/fireworks/models/mixtral-8x22b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mixtral 8X22B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/mixtral-8x22b-instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mixtral 8X22B Instruct Hf"
+    },
+    {
+      "id": "accounts/fireworks/models/mixtral-8x7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mixtral 8X7B"
+    },
+    {
+      "id": "accounts/fireworks/models/mixtral-8x7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mixtral 8X7B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/mixtral-8x7b-instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mixtral 8X7B Instruct Hf"
+    },
+    {
+      "id": "accounts/fireworks/models/mythomax-l2-13b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Mythomax L2 13B"
+    },
+    {
+      "id": "accounts/fireworks/models/nous-capybara-7b-v1p9",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Nous Capybara 7B V1P9"
+    },
+    {
+      "id": "accounts/fireworks/models/nous-hermes-2-mixtral-8x7b-dpo",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Nous Hermes 2 Mixtral 8X7B Dpo"
+    },
+    {
+      "id": "accounts/fireworks/models/nous-hermes-2-yi-34b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Nous Hermes 2 Yi 34B"
+    },
+    {
+      "id": "accounts/fireworks/models/nous-hermes-llama2-13b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Nous Hermes Llama2 13B"
+    },
+    {
+      "id": "accounts/fireworks/models/nous-hermes-llama2-70b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Nous Hermes Llama2 70B"
+    },
+    {
+      "id": "accounts/fireworks/models/nous-hermes-llama2-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Nous Hermes Llama2 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/openchat-3p5-0106-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Openchat 3P5 0106 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/openhermes-2-mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Openhermes 2 Mistral 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/openhermes-2p5-mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Openhermes 2P5 Mistral 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/openorca-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Openorca 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/phi-2-3b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Phi 2 3B"
+    },
+    {
+      "id": "accounts/fireworks/models/phi-3-mini-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Phi 3 Mini 128K Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/phi-3-vision-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Phi 3 Vision 128K Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/phind-code-llama-34b-python-v1",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Phind Code Llama 34B Python V1"
+    },
+    {
+      "id": "accounts/fireworks/models/phind-code-llama-34b-v1",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Phind Code Llama 34B V1"
+    },
+    {
+      "id": "accounts/fireworks/models/phind-code-llama-34b-v2",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Phind Code Llama 34B V2"
+    },
+    {
+      "id": "accounts/fireworks/models/playground-v2-1024px-aesthetic",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Playground V2 1024Px Aesthetic"
+    },
+    {
+      "id": "accounts/fireworks/models/playground-v2-5-1024px-aesthetic",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Playground V2 5 1024Px Aesthetic"
+    },
+    {
+      "id": "accounts/fireworks/models/pythia-12b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Pythia 12B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen-v2p5-14b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen V2P5 14B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen-v2p5-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen V2P5 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen1p5-72b-chat",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen1P5 72B Chat"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2 72B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2 7B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-14b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 14B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-14b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 14B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-32b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 32B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-32b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 32B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-72b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 72B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 72B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 7B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-coder-1p5b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 Coder 1P5B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-coder-1p5b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 Coder 1P5B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-coder-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 Coder 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-coder-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 Coder 7B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/qwen2p5-math-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Qwen2P5 Math 72B Instruct"
+    },
+    {
+      "id": "accounts/fireworks/models/snorkel-mistral-7b-pairrm-dpo",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Snorkel Mistral 7B Pairrm Dpo"
+    },
+    {
+      "id": "accounts/fireworks/models/SSD-1B",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Ssd 1B"
+    },
+    {
+      "id": "accounts/fireworks/models/stable-diffusion-xl-1024-v1-0",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Stable Diffusion Xl 1024 V1 0"
+    },
+    {
+      "id": "accounts/fireworks/models/stablecode-3b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Stablecode 3B"
+    },
+    {
+      "id": "accounts/fireworks/models/starcoder-16b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Starcoder 16B"
+    },
+    {
+      "id": "accounts/fireworks/models/starcoder-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Starcoder 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/starcoder2-15b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Starcoder2 15B"
+    },
+    {
+      "id": "accounts/fireworks/models/starcoder2-3b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Starcoder2 3B"
+    },
+    {
+      "id": "accounts/fireworks/models/starcoder2-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Starcoder2 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/toppy-m-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Toppy M 7B"
+    },
+    {
+      "id": "accounts/fireworks/models/yi-34b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Yi 34B"
+    },
+    {
+      "id": "accounts/fireworks/models/yi-34b-200k-capybara",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Yi 34B 200K Capybara"
+    },
+    {
+      "id": "accounts/fireworks/models/yi-34b-chat",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Yi 34B Chat"
+    },
+    {
+      "id": "accounts/fireworks/models/yi-6b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Yi 6B"
+    },
+    {
+      "id": "accounts/fireworks/models/zephyr-7b-beta",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Zephyr 7B Beta"
+    },
+    {
+      "id": "accounts/muhtasham-83b323/models/order-ds-lora",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Models/Order Ds Lora"
+    },
+    {
+      "id": "accounts/stability/models/japanese-stable-vlm-8b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Japanese Stable Vlm 8B"
+    },
+    {
+      "id": "accounts/stability/models/japanese-stablelm-instruct-beta-70b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Japanese Stablelm Instruct Beta 70B"
+    },
+    {
+      "id": "accounts/stability/models/japanese-stablelm-instruct-gamma-7b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Japanese Stablelm Instruct Gamma 7B"
+    },
+    {
+      "id": "accounts/stability/models/sd3",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Sd3"
+    },
+    {
+      "id": "accounts/stability/models/sd3-medium",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Sd3 Medium"
+    },
+    {
+      "id": "accounts/stability/models/sd3-turbo",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Sd3 Turbo"
+    },
+    {
+      "id": "accounts/stability/models/stablecode-3b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Stablecode 3B"
+    },
+    {
+      "id": "accounts/stability/models/stablelm-2-zephyr-2b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Stablelm 2 Zephyr 2B"
+    },
+    {
+      "id": "accounts/stability/models/stablelm-zephyr-3b",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "Stablelm Zephyr 3B"
+    },
+    {
+      "id": "accounts/yi-01-ai/models/yi-large",
+      "object": "model",
+      "provider": {
+        "id": "fireworks-ai"
+      },
+      "name": "I Large"
+    },
+    {
+      "id": "gemini-1.0-pro",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Gemini 1.0 Pro"
+    },
+    {
+      "id": "gemini-1.5-flash",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Gemini 1.5 Flash"
+    },
+    {
+      "id": "gemini-1.5-flash-8b-exp-0827",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Gemini 1.5 Flash 8B (Exp 0827)"
+    },
+    {
+      "id": "gemini-1.5-flash-exp-0827",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Gemini 1.5 Flash (Exp 0827)"
+    },
+    {
+      "id": "gemini-1.5-pro",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Gemini 1.5 Pro"
+    },
+    {
+      "id": "gemini-1.5-pro-exp-0801",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Gemini 1.5 Pro (Exp 0801)"
+    },
+    {
+      "id": "gemini-1.5-pro-exp-0827",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Gemini 1.5 Pro (Exp 0827)"
+    },
+    {
+      "id": "text-embedding-004",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Text Embedding 004"
+    },
+    {
+      "id": "aqa",
+      "object": "model",
+      "provider": {
+        "id": "google"
+      },
+      "name": "Attributed Question-Answering"
+    },
+    {
+      "id": "distil-whisper-large-v3-en",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Distil Whisper Large v3 English"
+    },
+    {
+      "id": "gemma2-9b-it",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Gemma 2 9B Italian"
+    },
+    {
+      "id": "gemma-7b-it",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Gemma 7B Italian"
+    },
+    {
+      "id": "llama3-groq-70b-8192-tool-use-preview",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3 Groq 70B 8192 Tool Use Preview"
+    },
+    {
+      "id": "llama3-groq-8b-8192-tool-use-preview",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3 Groq 8B 8192 Tool Use Preview"
+    },
+    {
+      "id": "llama-3.1-70b-versatile",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3.1 70B Versatile"
+    },
+    {
+      "id": "llama-3.1-8b-instant",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3.1 8B Instant"
+    },
+    {
+      "id": "llama-3.2-1b-preview",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3.2 1B Preview"
+    },
+    {
+      "id": "llama-3.2-3b-preview",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3.2 3B Preview"
+    },
+    {
+      "id": "llama-3.2-11b-vision-preview",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3.2 11B Vision Preview"
+    },
+    {
+      "id": "llama-3.2-90b-vision-preview",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3.2 90B Vision Preview"
+    },
+    {
+      "id": "llama-guard-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama Guard 3 8B"
+    },
+    {
+      "id": "yi-large",
+      "object": "model",
+      "provider": {
+        "id": "lingyi"
+      },
+      "name": "Yi Large"
+    },
+    {
+      "id": "yi-large-fc",
+      "object": "model",
+      "provider": {
+        "id": "lingyi"
+      },
+      "name": "Yi Large FC"
+    },
+    {
+      "id": "yi-large-turbo",
+      "object": "model",
+      "provider": {
+        "id": "lingyi"
+      },
+      "name": "Yi Large Turbo"
+    },
+    {
+      "id": "acolyte-22b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Acolyte 22B I1"
+    },
+    {
+      "id": "all-MiniLM-L6-v2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "All Minilm L6 V2"
+    },
+    {
+      "id": "anjir-8b-l3-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Anjir 8B L3 I1"
+    },
+    {
+      "id": "apollo2-9b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Apollo2 9B"
+    },
+    {
+      "id": "arcee-agent",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Arcee Agent"
+    },
+    {
+      "id": "arcee-spark",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Arcee Spark"
+    },
+    {
+      "id": "arch-function-1.5b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Arch Function 1.5B"
+    },
+    {
+      "id": "arch-function-3b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Arch Function 3B"
+    },
+    {
+      "id": "arch-function-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Arch Function 7B"
+    },
+    {
+      "id": "archangel_sft_pythia2-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Archangel_Sft_Pythia2 8B"
+    },
+    {
+      "id": "arliai-llama-3-8b-dolfin-v0.5",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Arliai Llama 3 8B Dolfin V0.5"
+    },
+    {
+      "id": "arliai-llama-3-8b-formax-v1.0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Arliai Llama 3 8B Formax V1.0"
+    },
+    {
+      "id": "astral-fusion-neural-happy-l3.1-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Astral Fusion Neural Happy L3.1 8B"
+    },
+    {
+      "id": "athena-codegemma-2-2b-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Athena Codegemma 2 2B It"
+    },
+    {
+      "id": "aura-llama-abliterated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Aura Llama Abliterated"
+    },
+    {
+      "id": "aura-uncensored-l3-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Aura Uncensored L3 8B Iq Imatrix"
+    },
+    {
+      "id": "aurora_l3_8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Aurora_L3_8B Iq Imatrix"
+    },
+    {
+      "id": "average_normie_l3_v1_8b-gguf-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Average_Normie_L3_V1_8B Gguf Iq Imatrix"
+    },
+    {
+      "id": "aya-23-35b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Aya 23 35B"
+    },
+    {
+      "id": "aya-23-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Aya 23 8B"
+    },
+    {
+      "id": "azure_dusk-v0.2-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Azure_Dusk V0.2 Iq Imatrix"
+    },
+    {
+      "id": "badger-lambda-llama-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Badger Lambda Llama 3 8B"
+    },
+    {
+      "id": "baldur-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Baldur 8B"
+    },
+    {
+      "id": "bert-embeddings",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Bert Embeddings"
+    },
+    {
+      "id": "big-tiger-gemma-27b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Big Tiger Gemma 27B V1"
+    },
+    {
+      "id": "bigqwen2.5-52b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Bigqwen2.5 52B Instruct"
+    },
+    {
+      "id": "biomistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Biomistral 7B"
+    },
+    {
+      "id": "buddy-2b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Buddy 2B V1"
+    },
+    {
+      "id": "bungo-l3-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Bungo L3 8B Iq Imatrix"
+    },
+    {
+      "id": "bunny-llama-3-8b-v",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Bunny Llama 3 8B V"
+    },
+    {
+      "id": "calme-2.1-phi3.5-4b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Calme 2.1 Phi3.5 4B I1"
+    },
+    {
+      "id": "calme-2.2-qwen2-72b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Calme 2.2 Qwen2 72B"
+    },
+    {
+      "id": "calme-2.2-qwen2.5-72b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Calme 2.2 Qwen2.5 72B I1"
+    },
+    {
+      "id": "calme-2.3-legalkit-8b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Calme 2.3 Legalkit 8B I1"
+    },
+    {
+      "id": "calme-2.3-phi3-4b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Calme 2.3 Phi3 4B"
+    },
+    {
+      "id": "calme-2.4-llama3-70b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Calme 2.4 Llama3 70B"
+    },
+    {
+      "id": "calme-2.8-qwen2-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Calme 2.8 Qwen2 7B"
+    },
+    {
+      "id": "cathallama-70b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Cathallama 70B"
+    },
+    {
+      "id": "chaos-rp_l3_b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Chaos Rp_L3_B Iq Imatrix"
+    },
+    {
+      "id": "codellama-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Codellama 7B"
+    },
+    {
+      "id": "codestral-22b-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Codestral 22B V0.1"
+    },
+    {
+      "id": "command-r-v01:q1_s",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Command R V01:Q1_S"
+    },
+    {
+      "id": "cream-phi-3-14b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Cream Phi 3 14B V1"
+    },
+    {
+      "id": "cursorcore-ds-6.7b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Cursorcore Ds 6.7B I1"
+    },
+    {
+      "id": "cursorcore-qw2.5-1.5b-lc-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Cursorcore Qw2.5 1.5B Lc I1"
+    },
+    {
+      "id": "cursorcore-qw2.5-7b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Cursorcore Qw2.5 7B I1"
+    },
+    {
+      "id": "cursorcore-yi-9b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Cursorcore Yi 9B"
+    },
+    {
+      "id": "dans-personalityengine-v1.0.0-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Dans Personalityengine V1.0.0 8B"
+    },
+    {
+      "id": "darkens-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Darkens 8B"
+    },
+    {
+      "id": "darkidol-llama-3.1-8b-instruct-1.0-uncensored-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Darkidol Llama 3.1 8B Instruct 1.0 Uncensored I1"
+    },
+    {
+      "id": "darkidol-llama-3.1-8b-instruct-1.1-uncensored-iq-imatrix-request",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Darkidol Llama 3.1 8B Instruct 1.1 Uncensored Iq Imatrix Request"
+    },
+    {
+      "id": "datagemma-rag-27b-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Datagemma Rag 27B It"
+    },
+    {
+      "id": "datagemma-rig-27b-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Datagemma Rig 27B It"
+    },
+    {
+      "id": "deepseek-coder-v2-lite-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Deepseek Coder V2 Lite Instruct"
+    },
+    {
+      "id": "doctoraifinetune-3.1-8b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Doctoraifinetune 3.1 8B I1"
+    },
+    {
+      "id": "dolphin-2.9-llama3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Dolphin 2.9 Llama3 8B"
+    },
+    {
+      "id": "dolphin-2.9-llama3-8b:Q6_K",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Dolphin 2.9 Llama3 8B:Q6_K"
+    },
+    {
+      "id": "dolphin-2.9.2-phi-3-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Dolphin 2.9.2 Phi 3 Medium"
+    },
+    {
+      "id": "dolphin-2.9.2-phi-3-Medium-abliterated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Dolphin 2.9.2 Phi 3 Medium Abliterated"
+    },
+    {
+      "id": "dolphin-2.9.2-qwen2-72b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Dolphin 2.9.2 Qwen2 72B"
+    },
+    {
+      "id": "dolphin-2.9.2-qwen2-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Dolphin 2.9.2 Qwen2 7B"
+    },
+    {
+      "id": "dreamshaper",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Dreamshaper"
+    },
+    {
+      "id": "duloxetine-4b-v1-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Duloxetine 4B V1 Iq Imatrix"
+    },
+    {
+      "id": "edgerunner-command-nested-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Edgerunner Command Nested I1"
+    },
+    {
+      "id": "edgerunner-tactical-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Edgerunner Tactical 7B"
+    },
+    {
+      "id": "einstein-v4-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Einstein V4 7B"
+    },
+    {
+      "id": "einstein-v6.1-llama3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Einstein V6.1 Llama3 8B"
+    },
+    {
+      "id": "einstein-v7-qwen2-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Einstein V7 Qwen2 7B"
+    },
+    {
+      "id": "emo-2b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Emo 2B"
+    },
+    {
+      "id": "eva-qwen2.5-14b-v0.1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Eva Qwen2.5 14B V0.1 I1"
+    },
+    {
+      "id": "ezo-common-9b-gemma-2-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Ezo Common 9B Gemma 2 It"
+    },
+    {
+      "id": "fimbulvetr-11b-v2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Fimbulvetr 11B V2"
+    },
+    {
+      "id": "fimbulvetr-11b-v2-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Fimbulvetr 11B V2 Iq Imatrix"
+    },
+    {
+      "id": "fireball-llama-3.11-8b-v1orpo",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Fireball Llama 3.11 8B V1Orpo"
+    },
+    {
+      "id": "fireball-meta-llama-3.2-8b-instruct-agent-003-128k-code-dpo",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Fireball Meta Llama 3.2 8B Instruct Agent 003 128K Code Dpo"
+    },
+    {
+      "id": "firefly-gemma-7b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Firefly Gemma 7B Iq Imatrix"
+    },
+    {
+      "id": "flux.1-dev",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Flux.1 Dev"
+    },
+    {
+      "id": "flux.1-schnell",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Flux.1 Schnell"
+    },
+    {
+      "id": "gemma-1.1-7b-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 1.1 7B It"
+    },
+    {
+      "id": "gemma-2-27b-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2 27B It"
+    },
+    {
+      "id": "gemma-2-2b-arliai-rpmax-v1.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2 2B Arliai Rpmax V1.1"
+    },
+    {
+      "id": "gemma-2-9b-arliai-rpmax-v1.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2 9B Arliai Rpmax V1.1"
+    },
+    {
+      "id": "gemma-2-9b-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2 9B It"
+    },
+    {
+      "id": "gemma-2-9b-it-abliterated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2 9B It Abliterated"
+    },
+    {
+      "id": "gemma-2-9b-it-sppo-iter3",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2 9B It Sppo Iter3"
+    },
+    {
+      "id": "gemma-2-ataraxy-v3i-9b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2 Ataraxy V3I 9B"
+    },
+    {
+      "id": "gemma-2b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2B"
+    },
+    {
+      "id": "gemma-2b-translation-v0.150",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma 2B Translation V0.150"
+    },
+    {
+      "id": "gemma2-9b-daybreak-v0.5",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemma2 9B Daybreak V0.5"
+    },
+    {
+      "id": "gemmasutra-mini-2b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemmasutra Mini 2B V1"
+    },
+    {
+      "id": "gemmasutra-pro-27b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemmasutra Pro 27B V1"
+    },
+    {
+      "id": "gemmoy-9b-g2-mk.3-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Gemmoy 9B G2 Mk.3 I1"
+    },
+    {
+      "id": "genius-llama3.1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Genius Llama3.1 I1"
+    },
+    {
+      "id": "guillaumetell-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Guillaumetell 7B"
+    },
+    {
+      "id": "halomaidrp-v1.33-15b-l3-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Halomaidrp V1.33 15B L3 I1"
+    },
+    {
+      "id": "halu-8b-llama3-blackroot-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Halu 8B Llama3 Blackroot Iq Imatrix"
+    },
+    {
+      "id": "hathor_respawn-l3-8b-v0.8",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hathor_Respawn L3 8B V0.8"
+    },
+    {
+      "id": "hathor_stable-v0.2-l3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hathor_Stable V0.2 L3 8B"
+    },
+    {
+      "id": "hathor_tahsin-l3-8b-v0.85",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hathor_Tahsin L3 8B V0.85"
+    },
+    {
+      "id": "hathor-l3-8b-v.01-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hathor L3 8B V.01 Iq Imatrix"
+    },
+    {
+      "id": "helpingai-9b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Helpingai 9B"
+    },
+    {
+      "id": "hercules-5.0-qwen2-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hercules 5.0 Qwen2 7B"
+    },
+    {
+      "id": "hermes-2-pro-llama-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 2 Pro Llama 3 8B"
+    },
+    {
+      "id": "hermes-2-pro-llama-3-8b:Q5_K_M",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 2 Pro Llama 3 8B:Q5_K_M"
+    },
+    {
+      "id": "hermes-2-pro-llama-3-8b:Q8_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 2 Pro Llama 3 8B:Q8_0"
+    },
+    {
+      "id": "hermes-2-pro-mistral",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 2 Pro Mistral"
+    },
+    {
+      "id": "hermes-2-pro-mistral:Q6_K",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 2 Pro Mistral:Q6_K"
+    },
+    {
+      "id": "hermes-2-pro-mistral:Q8_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 2 Pro Mistral:Q8_0"
+    },
+    {
+      "id": "hermes-2-theta-llama-3-70b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 2 Theta Llama 3 70B"
+    },
+    {
+      "id": "hermes-2-theta-llama-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 2 Theta Llama 3 8B"
+    },
+    {
+      "id": "hermes-3-llama-3.1-405b:vllm",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 405B:Vllm"
+    },
+    {
+      "id": "hermes-3-llama-3.1-70b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 70B"
+    },
+    {
+      "id": "hermes-3-llama-3.1-70b-lorablated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 70B Lorablated"
+    },
+    {
+      "id": "hermes-3-llama-3.1-70b:Q5_K_M",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 70B:Q5_K_M"
+    },
+    {
+      "id": "hermes-3-llama-3.1-70b:vllm",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 70B:Vllm"
+    },
+    {
+      "id": "hermes-3-llama-3.1-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 8B"
+    },
+    {
+      "id": "hermes-3-llama-3.1-8b-lorablated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 8B Lorablated"
+    },
+    {
+      "id": "hermes-3-llama-3.1-8b:Q8",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 8B:Q8"
+    },
+    {
+      "id": "hermes-3-llama-3.1-8b:vllm",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hermes 3 Llama 3.1 8B:Vllm"
+    },
+    {
+      "id": "hodachi-ezo-humanities-9b-gemma-2-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hodachi Ezo Humanities 9B Gemma 2 It"
+    },
+    {
+      "id": "hubble-4b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Hubble 4B V1"
+    },
+    {
+      "id": "humanish-roleplay-llama-3.1-8b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Humanish Roleplay Llama 3.1 8B I1"
+    },
+    {
+      "id": "infinity-instruct-7m-gen-llama3_1-70b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Infinity Instruct 7M Gen Llama3_1 70B"
+    },
+    {
+      "id": "internlm2_5-7b-chat-1m",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Internlm2_5 7B Chat 1M"
+    },
+    {
+      "id": "jsl-medllama-3-8b-v2.0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Jsl Medllama 3 8B V2.0"
+    },
+    {
+      "id": "kumiho-v1-rp-uwu-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Kumiho V1 Rp Uwu 8B"
+    },
+    {
+      "id": "kunocchini-7b-128k-test-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Kunocchini 7B 128K Test Imatrix"
+    },
+    {
+      "id": "l3-15b-etherealmaid-t0.0001-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 15B Etherealmaid T0.0001 I1"
+    },
+    {
+      "id": "l3-15b-mythicalmaid-t0.0001",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 15B Mythicalmaid T0.0001"
+    },
+    {
+      "id": "l3-8b-celeste-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Celeste V1"
+    },
+    {
+      "id": "l3-8b-celeste-v1.2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Celeste V1.2"
+    },
+    {
+      "id": "l3-8b-everything-cot",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Everything Cot"
+    },
+    {
+      "id": "l3-8b-lunaris-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Lunaris V1"
+    },
+    {
+      "id": "l3-8b-niitama-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Niitama V1"
+    },
+    {
+      "id": "l3-8b-niitama-v1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Niitama V1 I1"
+    },
+    {
+      "id": "l3-8b-stheno-horny-v3.3-32k-q5_k_m",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Stheno Horny V3.3 32K Q5_K_M"
+    },
+    {
+      "id": "l3-8b-stheno-v3.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Stheno V3.1"
+    },
+    {
+      "id": "l3-8b-stheno-v3.2-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 8B Stheno V3.2 Iq Imatrix"
+    },
+    {
+      "id": "l3-aethora-15b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 Aethora 15B"
+    },
+    {
+      "id": "l3-aethora-15b-v2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 Aethora 15B V2"
+    },
+    {
+      "id": "l3-chaoticsoliloquy-v1.5-4x8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 Chaoticsoliloquy V1.5 4X8B"
+    },
+    {
+      "id": "l3-ms-astoria-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 Ms Astoria 8B"
+    },
+    {
+      "id": "l3-solana-8b-v1-gguf",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 Solana 8B V1 Gguf"
+    },
+    {
+      "id": "l3-stheno-maid-blackroot-grand-horror-16b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 Stheno Maid Blackroot Grand Horror 16B"
+    },
+    {
+      "id": "l3-umbral-mind-rp-v1.0-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 Umbral Mind Rp V1.0 8B Iq Imatrix"
+    },
+    {
+      "id": "l3-uncen-merger-omelette-rp-v0.2-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3 Uncen Merger Omelette Rp V0.2 8B"
+    },
+    {
+      "id": "l3.1-70b-glitz-v0.2-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3.1 70B Glitz V0.2 I1"
+    },
+    {
+      "id": "l3.1-8b-celeste-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3.1 8B Celeste V1.5"
+    },
+    {
+      "id": "l3.1-8b-llamoutcast-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3.1 8B Llamoutcast I1"
+    },
+    {
+      "id": "l3.1-8b-niitama-v1.1-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3.1 8B Niitama V1.1 Iq Imatrix"
+    },
+    {
+      "id": "l3.1-etherealrainbow-v1.0-rc1-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "L3.1 Etherealrainbow V1.0 Rc1 8B"
+    },
+    {
+      "id": "leetcodewizard_7b_v1.1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Leetcodewizard_7B_V1.1 I1"
+    },
+    {
+      "id": "lexi-llama-3-8b-uncensored",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Lexi Llama 3 8B Uncensored"
+    },
+    {
+      "id": "llama-3_8b_unaligned_alpha",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3_8B_Unaligned_Alpha"
+    },
+    {
+      "id": "llama-3_8b_unaligned_alpha_rp_soup-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3_8B_Unaligned_Alpha_Rp_Soup I1"
+    },
+    {
+      "id": "llama-3_8b_unaligned_beta",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3_8B_Unaligned_Beta"
+    },
+    {
+      "id": "llama-3-11.5b-v2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 11.5B V2"
+    },
+    {
+      "id": "llama-3-13b-instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 13B Instruct V0.1"
+    },
+    {
+      "id": "llama-3-8b-instruct-abliterated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 8B Instruct Abliterated"
+    },
+    {
+      "id": "llama-3-8b-instruct-coder",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 8B Instruct Coder"
+    },
+    {
+      "id": "llama-3-8b-instruct-dpo-v0.3-32k",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 8B Instruct Dpo V0.3 32K"
+    },
+    {
+      "id": "llama-3-8b-instruct-mopeymule",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 8B Instruct Mopeymule"
+    },
+    {
+      "id": "llama-3-8b-lexifun-uncensored-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 8B Lexifun Uncensored V1"
+    },
+    {
+      "id": "llama-3-8b-openhermes-dpo",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 8B Openhermes Dpo"
+    },
+    {
+      "id": "llama-3-alpha-centauri-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Alpha Centauri V0.1"
+    },
+    {
+      "id": "llama-3-cursedstock-v1.8-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Cursedstock V1.8 8B Iq Imatrix"
+    },
+    {
+      "id": "llama-3-ezo-8b-common-it",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Ezo 8B Common It"
+    },
+    {
+      "id": "llama-3-hercules-5.0-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Hercules 5.0 8B"
+    },
+    {
+      "id": "llama-3-instruct-8b-SimPO-ExPO",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Instruct 8B Simpo Expo"
+    },
+    {
+      "id": "llama-3-lewdplay-8b-evo",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Lewdplay 8B Evo"
+    },
+    {
+      "id": "llama-3-llamilitary",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Llamilitary"
+    },
+    {
+      "id": "llama-3-lumimaid-8b-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Lumimaid 8B V0.1"
+    },
+    {
+      "id": "llama-3-lumimaid-8b-v0.1-oas-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Lumimaid 8B V0.1 Oas Iq Imatrix"
+    },
+    {
+      "id": "llama-3-lumimaid-v2-8b-v0.1-oas-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Lumimaid V2 8B V0.1 Oas Iq Imatrix"
+    },
+    {
+      "id": "llama-3-patronus-lynx-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Patronus Lynx 70B Instruct"
+    },
+    {
+      "id": "llama-3-perky-pat-instruct-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Perky Pat Instruct 8B"
+    },
+    {
+      "id": "llama-3-refueled",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Refueled"
+    },
+    {
+      "id": "llama-3-sauerkrautlm-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Sauerkrautlm 8B Instruct"
+    },
+    {
+      "id": "llama-3-sec-chat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Sec Chat"
+    },
+    {
+      "id": "llama-3-smaug-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Smaug 8B"
+    },
+    {
+      "id": "llama-3-soliloquy-8b-v2-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Soliloquy 8B V2 Iq Imatrix"
+    },
+    {
+      "id": "llama-3-sqlcoder-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Sqlcoder 8B"
+    },
+    {
+      "id": "llama-3-stheno-mahou-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Stheno Mahou 8B"
+    },
+    {
+      "id": "llama-3-tulu-2-8b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Tulu 2 8B I1"
+    },
+    {
+      "id": "llama-3-tulu-2-dpo-70b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Tulu 2 Dpo 70B I1"
+    },
+    {
+      "id": "llama-3-ultron",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Ultron"
+    },
+    {
+      "id": "llama-3-unholy-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Unholy 8B"
+    },
+    {
+      "id": "llama-3-unholy-8b:Q8_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Unholy 8B:Q8_0"
+    },
+    {
+      "id": "Llama-3-Yggdrasil-2.0-8B",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3 Yggdrasil 2.0 8B"
+    },
+    {
+      "id": "llama-3.1-70b-japanese-instruct-2407",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 70B Japanese Instruct 2407"
+    },
+    {
+      "id": "llama-3.1-8b-arliai-formax-v1.0-iq-arm-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 8B Arliai Formax V1.0 Iq Arm Imatrix"
+    },
+    {
+      "id": "llama-3.1-8b-arliai-rpmax-v1.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 8B Arliai Rpmax V1.1"
+    },
+    {
+      "id": "llama-3.1-8b-instruct-fei-v1-uncensored",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 8B Instruct Fei V1 Uncensored"
+    },
+    {
+      "id": "llama-3.1-8b-stheno-v3.4-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 8B Stheno V3.4 Iq Imatrix"
+    },
+    {
+      "id": "llama-3.1-nemotron-70b-instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 Nemotron 70B Instruct Hf"
+    },
+    {
+      "id": "llama-3.1-storm-8b-q4_k_m",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 Storm 8B Q4_K_M"
+    },
+    {
+      "id": "llama-3.1-supernova-lite",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 Supernova Lite"
+    },
+    {
+      "id": "llama-3.1-supernova-lite-reflection-v1.0-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 Supernova Lite Reflection V1.0 I1"
+    },
+    {
+      "id": "llama-3.1-swallow-70b-v0.1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 Swallow 70B V0.1 I1"
+    },
+    {
+      "id": "llama-3.1-techne-rp-8b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.1 Techne Rp 8B V1"
+    },
+    {
+      "id": "llama-3.2-1b-instruct:q4_k_m",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.2 1B Instruct:Q4_K_M"
+    },
+    {
+      "id": "llama-3.2-1b-instruct:q8_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.2 1B Instruct:Q8_0"
+    },
+    {
+      "id": "llama-3.2-3b-agent007",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.2 3B Agent007"
+    },
+    {
+      "id": "llama-3.2-3b-agent007-coder",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.2 3B Agent007 Coder"
+    },
+    {
+      "id": "llama-3.2-3b-instruct:q4_k_m",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.2 3B Instruct:Q4_K_M"
+    },
+    {
+      "id": "llama-3.2-3b-instruct:q8_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.2 3B Instruct:Q8_0"
+    },
+    {
+      "id": "llama-3.2-3b-reasoning-time",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.2 3B Reasoning Time"
+    },
+    {
+      "id": "llama-3.2-chibi-3b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama 3.2 Chibi 3B"
+    },
+    {
+      "id": "llama-guard-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama Guard 3 8B"
+    },
+    {
+      "id": "llama-salad-8x8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama Salad 8X8B"
+    },
+    {
+      "id": "llama-spark",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama Spark"
+    },
+    {
+      "id": "llama3-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 70B Instruct"
+    },
+    {
+      "id": "llama3-70b-instruct:IQ1_M",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 70B Instruct:Iq1_M"
+    },
+    {
+      "id": "llama3-70b-instruct:IQ1_S",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 70B Instruct:Iq1_S"
+    },
+    {
+      "id": "llama3-8B-aifeifei-1.0-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Aifeifei 1.0 Iq Imatrix"
+    },
+    {
+      "id": "llama3-8B-aifeifei-1.2-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Aifeifei 1.2 Iq Imatrix"
+    },
+    {
+      "id": "llama3-8b-darkidol-1.1-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Darkidol 1.1 Iq Imatrix"
+    },
+    {
+      "id": "llama3-8b-darkidol-1.2-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Darkidol 1.2 Iq Imatrix"
+    },
+    {
+      "id": "llama3-8b-darkidol-2.1-uncensored-1048k-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Darkidol 2.1 Uncensored 1048K Iq Imatrix"
+    },
+    {
+      "id": "llama3-8b-darkidol-2.2-uncensored-1048k-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Darkidol 2.2 Uncensored 1048K Iq Imatrix"
+    },
+    {
+      "id": "llama3-8b-feifei-1.0-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Feifei 1.0 Iq Imatrix"
+    },
+    {
+      "id": "llama3-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Instruct"
+    },
+    {
+      "id": "llama3-8b-instruct-replete-adapted",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Instruct Replete Adapted"
+    },
+    {
+      "id": "llama3-8b-instruct:Q6_K",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 8B Instruct:Q6_K"
+    },
+    {
+      "id": "llama3-iterative-dpo-final",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 Iterative Dpo Final"
+    },
+    {
+      "id": "llama3-turbcat-instruct-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3 Turbcat Instruct 8B"
+    },
+    {
+      "id": "llama3.1-70b-chinese-chat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3.1 70B Chinese Chat"
+    },
+    {
+      "id": "llama3.1-8b-chinese-chat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3.1 8B Chinese Chat"
+    },
+    {
+      "id": "llama3.1-8b-fireplace2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3.1 8B Fireplace2"
+    },
+    {
+      "id": "llama3.1-8b-shiningvaliant2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3.1 8B Shiningvaliant2"
+    },
+    {
+      "id": "llama3.1-flammades-70b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3.1 Flammades 70B"
+    },
+    {
+      "id": "llama3.1-gutenberg-doppel-70b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3.1 Gutenberg Doppel 70B"
+    },
+    {
+      "id": "llama3.2-3b-enigma",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3.2 3B Enigma"
+    },
+    {
+      "id": "llama3.2-3b-esper2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llama3.2 3B Esper2"
+    },
+    {
+      "id": "llamantino-3-anita-8b-inst-dpo-ita",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llamantino 3 Anita 8B Inst Dpo Ita"
+    },
+    {
+      "id": "llamax3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llamax3 8B"
+    },
+    {
+      "id": "llamax3-8b-alpaca",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llamax3 8B Alpaca"
+    },
+    {
+      "id": "llava-1.5",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llava 1.5"
+    },
+    {
+      "id": "llava-1.6-mistral",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llava 1.6 Mistral"
+    },
+    {
+      "id": "llava-1.6-vicuna",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llava 1.6 Vicuna"
+    },
+    {
+      "id": "llava-llama-3-8b-v1_1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llava Llama 3 8B V1_1"
+    },
+    {
+      "id": "llm-compiler-13b-ftd",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llm Compiler 13B Ftd"
+    },
+    {
+      "id": "llm-compiler-13b-imat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llm Compiler 13B Imat"
+    },
+    {
+      "id": "llm-compiler-7b-ftd-imat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llm Compiler 7B Ftd Imat"
+    },
+    {
+      "id": "llm-compiler-7b-imat-GGUF",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Llm Compiler 7B Imat Gguf"
+    },
+    {
+      "id": "LocalAI-llama3-8b-function-call-v0.2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Localai Llama3 8B Function Call V0.2"
+    },
+    {
+      "id": "loki-base-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Loki Base I1"
+    },
+    {
+      "id": "lumimaid-v0.2-12b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Lumimaid V0.2 12B"
+    },
+    {
+      "id": "lumimaid-v0.2-70b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Lumimaid V0.2 70B I1"
+    },
+    {
+      "id": "lumimaid-v0.2-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Lumimaid V0.2 8B"
+    },
+    {
+      "id": "magnum-32b-v1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Magnum 32B V1 I1"
+    },
+    {
+      "id": "magnum-72b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Magnum 72B V1"
+    },
+    {
+      "id": "magnum-v3-34b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Magnum V3 34B"
+    },
+    {
+      "id": "magnusintellectus-12b-v1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Magnusintellectus 12B V1 I1"
+    },
+    {
+      "id": "mahou-1.2-llama3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mahou 1.2 Llama3 8B"
+    },
+    {
+      "id": "mahou-1.3-llama3.1-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mahou 1.3 Llama3.1 8B"
+    },
+    {
+      "id": "mahou-1.3d-mistral-7b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mahou 1.3D Mistral 7B I1"
+    },
+    {
+      "id": "mahou-1.5-llama3.1-70b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mahou 1.5 Llama3.1 70B I1"
+    },
+    {
+      "id": "master-yi-9b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Master Yi 9B"
+    },
+    {
+      "id": "mathstral-7b-v0.1-imat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mathstral 7B V0.1 Imat"
+    },
+    {
+      "id": "meissa-qwen2.5-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meissa Qwen2.5 7B Instruct"
+    },
+    {
+      "id": "meta-llama-3-instruct-12.2b-brainstorm-20x-form-8",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3 Instruct 12.2B Brainstorm 20X Form 8"
+    },
+    {
+      "id": "meta-llama-3-instruct-8.9b-brainstorm-5x-form-11",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3 Instruct 8.9B Brainstorm 5X Form 11"
+    },
+    {
+      "id": "meta-llama-3.1-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3.1 70B Instruct"
+    },
+    {
+      "id": "meta-llama-3.1-8b-claude-imat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3.1 8B Claude Imat"
+    },
+    {
+      "id": "meta-llama-3.1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "meta-llama-3.1-8b-instruct-abliterated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3.1 8B Instruct Abliterated"
+    },
+    {
+      "id": "meta-llama-3.1-8b-instruct:grammar-functioncall",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3.1 8B Instruct:Grammar Functioncall"
+    },
+    {
+      "id": "meta-llama-3.1-8b-instruct:Q8_grammar-functioncall",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3.1 8B Instruct:Q8_Grammar Functioncall"
+    },
+    {
+      "id": "meta-llama-3.1-instruct-9.99b-brainstorm-10x-form-3",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Meta Llama 3.1 Instruct 9.99B Brainstorm 10X Form 3"
+    },
+    {
+      "id": "minicpm-llama3-v-2_5",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Minicpm Llama3 V 2_5"
+    },
+    {
+      "id": "mirai-nova-llama3-LocalAI-8b-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mirai Nova Llama3 Localai 8B V0.1"
+    },
+    {
+      "id": "mistral-7b-instruct-v0.3",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mistral 7B Instruct V0.3"
+    },
+    {
+      "id": "mistral-nemo-instruct-2407",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mistral Nemo Instruct 2407"
+    },
+    {
+      "id": "ml-ms-etheris-123b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Ml Ms Etheris 123B"
+    },
+    {
+      "id": "mn-12b-celeste-v1.9",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mn 12B Celeste V1.9"
+    },
+    {
+      "id": "mn-12b-lyra-v4-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mn 12B Lyra V4 Iq Imatrix"
+    },
+    {
+      "id": "mn-backyardai-party-12b-v1-iq-arm-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mn Backyardai Party 12B V1 Iq Arm Imatrix"
+    },
+    {
+      "id": "mn-lulanum-12b-fix-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Mn Lulanum 12B Fix I1"
+    },
+    {
+      "id": "moe-girl-1ba-7bt-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Moe Girl 1Ba 7Bt I1"
+    },
+    {
+      "id": "moondream2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Moondream2"
+    },
+    {
+      "id": "neural-sovlish-devil-8b-l3-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Neural Sovlish Devil 8B L3 Iq Imatrix"
+    },
+    {
+      "id": "neuraldaredevil-8b-abliterated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Neuraldaredevil 8B Abliterated"
+    },
+    {
+      "id": "new-dawn-llama-3-70b-32K-v1.0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "New Dawn Llama 3 70B 32K V1.0"
+    },
+    {
+      "id": "nightygurps-14b-v1.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Nightygurps 14B V1.1"
+    },
+    {
+      "id": "nihappy-l3.1-8b-v0.09",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Nihappy L3.1 8B V0.09"
+    },
+    {
+      "id": "noromaid-13b-0.4-DPO",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Noromaid 13B 0.4 Dpo"
+    },
+    {
+      "id": "nymph_8b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Nymph_8B I1"
+    },
+    {
+      "id": "nyun-llama3-62b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Nyun Llama3 62B"
+    },
+    {
+      "id": "openbiollm-llama3-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openbiollm Llama3 8B"
+    },
+    {
+      "id": "openbuddy-llama3.1-8b-v22.1-131k",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openbuddy Llama3.1 8B V22.1 131K"
+    },
+    {
+      "id": "openvino-all-MiniLM-L6-v2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openvino All Minilm L6 V2"
+    },
+    {
+      "id": "openvino-hermes2pro-llama3",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openvino Hermes2Pro Llama3"
+    },
+    {
+      "id": "openvino-llama-3-8b-instruct-ov-int8",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openvino Llama 3 8B Instruct Ov Int8"
+    },
+    {
+      "id": "openvino-llama3-aloe",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openvino Llama3 Aloe"
+    },
+    {
+      "id": "openvino-multilingual-e5-base",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openvino Multilingual E5 Base"
+    },
+    {
+      "id": "openvino-phi3",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openvino Phi3"
+    },
+    {
+      "id": "openvino-starling-lm-7b-beta-openvino-int8",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openvino Starling Lm 7B Beta Openvino Int8"
+    },
+    {
+      "id": "openvino-wizardlm2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Openvino Wizardlm2"
+    },
+    {
+      "id": "orthocopter_8b-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Orthocopter_8B Imatrix"
+    },
+    {
+      "id": "pantheon-rp-1.6-12b-nemo",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Pantheon Rp 1.6 12B Nemo"
+    },
+    {
+      "id": "parler-tts-mini-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Parler Tts Mini V0.1"
+    },
+    {
+      "id": "phi-2-chat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 2 Chat"
+    },
+    {
+      "id": "phi-2-chat:Q8_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 2 Chat:Q8_0"
+    },
+    {
+      "id": "phi-2-orange",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 2 Orange"
+    },
+    {
+      "id": "phi-3-medium-4k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 3 Medium 4K Instruct"
+    },
+    {
+      "id": "phi-3-mini-4k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 3 Mini 4K Instruct"
+    },
+    {
+      "id": "phi-3-mini-4k-instruct:fp16",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 3 Mini 4K Instruct:Fp16"
+    },
+    {
+      "id": "phi-3-vision:vllm",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 3 Vision:Vllm"
+    },
+    {
+      "id": "phi-3.1-mini-4k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 3.1 Mini 4K Instruct"
+    },
+    {
+      "id": "phi-3.5-mini-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 3.5 Mini Instruct"
+    },
+    {
+      "id": "phi-3.5-mini-titanfusion-0.2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 3.5 Mini Titanfusion 0.2"
+    },
+    {
+      "id": "phi-3.5-vision:vllm",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi 3.5 Vision:Vllm"
+    },
+    {
+      "id": "phi3-4x4b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phi3 4X4B V1"
+    },
+    {
+      "id": "phillama-3.8b-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Phillama 3.8B V0.1"
+    },
+    {
+      "id": "poppy_porpoise-v0.72-l3-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Poppy_Porpoise V0.72 L3 8B Iq Imatrix"
+    },
+    {
+      "id": "poppy_porpoise-v0.85-l3-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Poppy_Porpoise V0.85 L3 8B Iq Imatrix"
+    },
+    {
+      "id": "poppy_porpoise-v1.0-l3-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Poppy_Porpoise V1.0 L3 8B Iq Imatrix"
+    },
+    {
+      "id": "poppy_porpoise-v1.30-l3-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Poppy_Porpoise V1.30 L3 8B Iq Imatrix"
+    },
+    {
+      "id": "poppy_porpoise-v1.4-l3-8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Poppy_Porpoise V1.4 L3 8B Iq Imatrix"
+    },
+    {
+      "id": "qevacot-7b-v2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qevacot 7B V2"
+    },
+    {
+      "id": "qwen2-1.5b-ita",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2 1.5B Ita"
+    },
+    {
+      "id": "qwen2-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2 7B Instruct"
+    },
+    {
+      "id": "qwen2-7b-instruct-v0.8",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2 7B Instruct V0.8"
+    },
+    {
+      "id": "qwen2-wukong-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2 Wukong 7B"
+    },
+    {
+      "id": "qwen2.5-0.5b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 0.5B Instruct"
+    },
+    {
+      "id": "qwen2.5-1.5b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 1.5B Instruct"
+    },
+    {
+      "id": "qwen2.5-14b_uncencored",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 14B_Uncencored"
+    },
+    {
+      "id": "qwen2.5-14b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 14B Instruct"
+    },
+    {
+      "id": "qwen2.5-32b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 32B"
+    },
+    {
+      "id": "qwen2.5-32b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 32B Instruct"
+    },
+    {
+      "id": "qwen2.5-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 72B Instruct"
+    },
+    {
+      "id": "qwen2.5-7b-ins-v3",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 7B Ins V3"
+    },
+    {
+      "id": "qwen2.5-coder-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 Coder 7B Instruct"
+    },
+    {
+      "id": "qwen2.5-math-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 Math 72B Instruct"
+    },
+    {
+      "id": "qwen2.5-math-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Qwen2.5 Math 7B Instruct"
+    },
+    {
+      "id": "rawr_llama3_8b-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Rawr_Llama3_8B Iq Imatrix"
+    },
+    {
+      "id": "reflection-llama-3.1-70b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Reflection Llama 3.1 70B"
+    },
+    {
+      "id": "replete-coder-instruct-8b-merged",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Replete Coder Instruct 8B Merged"
+    },
+    {
+      "id": "replete-llm-v2.5-qwen-14b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Replete Llm V2.5 Qwen 14B"
+    },
+    {
+      "id": "replete-llm-v2.5-qwen-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Replete Llm V2.5 Qwen 7B"
+    },
+    {
+      "id": "rocinante-12b-v1.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Rocinante 12B V1.1"
+    },
+    {
+      "id": "rombos-llm-v2.5.1-qwen-3b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Rombos Llm V2.5.1 Qwen 3B"
+    },
+    {
+      "id": "salamandra-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Salamandra 7B Instruct"
+    },
+    {
+      "id": "samantha-qwen-2-7B",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Samantha Qwen 2 7B"
+    },
+    {
+      "id": "seeker-9b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Seeker 9B"
+    },
+    {
+      "id": "sekhmet_aleph-l3.1-8b-v0.1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Sekhmet_Aleph L3.1 8B V0.1 I1"
+    },
+    {
+      "id": "sfr-iterative-dpo-llama-3-8b-r",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Sfr Iterative Dpo Llama 3 8B R"
+    },
+    {
+      "id": "shieldgemma-9b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Shieldgemma 9B I1"
+    },
+    {
+      "id": "smegmma-9b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Smegmma 9B V1"
+    },
+    {
+      "id": "smegmma-deluxe-9b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Smegmma Deluxe 9B V1"
+    },
+    {
+      "id": "smollm-1.7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Smollm 1.7B Instruct"
+    },
+    {
+      "id": "sovl_llama3_8b-gguf-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Sovl_Llama3_8B Gguf Iq Imatrix"
+    },
+    {
+      "id": "stable-diffusion-3-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Stable Diffusion 3 Medium"
+    },
+    {
+      "id": "stablediffusion-cpp",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Stablediffusion Cpp"
+    },
+    {
+      "id": "stellardong-72b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Stellardong 72B I1"
+    },
+    {
+      "id": "sunfall-simpo-9b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Sunfall Simpo 9B"
+    },
+    {
+      "id": "sunfall-simpo-9b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Sunfall Simpo 9B I1"
+    },
+    {
+      "id": "supernova-medius",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Supernova Medius"
+    },
+    {
+      "id": "suzume-llama-3-8B-multilingual",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Suzume Llama 3 8B Multilingual"
+    },
+    {
+      "id": "suzume-llama-3-8b-multilingual-orpo-borda-top25",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Suzume Llama 3 8B Multilingual Orpo Borda Top25"
+    },
+    {
+      "id": "t.e-8.1-iq-imatrix-request",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "T.E 8.1 Iq Imatrix Request"
+    },
+    {
+      "id": "tarnished-9b-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tarnished 9B I1"
+    },
+    {
+      "id": "tess-2.0-llama-3-8B",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tess 2.0 Llama 3 8B"
+    },
+    {
+      "id": "tess-v2.5-gemma-2-27b-alpha",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tess V2.5 Gemma 2 27B Alpha"
+    },
+    {
+      "id": "tess-v2.5-phi-3-medium-128k-14b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tess V2.5 Phi 3 Medium 128K 14B"
+    },
+    {
+      "id": "theia-llama-3.1-8b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Theia Llama 3.1 8B V1"
+    },
+    {
+      "id": "therapyllama-8b-v1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Therapyllama 8B V1"
+    },
+    {
+      "id": "tiamat-8b-1.2-llama-3-dpo",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tiamat 8B 1.2 Llama 3 Dpo"
+    },
+    {
+      "id": "tifa-7b-qwen2-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tifa 7B Qwen2 V0.1"
+    },
+    {
+      "id": "tiger-gemma-9b-v1-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tiger Gemma 9B V1 I1"
+    },
+    {
+      "id": "tor-8b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tor 8B"
+    },
+    {
+      "id": "tsunami-0.5x-7b-instruct-i1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Tsunami 0.5X 7B Instruct I1"
+    },
+    {
+      "id": "una-thepitbull-21.4b-v2",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Una Thepitbull 21.4B V2"
+    },
+    {
+      "id": "versatillama-llama-3.2-3b-instruct-abliterated",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Versatillama Llama 3.2 3B Instruct Abliterated"
+    },
+    {
+      "id": "violet_twilight-v0.2-iq-imatrix",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Violet_Twilight V0.2 Iq Imatrix"
+    },
+    {
+      "id": "voice-ca-upc_ona-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Ca Upc_Ona X Low"
+    },
+    {
+      "id": "voice-ca-upc_pau-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Ca Upc_Pau X Low"
+    },
+    {
+      "id": "voice-da-nst_talesyntese-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Da Nst_Talesyntese Medium"
+    },
+    {
+      "id": "voice-de-eva_k-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice De Eva_K X Low"
+    },
+    {
+      "id": "voice-de-karlsson-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice De Karlsson Low"
+    },
+    {
+      "id": "voice-de-kerstin-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice De Kerstin Low"
+    },
+    {
+      "id": "voice-de-pavoque-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice De Pavoque Low"
+    },
+    {
+      "id": "voice-de-ramona-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice De Ramona Low"
+    },
+    {
+      "id": "voice-de-thorsten-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice De Thorsten Low"
+    },
+    {
+      "id": "voice-el-gr-rapunzelina-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice El Gr Rapunzelina Low"
+    },
+    {
+      "id": "voice-en-gb-alan-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Gb Alan Low"
+    },
+    {
+      "id": "voice-en-gb-southern_english_female-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Gb Southern_English_Female Low"
+    },
+    {
+      "id": "voice-en-us_lessac",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us_Lessac"
+    },
+    {
+      "id": "voice-en-us-amy-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Amy Low"
+    },
+    {
+      "id": "voice-en-us-danny-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Danny Low"
+    },
+    {
+      "id": "voice-en-us-kathleen-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Kathleen Low"
+    },
+    {
+      "id": "voice-en-us-kathleen-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Kathleen Low"
+    },
+    {
+      "id": "voice-en-us-lessac-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Lessac Low"
+    },
+    {
+      "id": "voice-en-us-lessac-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Lessac Medium"
+    },
+    {
+      "id": "voice-en-us-libritts-high",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Libritts High"
+    },
+    {
+      "id": "voice-en-us-ryan-high",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Ryan High"
+    },
+    {
+      "id": "voice-en-us-ryan-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Ryan Low"
+    },
+    {
+      "id": "voice-en-us-ryan-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice En Us Ryan Medium"
+    },
+    {
+      "id": "voice-es-carlfm-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Es Carlfm X Low"
+    },
+    {
+      "id": "voice-es-mls_10246-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Es Mls_10246 Low"
+    },
+    {
+      "id": "voice-es-mls_9972-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Es Mls_9972 Low"
+    },
+    {
+      "id": "voice-fi-harri-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Fi Harri Low"
+    },
+    {
+      "id": "voice-fr-gilles-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Fr Gilles Low"
+    },
+    {
+      "id": "voice-fr-mls_1840-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Fr Mls_1840 Low"
+    },
+    {
+      "id": "voice-fr-siwis-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Fr Siwis Low"
+    },
+    {
+      "id": "voice-fr-siwis-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Fr Siwis Medium"
+    },
+    {
+      "id": "voice-is-bui-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Is Bui Medium"
+    },
+    {
+      "id": "voice-is-salka-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Is Salka Medium"
+    },
+    {
+      "id": "voice-is-steinn-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Is Steinn Medium"
+    },
+    {
+      "id": "voice-is-ugla-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Is Ugla Medium"
+    },
+    {
+      "id": "voice-it-paola-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice It Paola Medium"
+    },
+    {
+      "id": "voice-it-riccardo_fasol-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice It Riccardo_Fasol X Low"
+    },
+    {
+      "id": "voice-kk-iseke-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Kk Iseke X Low"
+    },
+    {
+      "id": "voice-kk-issai-high",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Kk Issai High"
+    },
+    {
+      "id": "voice-kk-raya-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Kk Raya X Low"
+    },
+    {
+      "id": "voice-ne-google-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Ne Google Medium"
+    },
+    {
+      "id": "voice-ne-google-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Ne Google X Low"
+    },
+    {
+      "id": "voice-nl-mls_5809-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Nl Mls_5809 Low"
+    },
+    {
+      "id": "voice-nl-mls_7432-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Nl Mls_7432 Low"
+    },
+    {
+      "id": "voice-nl-nathalie-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Nl Nathalie X Low"
+    },
+    {
+      "id": "voice-nl-rdh-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Nl Rdh Medium"
+    },
+    {
+      "id": "voice-nl-rdh-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Nl Rdh X Low"
+    },
+    {
+      "id": "voice-no-talesyntese-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice No Talesyntese Medium"
+    },
+    {
+      "id": "voice-pl-mls_6892-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Pl Mls_6892 Low"
+    },
+    {
+      "id": "voice-pt-br-edresson-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Pt Br Edresson Low"
+    },
+    {
+      "id": "voice-ru-irinia-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Ru Irinia Medium"
+    },
+    {
+      "id": "voice-sv-se-nst-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Sv Se Nst Medium"
+    },
+    {
+      "id": "voice-uk-lada-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Uk Lada X Low"
+    },
+    {
+      "id": "voice-vi-25hours-single-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Vi 25Hours Single Low"
+    },
+    {
+      "id": "voice-vi-vivos-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Vi Vivos X Low"
+    },
+    {
+      "id": "voice-zh_CN-huayan-medium",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Zh_Cn Huayan Medium"
+    },
+    {
+      "id": "voice-zh-cn-huayan-x-low",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Voice Zh Cn Huayan X Low"
+    },
+    {
+      "id": "whisper-1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper 1"
+    },
+    {
+      "id": "whisper-base",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Base"
+    },
+    {
+      "id": "whisper-base-en",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Base En"
+    },
+    {
+      "id": "whisper-base-en-q5_1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Base En Q5_1"
+    },
+    {
+      "id": "whisper-base-q5_1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Base Q5_1"
+    },
+    {
+      "id": "whisper-large-q5_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Large Q5_0"
+    },
+    {
+      "id": "whisper-medium-q5_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Medium Q5_0"
+    },
+    {
+      "id": "whisper-small",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Small"
+    },
+    {
+      "id": "whisper-small",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Small"
+    },
+    {
+      "id": "whisper-small-en-q5_1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Small En Q5_1"
+    },
+    {
+      "id": "whisper-small-q5_1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Small Q5_1"
+    },
+    {
+      "id": "whisper-small-q5_1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Small Q5_1"
+    },
+    {
+      "id": "whisper-tiny",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Tiny"
+    },
+    {
+      "id": "whisper-tiny-en",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Tiny En"
+    },
+    {
+      "id": "whisper-tiny-en-q5_1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Tiny En Q5_1"
+    },
+    {
+      "id": "whisper-tiny-en-q8_0",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Tiny En Q8_0"
+    },
+    {
+      "id": "whisper-tiny-q5_1",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Whisper Tiny Q5_1"
+    },
+    {
+      "id": "wizardlm2-7b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Wizardlm2 7B"
+    },
+    {
+      "id": "yi-1.5-6b-chat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Yi 1.5 6B Chat"
+    },
+    {
+      "id": "yi-1.5-9b-chat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Yi 1.5 9B Chat"
+    },
+    {
+      "id": "yi-coder-1.5b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Yi Coder 1.5B"
+    },
+    {
+      "id": "yi-coder-1.5b-chat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Yi Coder 1.5B Chat"
+    },
+    {
+      "id": "yi-coder-9b",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Yi Coder 9B"
+    },
+    {
+      "id": "yi-coder-9b-chat",
+      "object": "model",
+      "provider": {
+        "id": "local-ai"
+      },
+      "name": "Yi Coder 9B Chat"
+    },
+    {
+      "id": "ministral-3b-latest",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Ministral 3B"
+    },
+    {
+      "id": "ministral-8b-latest",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Ministral 8B"
+    },
+    {
+      "id": "mistral-large-latest",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Mistral Large"
+    },
+    {
+      "id": "mistral-small-latest",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Mistral Small"
+    },
+    {
+      "id": "codestral-latest",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Codestral"
+    },
+    {
+      "id": "mistral-embed",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Mistral Embed"
+    },
+    {
+      "id": "pixtral-12b-2409",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Pixtral"
+    },
+    {
+      "id": "open-mistral-nemo",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Mistral Nemo"
+    },
+    {
+      "id": "open-codestral-mamba",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Codestral Mamba"
+    },
+    {
+      "id": "open-mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Mistral 7B"
+    },
+    {
+      "id": "google/gemma-2-9b-it",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Gemma 2 9B It"
+    },
+    {
+      "id": "img2img",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Img2Img"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3.1-8B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Meta Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "microsoft/Phi-3-mini-4k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Phi 3 Mini 4K Instruct"
+    },
+    {
+      "id": "mistralai/Mistral-7B-Instruct-v0.2",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Mistral 7B Instruct V0.2"
+    },
+    {
+      "id": "photo-maker",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Photo Maker"
+    },
+    {
+      "id": "pix2pix",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Pix2Pix"
+    },
+    {
+      "id": "sdxl-base",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Sdxl Base"
+    },
+    {
+      "id": "speech2text",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Speech2Text"
+    },
+    {
+      "id": "speech2text-v2",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Speech2Text V2"
+    },
+    {
+      "id": "sunoai-bark",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Sunoai Bark"
+    },
+    {
+      "id": "txt2img",
+      "object": "model",
+      "provider": {
+        "id": "monsterapi"
+      },
+      "name": "Txt2Img"
+    },
+    {
+      "id": "cognitivecomputations/dolphin-mixtral-8x22b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Dolphin Mixtral 8x22B"
+    },
+    {
+      "id": "google/gemma-2-9b-it",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Gemma 2 9B IT"
+    },
+    {
+      "id": "google/gemma-2-9b-it",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Gemma 2 9B IT"
+    },
+    {
+      "id": "gryphe/mythomax-l2-13b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "MythoMax L2 13B"
+    },
+    {
+      "id": "gryphe/mythomax-l2-13b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "MythoMax L2 13B"
+    },
+    {
+      "id": "jondurbin/airoboros-l2-70b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Airoboros L2 70B"
+    },
+    {
+      "id": "lzlv_70b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "LZLV 70B"
+    },
+    {
+      "id": "meta-llama/llama-3-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Llama 3 70B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Llama 3 8B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.1-405b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Llama 3.1 405B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.1-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Llama 3.1 70B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "microsoft/wizardlm-2-7b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "WizardLM 2 7B"
+    },
+    {
+      "id": "microsoft/wizardlm-2-8x22b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "WizardLM 2 8x22B"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Mistral 7B Instruct"
+    },
+    {
+      "id": "mistralai/mistral-nemo",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Mistral Nemo"
+    },
+    {
+      "id": "nousresearch/hermes-2-pro-llama-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Hermes 2 Pro Llama 3 8B"
+    },
+    {
+      "id": "nousresearch/meta-llama-3.1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Meta Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "nousresearch/nous-hermes-llama2-13b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Nous Hermes Llama 2 13B"
+    },
+    {
+      "id": "openchat/openchat-7b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "OpenChat 7B"
+    },
+    {
+      "id": "qwen/qwen-2-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Qwen 2 72B Instruct"
+    },
+    {
+      "id": "qwen/qwen-2-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Qwen 2 7B Instruct"
+    },
+    {
+      "id": "sao10k/l3-70b-euryale-v2.1",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "L3 70B Euryale v2.1"
+    },
+    {
+      "id": "sao10k/l31-70b-euryale-v2.2",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "L31 70B Euryale v2.2"
+    },
+    {
+      "id": "sophosympatheia/midnight-rose-70b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "Midnight Rose 70B"
+    },
+    {
+      "id": "teknium/openhermes-2.5-mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "novita-ai"
+      },
+      "name": "OpenHermes 2.5 Mistral 7B"
+    },
+    {
+      "id": "alfred",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Alfred"
+    },
+    {
+      "id": "all-minilm",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "All Minilm"
+    },
+    {
+      "id": "aya",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Aya"
+    },
+    {
+      "id": "bakllava",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Bakllava"
+    },
+    {
+      "id": "bespoke-minicheck",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Bespoke Minicheck"
+    },
+    {
+      "id": "bge-large",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Bge Large"
+    },
+    {
+      "id": "bge-m3",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Bge M3"
+    },
+    {
+      "id": "codebooga",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Codebooga"
+    },
+    {
+      "id": "codegeex4",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Codegeex4"
+    },
+    {
+      "id": "codegemma",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Codegemma"
+    },
+    {
+      "id": "codellama",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Codellama"
+    },
+    {
+      "id": "codeqwen",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Codeqwen"
+    },
+    {
+      "id": "codestral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Codestral"
+    },
+    {
+      "id": "codeup",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Codeup"
+    },
+    {
+      "id": "command-r",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Command R"
+    },
+    {
+      "id": "command-r-plus",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Command R Plus"
+    },
+    {
+      "id": "dbrx",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Dbrx"
+    },
+    {
+      "id": "deepseek-coder",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Deepseek Coder"
+    },
+    {
+      "id": "deepseek-coder-v2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Deepseek Coder V2"
+    },
+    {
+      "id": "deepseek-llm",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Deepseek Llm"
+    },
+    {
+      "id": "deepseek-v2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Deepseek V2"
+    },
+    {
+      "id": "deepseek-v2.5",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Deepseek V2.5"
+    },
+    {
+      "id": "dolphin-llama3",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Dolphin Llama3"
+    },
+    {
+      "id": "dolphin-mistral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Dolphin Mistral"
+    },
+    {
+      "id": "dolphin-mixtral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Dolphin Mixtral"
+    },
+    {
+      "id": "dolphin-phi",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Dolphin Phi"
+    },
+    {
+      "id": "dolphincoder",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Dolphincoder"
+    },
+    {
+      "id": "duckdb-nsql",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Duckdb Nsql"
+    },
+    {
+      "id": "everythinglm",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Everythinglm"
+    },
+    {
+      "id": "falcon",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Falcon"
+    },
+    {
+      "id": "falcon2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Falcon2"
+    },
+    {
+      "id": "firefunction-v2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Firefunction V2"
+    },
+    {
+      "id": "gemma",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Gemma"
+    },
+    {
+      "id": "gemma2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Gemma2"
+    },
+    {
+      "id": "glm4",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Glm4"
+    },
+    {
+      "id": "goliath",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Goliath"
+    },
+    {
+      "id": "granite-code",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Granite Code"
+    },
+    {
+      "id": "granite3-dense",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Granite3 Dense"
+    },
+    {
+      "id": "granite3-moe",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Granite3 Moe"
+    },
+    {
+      "id": "hermes3",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Hermes3"
+    },
+    {
+      "id": "internlm2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Internlm2"
+    },
+    {
+      "id": "llama-guard3",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama Guard3"
+    },
+    {
+      "id": "llama-pro",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama Pro"
+    },
+    {
+      "id": "llama2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama2"
+    },
+    {
+      "id": "llama2-chinese",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama2 Chinese"
+    },
+    {
+      "id": "llama2-uncensored",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama2 Uncensored"
+    },
+    {
+      "id": "llama3",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama3"
+    },
+    {
+      "id": "llama3-chatqa",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama3 Chatqa"
+    },
+    {
+      "id": "llama3-gradient",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama3 Gradient"
+    },
+    {
+      "id": "llama3-groq-tool-use",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama3 Groq Tool Use"
+    },
+    {
+      "id": "llama3.1",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama3.1"
+    },
+    {
+      "id": "llama3.2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llama3.2"
+    },
+    {
+      "id": "llava",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llava"
+    },
+    {
+      "id": "llava-llama3",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llava Llama3"
+    },
+    {
+      "id": "llava-phi3",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Llava Phi3"
+    },
+    {
+      "id": "magicoder",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Magicoder"
+    },
+    {
+      "id": "mathstral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mathstral"
+    },
+    {
+      "id": "meditron",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Meditron"
+    },
+    {
+      "id": "medllama2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Medllama2"
+    },
+    {
+      "id": "megadolphin",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Megadolphin"
+    },
+    {
+      "id": "minicpm-v",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Minicpm V"
+    },
+    {
+      "id": "mistral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mistral"
+    },
+    {
+      "id": "mistral-large",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mistral Large"
+    },
+    {
+      "id": "mistral-nemo",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mistral Nemo"
+    },
+    {
+      "id": "mistral-openorca",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mistral Openorca"
+    },
+    {
+      "id": "mistral-small",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mistral Small"
+    },
+    {
+      "id": "mistrallite",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mistrallite"
+    },
+    {
+      "id": "mixtral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mixtral"
+    },
+    {
+      "id": "moondream",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Moondream"
+    },
+    {
+      "id": "mxbai-embed-large",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Mxbai Embed Large"
+    },
+    {
+      "id": "nemotron",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Nemotron"
+    },
+    {
+      "id": "nemotron-mini",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Nemotron Mini"
+    },
+    {
+      "id": "neural-chat",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Neural Chat"
+    },
+    {
+      "id": "nexusraven",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Nexusraven"
+    },
+    {
+      "id": "nomic-embed-text",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Nomic Embed Text"
+    },
+    {
+      "id": "notus",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Notus"
+    },
+    {
+      "id": "notux",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Notux"
+    },
+    {
+      "id": "nous-hermes",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Nous Hermes"
+    },
+    {
+      "id": "nous-hermes2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Nous Hermes2"
+    },
+    {
+      "id": "nous-hermes2-mixtral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Nous Hermes2 Mixtral"
+    },
+    {
+      "id": "nuextract",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Nuextract"
+    },
+    {
+      "id": "open-orca-platypus2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Open Orca Platypus2"
+    },
+    {
+      "id": "openchat",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Openchat"
+    },
+    {
+      "id": "openhermes",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Openhermes"
+    },
+    {
+      "id": "orca-mini",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Orca Mini"
+    },
+    {
+      "id": "orca2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Orca2"
+    },
+    {
+      "id": "paraphrase-multilingual",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Paraphrase Multilingual"
+    },
+    {
+      "id": "phi",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Phi"
+    },
+    {
+      "id": "phi3",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Phi3"
+    },
+    {
+      "id": "phi3.5",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Phi3.5"
+    },
+    {
+      "id": "phind-codellama",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Phind Codellama"
+    },
+    {
+      "id": "qwen",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Qwen"
+    },
+    {
+      "id": "qwen2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Qwen2"
+    },
+    {
+      "id": "qwen2-math",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Qwen2 Math"
+    },
+    {
+      "id": "qwen2.5",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Qwen2.5"
+    },
+    {
+      "id": "qwen2.5-coder",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Qwen2.5 Coder"
+    },
+    {
+      "id": "reader-lm",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Reader Lm"
+    },
+    {
+      "id": "reflection",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Reflection"
+    },
+    {
+      "id": "samantha-mistral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Samantha Mistral"
+    },
+    {
+      "id": "shieldgemma",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Shieldgemma"
+    },
+    {
+      "id": "smollm",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Smollm"
+    },
+    {
+      "id": "snowflake-arctic-embed",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Snowflake Arctic Embed"
+    },
+    {
+      "id": "solar",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Solar"
+    },
+    {
+      "id": "solar-pro",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Solar Pro"
+    },
+    {
+      "id": "sqlcoder",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Sqlcoder"
+    },
+    {
+      "id": "stable-beluga",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Stable Beluga"
+    },
+    {
+      "id": "stable-code",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Stable Code"
+    },
+    {
+      "id": "stablelm-zephyr",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Stablelm Zephyr"
+    },
+    {
+      "id": "stablelm2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Stablelm2"
+    },
+    {
+      "id": "starcoder",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Starcoder"
+    },
+    {
+      "id": "starcoder2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Starcoder2"
+    },
+    {
+      "id": "starling-lm",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Starling Lm"
+    },
+    {
+      "id": "tinydolphin",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Tinydolphin"
+    },
+    {
+      "id": "tinyllama",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Tinyllama"
+    },
+    {
+      "id": "vicuna",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Vicuna"
+    },
+    {
+      "id": "wizard-math",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Wizard Math"
+    },
+    {
+      "id": "wizard-vicuna",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Wizard Vicuna"
+    },
+    {
+      "id": "wizard-vicuna-uncensored",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Wizard Vicuna Uncensored"
+    },
+    {
+      "id": "wizardcoder",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Wizardcoder"
+    },
+    {
+      "id": "wizardlm",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Wizardlm"
+    },
+    {
+      "id": "wizardlm-uncensored",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Wizardlm Uncensored"
+    },
+    {
+      "id": "wizardlm2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Wizardlm2"
+    },
+    {
+      "id": "xwinlm",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Xwinlm"
+    },
+    {
+      "id": "yarn-llama2",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Yarn Llama2"
+    },
+    {
+      "id": "yarn-mistral",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Yarn Mistral"
+    },
+    {
+      "id": "yi",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Yi"
+    },
+    {
+      "id": "yi-coder",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Yi Coder"
+    },
+    {
+      "id": "zephyr",
+      "object": "model",
+      "provider": {
+        "id": "ollama"
+      },
+      "name": "Zephyr"
+    },
+    {
+      "id": "babbage-002",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Babbage 002"
+    },
+    {
+      "id": "chatgpt-4o-latest",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Chatgpt 4o Latest"
+    },
+    {
+      "id": "dall-e-2",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Dall-E 2"
+    },
+    {
+      "id": "dall-e-3",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Dall-E 3"
+    },
+    {
+      "id": "davinci-002",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Davinci 002"
+    },
+    {
+      "id": "gpt-3.5-turbo",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 3.5 Turbo"
+    },
+    {
+      "id": "gpt-3.5-turbo-0125",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 3.5 Turbo 0125"
+    },
+    {
+      "id": "gpt-3.5-turbo-1106",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 3.5 Turbo 1106"
+    },
+    {
+      "id": "gpt-3.5-turbo-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 3.5 Turbo Instruct"
+    },
+    {
+      "id": "gpt-4",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4"
+    },
+    {
+      "id": "gpt-4-0125-preview",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4 0125 Preview"
+    },
+    {
+      "id": "gpt-4-0314",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4 0314"
+    },
+    {
+      "id": "gpt-4-0613",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4 0613"
+    },
+    {
+      "id": "gpt-4-1106-preview",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4 1106 Preview"
+    },
+    {
+      "id": "gpt-4-turbo",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4 Turbo"
+    },
+    {
+      "id": "gpt-4-turbo-2024-04-09",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4 Turbo 2024 04 09"
+    },
+    {
+      "id": "gpt-4-turbo-preview",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4 Turbo Preview"
+    },
+    {
+      "id": "gpt-4o",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT 4o"
+    },
+    {
+      "id": "gpt-4o-2024-05-13",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT-4o 2024 05 13"
+    },
+    {
+      "id": "gpt-4o-2024-08-06",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT-4o 2024 08 06"
+    },
+    {
+      "id": "gpt-4o-audio-preview",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT-4o Audio Preview"
+    },
+    {
+      "id": "gpt-4o-audio-preview-2024-10-01",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT-4o Audio Preview 2024 10 01"
+    },
+    {
+      "id": "gpt-4o-mini",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT-4o Mini"
+    },
+    {
+      "id": "gpt-4o-mini-2024-07-18",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT-4o Mini 2024 07 18"
+    },
+    {
+      "id": "gpt-4o-realtime-preview",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT-4o Realtime Preview"
+    },
+    {
+      "id": "gpt-4o-realtime-preview-2024-10-01",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "GPT-4o Realtime Preview 2024 10 01"
+    },
+    {
+      "id": "hd/1024-x-1024/dall-e-3",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "HD/1024 X 1024/Dall-E 3"
+    },
+    {
+      "id": "o1-mini",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "O1 Mini"
+    },
+    {
+      "id": "o1-mini-2024-09-12",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "O1 Mini 2024-09-12"
+    },
+    {
+      "id": "o1-preview",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "O1 Preview"
+    },
+    {
+      "id": "o1-preview-2024-09-12",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "O1 Preview 2024-09-12"
+    },
+    {
+      "id": "omni-moderation-2024-09-26",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Omni Moderation 2024-09-26"
+    },
+    {
+      "id": "omni-moderation-latest",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Omni Moderation Latest"
+    },
+    {
+      "id": "standard/1024-x-1024/dall-e-3",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Standard/1024 X 1024/Dall-E 3"
+    },
+    {
+      "id": "standard/1024-x-1792/dall-e-3",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Standard/1024 X 1792/Dall-E 3"
+    },
+    {
+      "id": "standard/1792-x-1024/dall-e-3",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Standard/1792 X 1024/Dall-E 3"
+    },
+    {
+      "id": "text-embedding-3-large",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Text Embedding 3 Large"
+    },
+    {
+      "id": "text-embedding-3-small",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Text Embedding 3 Small"
+    },
+    {
+      "id": "text-embedding-ada-002",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Text Embedding Ada 002"
+    },
+    {
+      "id": "text-moderation-007",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Text Moderation 007"
+    },
+    {
+      "id": "text-moderation-latest",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Text Moderation Latest"
+    },
+    {
+      "id": "text-moderation-stable",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Text Moderation Stable"
+    },
+    {
+      "id": "tts-1",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Tts 1"
+    },
+    {
+      "id": "tts-1",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Tts 1"
+    },
+    {
+      "id": "tts-1-hd",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Tts 1 Hd"
+    },
+    {
+      "id": "tts-1-hd",
+      "object": "model",
+      "provider": {
+        "id": "openai"
+      },
+      "name": "Tts 1 Hd"
+    },
+    {
+      "id": "aetherwiing/mn-starcannon-12b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral Nemo 12B Starcannon"
+    },
+    {
+      "id": "ai21/jamba-1-5-large",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "AI21: Jamba 1.5 Large"
+    },
+    {
+      "id": "ai21/jamba-1-5-mini",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "AI21: Jamba 1.5 Mini"
+    },
+    {
+      "id": "ai21/jamba-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "AI21: Jamba Instruct"
+    },
+    {
+      "id": "alpindale/goliath-120b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Goliath 120B"
+    },
+    {
+      "id": "alpindale/magnum-72b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Magnum 72B"
+    },
+    {
+      "id": "anthracite-org/magnum-v2-72b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Magnum v2 72B"
+    },
+    {
+      "id": "anthropic/claude-1",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude v1"
+    },
+    {
+      "id": "anthropic/claude-1.2",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude v1.2"
+    },
+    {
+      "id": "anthropic/claude-2",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude v2"
+    },
+    {
+      "id": "anthropic/claude-2:beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude v2 (self-moderated)"
+    },
+    {
+      "id": "anthropic/claude-2.0",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude v2.0"
+    },
+    {
+      "id": "anthropic/claude-2.0:beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude v2.0 (self-moderated)"
+    },
+    {
+      "id": "anthropic/claude-2.1",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude v2.1"
+    },
+    {
+      "id": "anthropic/claude-2.1:beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude v2.1 (self-moderated)"
+    },
+    {
+      "id": "anthropic/claude-3-haiku",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude 3 Haiku"
+    },
+    {
+      "id": "anthropic/claude-3-haiku:beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude 3 Haiku (self-moderated)"
+    },
+    {
+      "id": "anthropic/claude-3-opus",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude 3 Opus"
+    },
+    {
+      "id": "anthropic/claude-3-opus:beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude 3 Opus (self-moderated)"
+    },
+    {
+      "id": "anthropic/claude-3-sonnet",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude 3 Sonnet"
+    },
+    {
+      "id": "anthropic/claude-3-sonnet:beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude 3 Sonnet (self-moderated)"
+    },
+    {
+      "id": "anthropic/claude-3.5-sonnet",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude 3.5 Sonnet"
+    },
+    {
+      "id": "anthropic/claude-3.5-sonnet:beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude 3.5 Sonnet (self-moderated)"
+    },
+    {
+      "id": "anthropic/claude-instant-1",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude Instant v1"
+    },
+    {
+      "id": "anthropic/claude-instant-1:beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude Instant v1 (self-moderated)"
+    },
+    {
+      "id": "anthropic/claude-instant-1.0",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude Instant v1.0"
+    },
+    {
+      "id": "anthropic/claude-instant-1.1",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Anthropic: Claude Instant v1.1"
+    },
+    {
+      "id": "cognitivecomputations/dolphin-mixtral-8x22b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Dolphin 2.9.2 Mixtral 8x22B \ud83d\udc2c"
+    },
+    {
+      "id": "cognitivecomputations/dolphin-mixtral-8x7b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Dolphin 2.6 Mixtral 8x7B \ud83d\udc2c"
+    },
+    {
+      "id": "cohere/command",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Cohere: Command"
+    },
+    {
+      "id": "cohere/command-r",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Cohere: Command R"
+    },
+    {
+      "id": "cohere/command-r-03-2024",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Cohere: Command R (03-2024)"
+    },
+    {
+      "id": "cohere/command-r-08-2024",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Cohere: Command R (08-2024)"
+    },
+    {
+      "id": "cohere/command-r-plus",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Cohere: Command R+"
+    },
+    {
+      "id": "cohere/command-r-plus-04-2024",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Cohere: Command R+ (04-2024)"
+    },
+    {
+      "id": "cohere/command-r-plus-08-2024",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Cohere: Command R+ (08-2024)"
+    },
+    {
+      "id": "databricks/dbrx-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Databricks: DBRX 132B Instruct"
+    },
+    {
+      "id": "deepseek/deepseek-chat",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "DeepSeek V2.5"
+    },
+    {
+      "id": "eva-unit-01/eva-qwen-2.5-14b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "EVA Qwen2.5 14B"
+    },
+    {
+      "id": "google/gemini-flash-1.5",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemini Flash 1.5"
+    },
+    {
+      "id": "google/gemini-flash-1.5-8b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemini 1.5 Flash-8B"
+    },
+    {
+      "id": "google/gemini-flash-1.5-8b-exp",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemini Flash 8B 1.5 Experimental"
+    },
+    {
+      "id": "google/gemini-flash-1.5-exp",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemini Flash 1.5 Experimental"
+    },
+    {
+      "id": "google/gemini-pro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemini Pro 1.0"
+    },
+    {
+      "id": "google/gemini-pro-1.5",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemini Pro 1.5"
+    },
+    {
+      "id": "google/gemini-pro-1.5-exp",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemini Pro 1.5 Experimental"
+    },
+    {
+      "id": "google/gemini-pro-vision",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemini Pro Vision 1.0"
+    },
+    {
+      "id": "google/gemma-2-27b-it",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemma 2 27B"
+    },
+    {
+      "id": "google/gemma-2-9b-it",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemma 2 9B"
+    },
+    {
+      "id": "google/gemma-2-9b-it:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: Gemma 2 9B (free)"
+    },
+    {
+      "id": "google/palm-2-chat-bison",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: PaLM 2 Chat"
+    },
+    {
+      "id": "google/palm-2-chat-bison-32k",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: PaLM 2 Chat 32k"
+    },
+    {
+      "id": "google/palm-2-codechat-bison",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: PaLM 2 Code Chat"
+    },
+    {
+      "id": "google/palm-2-codechat-bison-32k",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Google: PaLM 2 Code Chat 32k"
+    },
+    {
+      "id": "gryphe/mythomax-l2-13b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "MythoMax 13B"
+    },
+    {
+      "id": "gryphe/mythomax-l2-13b:extended",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "MythoMax 13B (extended)"
+    },
+    {
+      "id": "gryphe/mythomax-l2-13b:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "MythoMax 13B (free)"
+    },
+    {
+      "id": "gryphe/mythomax-l2-13b:nitro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "MythoMax 13B (nitro)"
+    },
+    {
+      "id": "gryphe/mythomist-7b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "MythoMist 7B"
+    },
+    {
+      "id": "gryphe/mythomist-7b:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "MythoMist 7B (free)"
+    },
+    {
+      "id": "huggingfaceh4/zephyr-7b-beta:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Hugging Face: Zephyr 7B (free)"
+    },
+    {
+      "id": "inflection/inflection-3-pi",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Inflection: Inflection 3 Pi"
+    },
+    {
+      "id": "inflection/inflection-3-productivity",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Inflection: Inflection 3 Productivity"
+    },
+    {
+      "id": "jondurbin/airoboros-l2-70b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Airoboros 70B"
+    },
+    {
+      "id": "liquid/lfm-40b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Liquid: LFM 40B MoE"
+    },
+    {
+      "id": "liquid/lfm-40b:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Liquid: LFM 40B MoE (free)"
+    },
+    {
+      "id": "lizpreciatior/lzlv-70b-fp16-hf",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "lzlv 70B"
+    },
+    {
+      "id": "mancer/weaver",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mancer: Weaver (alpha)"
+    },
+    {
+      "id": "meta-llama/llama-2-13b-chat",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama v2 13B Chat"
+    },
+    {
+      "id": "meta-llama/llama-3-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3 70B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3-70b-instruct:nitro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3 70B Instruct (nitro)"
+    },
+    {
+      "id": "meta-llama/llama-3-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3 8B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3-8b-instruct:extended",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3 8B Instruct (extended)"
+    },
+    {
+      "id": "meta-llama/llama-3-8b-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3 8B Instruct (free)"
+    },
+    {
+      "id": "meta-llama/llama-3-8b-instruct:nitro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3 8B Instruct (nitro)"
+    },
+    {
+      "id": "meta-llama/llama-3.1-405b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 405B (base)"
+    },
+    {
+      "id": "meta-llama/llama-3.1-405b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 405B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.1-405b-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 405B Instruct (free)"
+    },
+    {
+      "id": "meta-llama/llama-3.1-405b-instruct:nitro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 405B Instruct (nitro)"
+    },
+    {
+      "id": "meta-llama/llama-3.1-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 70B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.1-70b-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 70B Instruct (free)"
+    },
+    {
+      "id": "meta-llama/llama-3.1-70b-instruct:nitro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 70B Instruct (nitro)"
+    },
+    {
+      "id": "meta-llama/llama-3.1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.1-8b-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.1 8B Instruct (free)"
+    },
+    {
+      "id": "meta-llama/llama-3.2-11b-vision-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.2 11B Vision Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.2-11b-vision-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.2 11B Vision Instruct (free)"
+    },
+    {
+      "id": "meta-llama/llama-3.2-1b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.2 1B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.2-1b-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.2 1B Instruct (free)"
+    },
+    {
+      "id": "meta-llama/llama-3.2-3b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.2 3B Instruct"
+    },
+    {
+      "id": "meta-llama/llama-3.2-3b-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.2 3B Instruct (free)"
+    },
+    {
+      "id": "meta-llama/llama-3.2-90b-vision-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: Llama 3.2 90B Vision Instruct"
+    },
+    {
+      "id": "meta-llama/llama-guard-2-8b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Meta: LlamaGuard 2 8B"
+    },
+    {
+      "id": "microsoft/phi-3-medium-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Phi-3 Medium 128K Instruct"
+    },
+    {
+      "id": "microsoft/phi-3-medium-128k-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Phi-3 Medium 128K Instruct (free)"
+    },
+    {
+      "id": "microsoft/phi-3-mini-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Phi-3 Mini 128K Instruct"
+    },
+    {
+      "id": "microsoft/phi-3-mini-128k-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Phi-3 Mini 128K Instruct (free)"
+    },
+    {
+      "id": "microsoft/phi-3.5-mini-128k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Phi-3.5 Mini 128K Instruct"
+    },
+    {
+      "id": "microsoft/wizardlm-2-7b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "WizardLM-2 7B"
+    },
+    {
+      "id": "microsoft/wizardlm-2-8x22b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "WizardLM-2 8x22B"
+    },
+    {
+      "id": "mistralai/codestral-mamba",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Codestral Mamba"
+    },
+    {
+      "id": "mistralai/ministral-3b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Ministral 3B"
+    },
+    {
+      "id": "mistralai/ministral-8b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Ministral 8B"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Mistral 7B Instruct"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Mistral 7B Instruct v0.1"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct-v0.2",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Mistral 7B Instruct v0.2"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct-v0.3",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Mistral 7B Instruct v0.3"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Mistral 7B Instruct (free)"
+    },
+    {
+      "id": "mistralai/mistral-7b-instruct:nitro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Mistral 7B Instruct (nitro)"
+    },
+    {
+      "id": "mistralai/mistral-large",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral Large"
+    },
+    {
+      "id": "mistralai/mistral-medium",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral Medium"
+    },
+    {
+      "id": "mistralai/mistral-nemo",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Mistral Nemo"
+    },
+    {
+      "id": "mistralai/mistral-small",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral Small"
+    },
+    {
+      "id": "mistralai/mistral-tiny",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral Tiny"
+    },
+    {
+      "id": "mistralai/mixtral-8x22b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Mixtral 8x22B Instruct"
+    },
+    {
+      "id": "mistralai/mixtral-8x7b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mixtral 8x7B (base)"
+    },
+    {
+      "id": "mistralai/mixtral-8x7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mixtral 8x7B Instruct"
+    },
+    {
+      "id": "mistralai/mixtral-8x7b-instruct:nitro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mixtral 8x7B Instruct (nitro)"
+    },
+    {
+      "id": "mistralai/pixtral-12b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral: Pixtral 12B"
+    },
+    {
+      "id": "neversleep/llama-3-lumimaid-70b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Llama 3 Lumimaid 70B"
+    },
+    {
+      "id": "neversleep/llama-3-lumimaid-8b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Llama 3 Lumimaid 8B"
+    },
+    {
+      "id": "neversleep/llama-3-lumimaid-8b:extended",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Llama 3 Lumimaid 8B (extended)"
+    },
+    {
+      "id": "neversleep/llama-3.1-lumimaid-8b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Lumimaid v0.2 8B"
+    },
+    {
+      "id": "neversleep/noromaid-20b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Noromaid 20B"
+    },
+    {
+      "id": "nothingiisreal/mn-celeste-12b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Mistral Nemo 12B Celeste"
+    },
+    {
+      "id": "nousresearch/hermes-2-pro-llama-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "NousResearch: Hermes 2 Pro - Llama-3 8B"
+    },
+    {
+      "id": "nousresearch/hermes-2-theta-llama-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Nous: Hermes 2 Theta 8B"
+    },
+    {
+      "id": "nousresearch/hermes-3-llama-3.1-405b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Nous: Hermes 3 405B Instruct"
+    },
+    {
+      "id": "nousresearch/hermes-3-llama-3.1-405b:extended",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Nous: Hermes 3 405B Instruct (extended)"
+    },
+    {
+      "id": "nousresearch/hermes-3-llama-3.1-405b:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Nous: Hermes 3 405B Instruct (free)"
+    },
+    {
+      "id": "nousresearch/hermes-3-llama-3.1-70b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Nous: Hermes 3 70B Instruct"
+    },
+    {
+      "id": "nousresearch/nous-hermes-2-mixtral-8x7b-dpo",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Nous: Hermes 2 Mixtral 8x7B DPO"
+    },
+    {
+      "id": "nousresearch/nous-hermes-llama2-13b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Nous: Hermes 13B"
+    },
+    {
+      "id": "nvidia/llama-3.1-nemotron-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "NVIDIA: Llama 3.1 Nemotron 70B Instruct"
+    },
+    {
+      "id": "openai/chatgpt-4o-latest",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: ChatGPT-4o"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-3.5 Turbo"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-0125",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-3.5 Turbo 16k"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-0613",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-3.5 Turbo (older v0613)"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-1106",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-3.5 Turbo 16k (older v1106)"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-16k",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-3.5 Turbo 16k"
+    },
+    {
+      "id": "openai/gpt-3.5-turbo-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-3.5 Turbo Instruct"
+    },
+    {
+      "id": "openai/gpt-4",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4"
+    },
+    {
+      "id": "openai/gpt-4-0314",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4 (older v0314)"
+    },
+    {
+      "id": "openai/gpt-4-1106-preview",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4 Turbo (older v1106)"
+    },
+    {
+      "id": "openai/gpt-4-32k",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4 32k"
+    },
+    {
+      "id": "openai/gpt-4-32k-0314",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4 32k (older v0314)"
+    },
+    {
+      "id": "openai/gpt-4-turbo",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4 Turbo"
+    },
+    {
+      "id": "openai/gpt-4-turbo-preview",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4 Turbo Preview"
+    },
+    {
+      "id": "openai/gpt-4-vision-preview",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4 Vision"
+    },
+    {
+      "id": "openai/gpt-4o",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4o"
+    },
+    {
+      "id": "openai/gpt-4o-2024-05-13",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4o (2024-05-13)"
+    },
+    {
+      "id": "openai/gpt-4o-2024-08-06",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4o (2024-08-06)"
+    },
+    {
+      "id": "openai/gpt-4o-mini",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4o-mini"
+    },
+    {
+      "id": "openai/gpt-4o-mini-2024-07-18",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4o-mini (2024-07-18)"
+    },
+    {
+      "id": "openai/gpt-4o:extended",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: GPT-4o (extended)"
+    },
+    {
+      "id": "openai/o1-mini",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: o1-mini"
+    },
+    {
+      "id": "openai/o1-mini-2024-09-12",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: o1-mini (2024-09-12)"
+    },
+    {
+      "id": "openai/o1-preview",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: o1-preview"
+    },
+    {
+      "id": "openai/o1-preview-2024-09-12",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenAI: o1-preview (2024-09-12)"
+    },
+    {
+      "id": "openchat/openchat-7b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenChat 3.5 7B"
+    },
+    {
+      "id": "openchat/openchat-7b:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenChat 3.5 7B (free)"
+    },
+    {
+      "id": "openrouter/auto",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Auto (best for prompt)"
+    },
+    {
+      "id": "perplexity/llama-3-sonar-large-32k-chat",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Perplexity: Llama3 Sonar 70B"
+    },
+    {
+      "id": "perplexity/llama-3-sonar-large-32k-online",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Perplexity: Llama3 Sonar 70B Online"
+    },
+    {
+      "id": "perplexity/llama-3-sonar-small-32k-chat",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Perplexity: Llama3 Sonar 8B"
+    },
+    {
+      "id": "perplexity/llama-3.1-sonar-huge-128k-online",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Perplexity: Llama 3.1 Sonar 405B Online"
+    },
+    {
+      "id": "perplexity/llama-3.1-sonar-large-128k-chat",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Perplexity: Llama 3.1 Sonar 70B"
+    },
+    {
+      "id": "perplexity/llama-3.1-sonar-large-128k-online",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Perplexity: Llama 3.1 Sonar 70B Online"
+    },
+    {
+      "id": "perplexity/llama-3.1-sonar-small-128k-chat",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Perplexity: Llama 3.1 Sonar 8B"
+    },
+    {
+      "id": "perplexity/llama-3.1-sonar-small-128k-online",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Perplexity: Llama 3.1 Sonar 8B Online"
+    },
+    {
+      "id": "pygmalionai/mythalion-13b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Pygmalion: Mythalion 13B"
+    },
+    {
+      "id": "qwen/qwen-110b-chat",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen 1.5 110B Chat"
+    },
+    {
+      "id": "qwen/qwen-2-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen 2 72B Instruct"
+    },
+    {
+      "id": "qwen/qwen-2-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen 2 7B Instruct"
+    },
+    {
+      "id": "qwen/qwen-2-7b-instruct:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen 2 7B Instruct (free)"
+    },
+    {
+      "id": "qwen/qwen-2-vl-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen2-VL 72B Instruct"
+    },
+    {
+      "id": "qwen/qwen-2-vl-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen2-VL 7B Instruct"
+    },
+    {
+      "id": "qwen/qwen-2.5-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen2.5 72B Instruct"
+    },
+    {
+      "id": "qwen/qwen-2.5-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen2.5 7B Instruct"
+    },
+    {
+      "id": "qwen/qwen-72b-chat",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Qwen 1.5 72B Chat"
+    },
+    {
+      "id": "sao10k/fimbulvetr-11b-v2",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Fimbulvetr 11B v2"
+    },
+    {
+      "id": "sao10k/l3-euryale-70b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Llama 3 Euryale 70B v2.1"
+    },
+    {
+      "id": "sao10k/l3-lunaris-8b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Llama 3 8B Lunaris"
+    },
+    {
+      "id": "sao10k/l3.1-euryale-70b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Llama 3.1 Euryale 70B v2.2"
+    },
+    {
+      "id": "sophosympatheia/midnight-rose-70b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Midnight Rose 70B"
+    },
+    {
+      "id": "teknium/openhermes-2.5-mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "OpenHermes 2.5 Mistral 7B"
+    },
+    {
+      "id": "thedrummer/rocinante-12b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Rocinante 12B"
+    },
+    {
+      "id": "undi95/remm-slerp-l2-13b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "ReMM SLERP 13B"
+    },
+    {
+      "id": "undi95/remm-slerp-l2-13b:extended",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "ReMM SLERP 13B (extended)"
+    },
+    {
+      "id": "undi95/toppy-m-7b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Toppy M 7B"
+    },
+    {
+      "id": "undi95/toppy-m-7b:free",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Toppy M 7B (free)"
+    },
+    {
+      "id": "undi95/toppy-m-7b:nitro",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Toppy M 7B (nitro)"
+    },
+    {
+      "id": "x-ai/grok-beta",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "xAI: Grok Beta"
+    },
+    {
+      "id": "xwin-lm/xwin-lm-70b",
+      "object": "model",
+      "provider": {
+        "id": "openrouter"
+      },
+      "name": "Xwin 70B"
+    },
+    {
+      "id": "llama-3.1-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "perplexity"
+      },
+      "name": "Llama 3.1 70B Instruct"
+    },
+    {
+      "id": "llama-3.1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "perplexity"
+      },
+      "name": "Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "llama-3.1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "perplexity"
+      },
+      "name": "Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "llama-3.1-sonar-huge-128k-online",
+      "object": "model",
+      "provider": {
+        "id": "perplexity"
+      },
+      "name": "Llama 3.1 Sonar Huge 128k Online"
+    },
+    {
+      "id": "llama-3.1-sonar-large-128k-chat",
+      "object": "model",
+      "provider": {
+        "id": "perplexity"
+      },
+      "name": "Llama 3.1 Sonar Large 128k Chat"
+    },
+    {
+      "id": "llama-3.1-sonar-large-128k-online",
+      "object": "model",
+      "provider": {
+        "id": "perplexity"
+      },
+      "name": "Llama 3.1 Sonar Large 128k Online"
+    },
+    {
+      "id": "llama-3.1-sonar-small-128k-chat",
+      "object": "model",
+      "provider": {
+        "id": "perplexity"
+      },
+      "name": "Llama 3.1 Sonar Small 128k Chat"
+    },
+    {
+      "id": "llama-3.1-sonar-small-128k-online",
+      "object": "model",
+      "provider": {
+        "id": "perplexity"
+      },
+      "name": "Llama 3.1 Sonar Small 128k Online"
+    },
+    {
+      "id": "codellama-13b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Codellama 13B Instruct"
+    },
+    {
+      "id": "codellama-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Codellama 70B Instruct"
+    },
+    {
+      "id": "codellama-7b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Codellama 7B"
+    },
+    {
+      "id": "codellama-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Codellama 7B Instruct"
+    },
+    {
+      "id": "gemma-2-27b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Gemma 2 27B"
+    },
+    {
+      "id": "gemma-2-27b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Gemma 2 27B Instruct"
+    },
+    {
+      "id": "gemma-2-9b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Gemma 2 9B"
+    },
+    {
+      "id": "gemma-2-9b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Gemma 2 9B Instruct"
+    },
+    {
+      "id": "gemma-2b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Gemma 2B"
+    },
+    {
+      "id": "gemma-2b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Gemma 2B Instruct"
+    },
+    {
+      "id": "gemma-7b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Gemma 7B"
+    },
+    {
+      "id": "gemma-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Gemma 7B Instruct"
+    },
+    {
+      "id": "llama-2-13b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 2 13B"
+    },
+    {
+      "id": "llama-2-13b-chat",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 2 13B Chat"
+    },
+    {
+      "id": "llama-2-70b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 2 70B"
+    },
+    {
+      "id": "llama-2-70b-chat",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 2 70B Chat"
+    },
+    {
+      "id": "llama-2-7b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 2 7B"
+    },
+    {
+      "id": "llama-2-7b-chat",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 2 7B Chat"
+    },
+    {
+      "id": "llama-3-1-8b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 3 1 8B"
+    },
+    {
+      "id": "llama-3-1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 3 1 8B Instruct"
+    },
+    {
+      "id": "llama-3-70b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 3 70B"
+    },
+    {
+      "id": "llama-3-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 3 70B Instruct"
+    },
+    {
+      "id": "llama-3-8b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 3 8B"
+    },
+    {
+      "id": "llama-3-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Llama 3 8B Instruct"
+    },
+    {
+      "id": "mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Mistral 7B"
+    },
+    {
+      "id": "mistral-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Mistral 7B Instruct"
+    },
+    {
+      "id": "mistral-7b-instruct-v0-2",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Mistral 7B Instruct V0 2"
+    },
+    {
+      "id": "mistral-7b-instruct-v0-3",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Mistral 7B Instruct V0 3"
+    },
+    {
+      "id": "mistral-nemo-12b-2407",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Mistral Nemo 12B 2407"
+    },
+    {
+      "id": "mistral-nemo-12b-instruct-2407",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Mistral Nemo 12B Instruct 2407"
+    },
+    {
+      "id": "mixtral-8x7b-instruct-v0-1",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Mixtral 8X7B Instruct V0 1"
+    },
+    {
+      "id": "mixtral-8x7b-v0-1",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Mixtral 8X7B V0 1"
+    },
+    {
+      "id": "phi-2",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Phi 2"
+    },
+    {
+      "id": "phi-3-5-mini-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Phi 3 5 Mini Instruct"
+    },
+    {
+      "id": "phi-3-mini-4k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Phi 3 Mini 4K Instruct"
+    },
+    {
+      "id": "qwen2-1-5b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Qwen2 1 5B"
+    },
+    {
+      "id": "qwen2-1-5b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Qwen2 1 5B Instruct"
+    },
+    {
+      "id": "qwen2-72b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Qwen2 72B"
+    },
+    {
+      "id": "qwen2-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Qwen2 72B Instruct"
+    },
+    {
+      "id": "qwen2-7b",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Qwen2 7B"
+    },
+    {
+      "id": "qwen2-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Qwen2 7B Instruct"
+    },
+    {
+      "id": "solar-1-mini-chat-240612",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Solar 1 Mini Chat 240612"
+    },
+    {
+      "id": "solar-pro-preview-instruct",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Solar Pro Preview Instruct"
+    },
+    {
+      "id": "zephyr-7b-beta",
+      "object": "model",
+      "provider": {
+        "id": "predibase"
+      },
+      "name": "Zephyr 7B Beta"
+    },
+    {
+      "id": "reka-core",
+      "object": "model",
+      "provider": {
+        "id": "reka"
+      },
+      "name": "Reka Core"
+    },
+    {
+      "id": "reka-edge",
+      "object": "model",
+      "provider": {
+        "id": "reka"
+      },
+      "name": "Reka Edge"
+    },
+    {
+      "id": "reka-flash",
+      "object": "model",
+      "provider": {
+        "id": "reka"
+      },
+      "name": "Reka Flash"
+    },
+    {
+      "id": "rerank-2",
+      "object": "model",
+      "provider": {
+        "id": "voyage"
+      },
+      "name": "Rerank 2"
+    },
+    {
+      "id": "rerank-2-lite",
+      "object": "model",
+      "provider": {
+        "id": "voyage"
+      },
+      "name": "Rerank 2 Lite"
+    },
+    {
+      "id": "voyage-3",
+      "object": "model",
+      "provider": {
+        "id": "voyage"
+      },
+      "name": "Voyage 3"
+    },
+    {
+      "id": "voyage-3-lite",
+      "object": "model",
+      "provider": {
+        "id": "voyage"
+      },
+      "name": "Voyage 3 Lite"
+    },
+    {
+      "id": "voyage-code-2",
+      "object": "model",
+      "provider": {
+        "id": "voyage"
+      },
+      "name": "Voyage Code 2"
+    },
+    {
+      "id": "voyage-finance-2",
+      "object": "model",
+      "provider": {
+        "id": "voyage"
+      },
+      "name": "Voyage Finance 2"
+    },
+    {
+      "id": "voyage-law-2",
+      "object": "model",
+      "provider": {
+        "id": "voyage"
+      },
+      "name": "Voyage Law 2"
+    },
+    {
+      "id": "voyage-multilingual-2",
+      "object": "model",
+      "provider": {
+        "id": "voyage"
+      },
+      "name": "Voyage Multilingual 2"
+    },
+    {
+      "id": "bart-large-cnn",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Bart Large Cnn"
+    },
+    {
+      "id": "bge-base-en-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Bge Base En V1.5"
+    },
+    {
+      "id": "bge-large-en-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Bge Large En V1.5"
+    },
+    {
+      "id": "bge-small-en-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Bge Small En V1.5"
+    },
+    {
+      "id": "deepseek-coder-6.7b-base-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Deepseek Coder 6.7B Base Awq"
+    },
+    {
+      "id": "deepseek-coder-6.7b-instruct-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Deepseek Coder 6.7B Instruct Awq"
+    },
+    {
+      "id": "deepseek-math-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Deepseek Math 7B Instruct"
+    },
+    {
+      "id": "detr-resnet-50",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Detr Resnet 50"
+    },
+    {
+      "id": "discolm-german-7b-v1-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Discolm German 7B V1 Awq"
+    },
+    {
+      "id": "distilbert-sst-2-int8",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Distilbert Sst 2 Int8"
+    },
+    {
+      "id": "dreamshaper-8-lcm",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Dreamshaper 8 Lcm"
+    },
+    {
+      "id": "falcon-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Falcon 7B Instruct"
+    },
+    {
+      "id": "flux-1-schnell",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Flux 1 Schnell"
+    },
+    {
+      "id": "gemma-2b-it-lora",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Gemma 2B It Lora"
+    },
+    {
+      "id": "gemma-7b-it",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Gemma 7B It"
+    },
+    {
+      "id": "gemma-7b-it-lora",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Gemma 7B It Lora"
+    },
+    {
+      "id": "hermes-2-pro-mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Hermes 2 Pro Mistral 7B"
+    },
+    {
+      "id": "llama-2-13b-chat-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 2 13B Chat Awq"
+    },
+    {
+      "id": "llama-2-7b-chat-fp16",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 2 7B Chat Fp16"
+    },
+    {
+      "id": "llama-2-7b-chat-hf-lora",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 2 7B Chat Hf Lora"
+    },
+    {
+      "id": "llama-2-7b-chat-int8",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 2 7B Chat Int8"
+    },
+    {
+      "id": "llama-3-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3 8B Instruct"
+    },
+    {
+      "id": "llama-3-8b-instruct-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3 8B Instruct Awq"
+    },
+    {
+      "id": "llama-3.1-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3.1 70B Instruct"
+    },
+    {
+      "id": "llama-3.1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "llama-3.1-8b-instruct-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3.1 8B Instruct Awq"
+    },
+    {
+      "id": "llama-3.1-8b-instruct-fast",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3.1 8B Instruct Fast"
+    },
+    {
+      "id": "llama-3.1-8b-instruct-fp8",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3.1 8B Instruct Fp8"
+    },
+    {
+      "id": "llama-3.2-11b-vision-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3.2 11B Vision Instruct"
+    },
+    {
+      "id": "llama-3.2-1b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3.2 1B Instruct"
+    },
+    {
+      "id": "llama-3.2-3b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llama 3.2 3B Instruct"
+    },
+    {
+      "id": "llamaguard-7b-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llamaguard 7B Awq"
+    },
+    {
+      "id": "llava-1.5-7b-hf",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Llava 1.5 7B Hf"
+    },
+    {
+      "id": "m2m100-1.2b",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "M2M100 1.2B"
+    },
+    {
+      "id": "meta-llama-3-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Meta Llama 3 8B Instruct"
+    },
+    {
+      "id": "mistral-7b-instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Mistral 7B Instruct V0.1"
+    },
+    {
+      "id": "mistral-7b-instruct-v0.1-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Mistral 7B Instruct V0.1 Awq"
+    },
+    {
+      "id": "mistral-7b-instruct-v0.2",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Mistral 7B Instruct V0.2"
+    },
+    {
+      "id": "mistral-7b-instruct-v0.2-lora",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Mistral 7B Instruct V0.2 Lora"
+    },
+    {
+      "id": "neural-chat-7b-v3-1-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Neural Chat 7B V3 1 Awq"
+    },
+    {
+      "id": "openchat-3.5-0106",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Openchat 3.5 0106"
+    },
+    {
+      "id": "openhermes-2.5-mistral-7b-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Openhermes 2.5 Mistral 7B Awq"
+    },
+    {
+      "id": "phi-2",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Phi 2"
+    },
+    {
+      "id": "qwen1.5-0.5b-chat",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Qwen1.5 0.5B Chat"
+    },
+    {
+      "id": "qwen1.5-1.8b-chat",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Qwen1.5 1.8B Chat"
+    },
+    {
+      "id": "qwen1.5-14b-chat-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Qwen1.5 14B Chat Awq"
+    },
+    {
+      "id": "qwen1.5-7b-chat-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Qwen1.5 7B Chat Awq"
+    },
+    {
+      "id": "resnet-50",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Resnet 50"
+    },
+    {
+      "id": "sqlcoder-7b-2",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Sqlcoder 7B 2"
+    },
+    {
+      "id": "stable-diffusion-v1-5-img2img",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Stable Diffusion V1 5 Img2Img"
+    },
+    {
+      "id": "stable-diffusion-v1-5-inpainting",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Stable Diffusion V1 5 Inpainting"
+    },
+    {
+      "id": "stable-diffusion-xl-base-1.0",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Stable Diffusion Xl Base 1.0"
+    },
+    {
+      "id": "stable-diffusion-xl-lightning",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Stable Diffusion Xl Lightning"
+    },
+    {
+      "id": "starling-lm-7b-beta",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Starling Lm 7B Beta"
+    },
+    {
+      "id": "tinyllama-1.1b-chat-v1.0",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Tinyllama 1.1B Chat V1.0"
+    },
+    {
+      "id": "uform-gen2-qwen-500m",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Uform Gen2 Qwen 500M"
+    },
+    {
+      "id": "una-cybertron-7b-v2-bf16",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Una Cybertron 7B V2 Bf16"
+    },
+    {
+      "id": "whisper",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Whisper"
+    },
+    {
+      "id": "whisper-tiny-en",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Whisper Tiny En"
+    },
+    {
+      "id": "zephyr-7b-beta-awq",
+      "object": "model",
+      "provider": {
+        "id": "workers-ai"
+      },
+      "name": "Zephyr 7B Beta Awq"
+    },
+    {
+      "id": "glm-3-turbo",
+      "object": "model",
+      "provider": {
+        "id": "zhipu"
+      },
+      "name": "GLM-3 Turbo"
+    },
+    {
+      "id": "glm-4",
+      "object": "model",
+      "provider": {
+        "id": "zhipu"
+      },
+      "name": "GLM-4"
+    },
+    {
+      "id": "glm-4-0520",
+      "object": "model",
+      "provider": {
+        "id": "zhipu"
+      },
+      "name": "GLM-4 0520"
+    },
+    {
+      "id": "glm-4-air",
+      "object": "model",
+      "provider": {
+        "id": "zhipu"
+      },
+      "name": "GLM-4 Air"
+    },
+    {
+      "id": "glm-4-airx",
+      "object": "model",
+      "provider": {
+        "id": "zhipu"
+      },
+      "name": "GLM-4 AirX"
+    },
+    {
+      "id": "glm-4-flashx",
+      "object": "model",
+      "provider": {
+        "id": "zhipu"
+      },
+      "name": "GLM-4 FlashX"
+    },
+    {
+      "id": "glm-4-long",
+      "object": "model",
+      "provider": {
+        "id": "zhipu"
+      },
+      "name": "GLM-4 Long"
+    },
+    {
+      "id": "glm-4-plus",
+      "object": "model",
+      "provider": {
+        "id": "zhipu"
+      },
+      "name": "GLM-4 Plus"
+    },
+    {
+      "id": "mistralai/Mixtral-8x22B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "anyscale"
+      },
+      "name": "Mixtral 8x22B Instruct v0.1"
+    },
+    {
+      "id": "Llama-3.2-3B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 3.2 3B Instruct"
+    },
+    {
+      "id": "Llama-3.2-1B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 3.2 1B Instruct"
+    },
+    {
+      "id": "Llama-Guard-3-11B-Vision",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama Guard 3 11B Vision"
+    },
+    {
+      "id": "Llama-3.2-11B-Vision-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 3.2 11B Vision Instruct"
+    },
+    {
+      "id": "Llama-Guard-3-1B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama Guard 3 1B"
+    },
+    {
+      "id": "Llama-3.2-90B-Vision-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 3.2 90B Vision Instruct"
+    },
+    {
+      "id": "Llama-2-7b",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 2 7B"
+    },
+    {
+      "id": "Llama-2-70b",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 2 70B"
+    },
+    {
+      "id": "Llama-2-13b",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 2 13B"
+    },
+    {
+      "id": "Llama-2-7b-chat",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 2 7B Chat"
+    },
+    {
+      "id": "Llama-2-70b-chat",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 2 70B Chat"
+    },
+    {
+      "id": "Llama-2-13b-chat",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Llama 2 13B Chat"
+    },
+    {
+      "id": "CodeLlama-7b-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 7B HF"
+    },
+    {
+      "id": "CodeLlama-7b-Python-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 7B Python HF"
+    },
+    {
+      "id": "CodeLlama-7b-Instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 7B Instruct HF"
+    },
+    {
+      "id": "CodeLlama-34b-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 34B HF"
+    },
+    {
+      "id": "CodeLlama-34b-Python-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 34B Python HF"
+    },
+    {
+      "id": "CodeLlama-34b-Instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 34B Instruct HF"
+    },
+    {
+      "id": "CodeLlama-13b-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 13B HF"
+    },
+    {
+      "id": "CodeLlama-13b-Python-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 13B Python HF"
+    },
+    {
+      "id": "CodeLlama-13b-Instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 13B Instruct HF"
+    },
+    {
+      "id": "Prompt-Guard-86M",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Prompt Guard 86M"
+    },
+    {
+      "id": "Meta-Llama-3.1-405B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Meta Llama 3.1 405B Instruct"
+    },
+    {
+      "id": "Ministral-3B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Ministral 3B"
+    },
+    {
+      "id": "Mistral-large-2407",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mistral Large 2407"
+    },
+    {
+      "id": "Mistral-Nemo",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mistral Nemo"
+    },
+    {
+      "id": "mistralai-Mixtral-8x7B-v01",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mixtral 8x7B v01"
+    },
+    {
+      "id": "mistralai-Mixtral-8x7B-Instruct-v01",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mixtral 8x7B Instruct v01"
+    },
+    {
+      "id": "mistralai-Mixtral-8x22B-v0-1",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mixtral 8x22B v0-1"
+    },
+    {
+      "id": "mistralai-Mixtral-8x22B-Instruct-v0-1",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mixtral 8x22B Instruct v0-1"
+    },
+    {
+      "id": "mistralai-Mistral-7B-v01",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mistral 7B v01"
+    },
+    {
+      "id": "mistralai-Mistral-7B-Instruct-v0-2",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mistral 7B Instruct v0-2"
+    },
+    {
+      "id": "mistral-community-Mixtral-8x22B-v0-1",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mixtral 8x22B v0-1"
+    },
+    {
+      "id": "mistralai-Mistral-7B-Instruct-v01",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mistral 7B Instruct v01"
+    },
+    {
+      "id": "Mistral-small",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mistral Small"
+    },
+    {
+      "id": "Mistral-large",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Mistral Large"
+    },
+    {
+      "id": "Nemotron-3-8B-Chat-SteerLM",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Nemotron 3 8B Chat SteerLM"
+    },
+    {
+      "id": "Nemotron-3-8B-Chat-RLHF",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Nemotron 3 8B Chat RLHF"
+    },
+    {
+      "id": "Nemotron-3-8B-Chat-SFT",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Nemotron 3 8B Chat SFT"
+    },
+    {
+      "id": "AI21-Jamba-1.5-Mini",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "AI21 Jamba 1.5 Mini"
+    },
+    {
+      "id": "AI21-Jamba-1.5-Large",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "AI21 Jamba 1.5 Large"
+    },
+    {
+      "id": "Deci-DeciLM-7B-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DeciLM 7B Instruct"
+    },
+    {
+      "id": "Deci-DeciLM-7B",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DeciLM 7B"
+    },
+    {
+      "id": "Deci-DeciCoder-1b",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DeciCoder 1B"
+    },
+    {
+      "id": "TimeGEN-1",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "TimeGEN 1"
+    },
+    {
+      "id": "jais-30b-chat",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Jais 30B Chat"
+    },
+    {
+      "id": "Cohere-command-r-plus-08-2024",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Cohere Command R+ 08-2024"
+    },
+    {
+      "id": "Cohere-command-r-08-2024",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Cohere Command R 08-2024"
+    },
+    {
+      "id": "Cohere-rerank-v3-multilingual",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Cohere Rerank v3 Multilingual"
+    },
+    {
+      "id": "Cohere-rerank-v3-english",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Cohere Rerank v3 English"
+    },
+    {
+      "id": "Cohere-embed-v3-multilingual",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Cohere Embed v3 Multilingual"
+    },
+    {
+      "id": "Cohere-embed-v3-english",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Cohere Embed v3 English"
+    },
+    {
+      "id": "Cohere-command-r-plus",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Cohere Command R+"
+    },
+    {
+      "id": "Cohere-command-r",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Cohere Command R"
+    },
+    {
+      "id": "databricks-dolly-v2-12b",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Dolly v2 12B"
+    },
+    {
+      "id": "snowflake-arctic-base",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Snowflake Arctic Base"
+    },
+    {
+      "id": "ALLaM-2-7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "ALLaM 2 7B Instruct"
+    },
+    {
+      "id": "MedImageParse",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "MedImageParse"
+    },
+    {
+      "id": "MedImageInsight",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "MedImageInsight"
+    },
+    {
+      "id": "CxrReportGen",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CxrReportGen"
+    },
+    {
+      "id": "Virchow2",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Virchow2"
+    },
+    {
+      "id": "Prism",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Prism"
+    },
+    {
+      "id": "Virchow",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Virchow"
+    },
+    {
+      "id": "BiomedCLIP-PubMedBERT_256-vit_base_patch16_224",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "BiomedCLIP PubMedBERT_256-vit_base_patch16_224"
+    },
+    {
+      "id": "microsoft-llava-med-v1.5-mistral-7b",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Microsoft LLaMA-Med v1.5 Mistral 7B"
+    },
+    {
+      "id": "snowflake-arctic-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Snowflake Arctic Instruct"
+    },
+    {
+      "id": "facebook-dinov2-base-imagenet1k-1-layer",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DinoV2 Base ImageNet1K 1-Layer"
+    },
+    {
+      "id": "CodeLlama-70b-Python-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 70B Python HF"
+    },
+    {
+      "id": "microsoft-phi-1-5",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Microsoft Phi-1.5"
+    },
+    {
+      "id": "CodeLlama-70b-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 70B HF"
+    },
+    {
+      "id": "CodeLlama-70b-Instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "CodeLlama 70B Instruct HF"
+    },
+    {
+      "id": "deci-decidiffusion-v1-0",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Deci Diffusion v1.0"
+    },
+    {
+      "id": "facebook-deit-base-patch16-224",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DEiT Base Patch16 224"
+    },
+    {
+      "id": "openai-clip-vit-large-patch14",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "OpenAI CLIP ViT-Large Patch14"
+    },
+    {
+      "id": "openai-clip-vit-base-patch32",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "OpenAI CLIP ViT-Base Patch32"
+    },
+    {
+      "id": "facebook-sam-vit-large",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "SAM ViT-Large"
+    },
+    {
+      "id": "facebook-sam-vit-huge",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "SAM ViT-Huge"
+    },
+    {
+      "id": "facebook-sam-vit-base",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "SAM ViT-Base"
+    },
+    {
+      "id": "OpenAI-CLIP-Image-Text-Embeddings-vit-base-patch32",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "OpenAI CLIP Image Text Embeddings ViT-Base Patch32"
+    },
+    {
+      "id": "microsoft-phi-2",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Microsoft Phi-2"
+    },
+    {
+      "id": "microsoft-swinv2-base-patch4-window12-192-22k",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "SwinV2 Base Patch4 Window12 192 22K"
+    },
+    {
+      "id": "microsoft-beit-base-patch16-224-pt22k-ft22k",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "BEiT Base Patch16 224 PT22K FT22K"
+    },
+    {
+      "id": "OpenAI-CLIP-Image-Text-Embeddings-ViT-Large-Patch14-336",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "OpenAI CLIP Image Text Embeddings ViT-Large Patch14 336"
+    },
+    {
+      "id": "Facebook-DinoV2-Image-Embeddings-ViT-Giant",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DinoV2 Image Embeddings ViT-Giant"
+    },
+    {
+      "id": "Facebook-DinoV2-Image-Embeddings-ViT-Base",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DinoV2 Image Embeddings ViT-Base"
+    },
+    {
+      "id": "microsoft-Orca-2-7b",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Microsoft Orca 2 7B"
+    },
+    {
+      "id": "microsoft-Orca-2-13b",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "Microsoft Orca 2 13B"
+    },
+    {
+      "id": "databricks-dbrx-instruct",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DBRX Instruct"
+    },
+    {
+      "id": "databricks-dbrx-base",
+      "object": "model",
+      "provider": {
+        "id": "azure"
+      },
+      "name": "DBRX Base"
+    },
+    {
+      "id": "stable-diffusion-3.5-turbo-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 3.5 Turbo Text-to-Image"
+    },
+    {
+      "id": "llama3-70b-8192",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3 70B 8192"
+    },
+    {
+      "id": "llama3-8b-8192",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Llama 3 8B 8192"
+    },
+    {
+      "id": "mixtral-8x7b-32768",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Mixtral 8x7B 32768"
+    },
+    {
+      "id": "whisper-large-v3",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Whisper Large v3"
+    },
+    {
+      "id": "whisper-large-v3-turbo",
+      "object": "model",
+      "provider": {
+        "id": "groq"
+      },
+      "name": "Whisper Large v3 Turbo"
+    },
+    {
+      "id": "yi-vision",
+      "object": "model",
+      "provider": {
+        "id": "lingyi"
+      },
+      "name": "Yi Vision"
+    },
+    {
+      "id": "open-mixtral-8x7b",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Mixtral 8x7B"
+    },
+    {
+      "id": "open-mixtral-8x22b",
+      "object": "model",
+      "provider": {
+        "id": "mistral-ai"
+      },
+      "name": "Mixtral 8x22B"
+    },
+    {
+      "id": "stable-diffusion-3.5-large-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 3.5 Large Text-to-Image"
+    },
+    {
+      "id": "flux-1.1-pro",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux 1.1 Pro"
+    },
+    {
+      "id": "Simple_Vector_Flux",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Simple Vector Flux"
+    },
+    {
+      "id": "ideogram-txt-2-img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Ideogram Text-to-Image"
+    },
+    {
+      "id": "fast-flux-schnell",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Fast Flux Schnell"
+    },
+    {
+      "id": "flux-realism-lora",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux Realism LoRA"
+    },
+    {
+      "id": "flux-dev",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux Dev"
+    },
+    {
+      "id": "flux-schnell",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux Schnell"
+    },
+    {
+      "id": "flux-pro",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux Pro"
+    },
+    {
+      "id": "sdxl1.0-realdream-pony-v9",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 RealDream Pony v9"
+    },
+    {
+      "id": "sdxl1.0-realdream-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 RealDream Lightning"
+    },
+    {
+      "id": "playground-v2.5",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Playground v2.5"
+    },
+    {
+      "id": "background-eraser",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Background Eraser"
+    },
+    {
+      "id": "stable-diffusion-3-medium-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 3 Medium Text-to-Image"
+    },
+    {
+      "id": "sdxl1.0-yamers-realistic",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Yamers Realistic"
+    },
+    {
+      "id": "sdxl1.0-newreality-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 NewReality Lightning"
+    },
+    {
+      "id": "sdxl1.0-dreamshaper-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Dreamshaper Lightning"
+    },
+    {
+      "id": "sdxl1.0-colossus-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Colossus Lightning"
+    },
+    {
+      "id": "sdxl1.0-samaritan-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Samaritan Lightning"
+    },
+    {
+      "id": "sdxl1.0-realism-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Realism Lightning"
+    },
+    {
+      "id": "sdxl1.0-protovis-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Protovis Lightning"
+    },
+    {
+      "id": "sdxl1.0-nightvis-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Nightvis Lightning"
+    },
+    {
+      "id": "sdxl1.0-wildcard-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Wildcard Lightning"
+    },
+    {
+      "id": "sdxl1.0-dyanvis-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Dyanvis Lightning"
+    },
+    {
+      "id": "sdxl1.0-juggernaut-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Juggernaut Lightning"
+    },
+    {
+      "id": "sdxl1.0-realvis-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Realvis Lightning"
+    },
+    {
+      "id": "sdxl1.0-samaritan-3d",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Samaritan 3D"
+    },
+    {
+      "id": "segmind-vega",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Segmind Vega"
+    },
+    {
+      "id": "segmind-vega-rt-v1",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Segmind Vega RT v1"
+    },
+    {
+      "id": "ssd-1b",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SSD 1B"
+    },
+    {
+      "id": "sdxl1.0-timeless",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Timeless"
+    },
+    {
+      "id": "sdxl1.0-zavychroma",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Zavychroma"
+    },
+    {
+      "id": "sdxl1.0-realvis",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Realvis"
+    },
+    {
+      "id": "sdxl1.0-dreamshaper",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Dreamshaper"
+    },
+    {
+      "id": "sd2.1-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 2.1 Text-to-Image"
+    },
+    {
+      "id": "sdxl-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL Text-to-Image"
+    },
+    {
+      "id": "tinysd1.5-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "TinySD 1.5 Text-to-Image"
+    },
+    {
+      "id": "smallsd1.5-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SmallSD 1.5 Text-to-Image"
+    },
+    {
+      "id": "sdxl1.0-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL 1.0 Text-to-Image"
+    },
+    {
+      "id": "sd1.5-scifi",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Sci-Fi"
+    },
+    {
+      "id": "sd1.5-samaritan_3d",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Samaritan 3D"
+    },
+    {
+      "id": "sd1.5-rpg",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 RPG"
+    },
+    {
+      "id": "sd1.5-reliberate",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 ReLiberate"
+    },
+    {
+      "id": "sd1.5-realisticvision",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Realistic Vision"
+    },
+    {
+      "id": "sd1.5-rcnz",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 RCNZ"
+    },
+    {
+      "id": "sd1.5-paragon",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Paragon"
+    },
+    {
+      "id": "sd1.5-manmarumix",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Manmarumix"
+    },
+    {
+      "id": "sd1.5-majicmix",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Majicmix"
+    },
+    {
+      "id": "sd1.5-juggernaut",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Juggernaut"
+    },
+    {
+      "id": "sd1.5-fruitfusion",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 FruitFusion"
+    },
+    {
+      "id": "sd1.5-flat2d",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Flat2D"
+    },
+    {
+      "id": "sd1.5-fantassifiedicons",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 FantassifiedIcons"
+    },
+    {
+      "id": "sd1.5-epicrealism",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Epic Realism"
+    },
+    {
+      "id": "sd1.5-edgeofrealism",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Edge of Realism"
+    },
+    {
+      "id": "sd1.5-dvrach",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Dvrach"
+    },
+    {
+      "id": "sd1.5-dreamshaper",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Dreamshaper"
+    },
+    {
+      "id": "sd1.5-deepspacediffusion",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 DeepSpaceDiffusion"
+    },
+    {
+      "id": "sd1.5-cyberrealistic",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 CyberRealistic"
+    },
+    {
+      "id": "sd1.5-cuterichstyle",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 CuteRichStyle"
+    },
+    {
+      "id": "sd1.5-colorful",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Colorful"
+    },
+    {
+      "id": "sd1.5-allinonepixel",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 AllInOnePixel"
+    },
+    {
+      "id": "sd1.5-526mix",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 526mix"
+    },
+    {
+      "id": "qrsd1.5-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "QRS 1.5 Text-to-Image"
+    },
+    {
+      "id": "potraitsd1.5-txt2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "PortraitSD 1.5 Text-to-Image"
+    },
+    {
+      "id": "kandinsky2.1-txt2im",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Kandinsky 2.1 Text-to-Image"
+    },
+    {
+      "id": "sd1.5-revanimated",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Reanimated"
+    },
+    {
+      "id": "face-detailer",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Face Detailer"
+    },
+    {
+      "id": "expression-editor",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Expression Editor"
+    },
+    {
+      "id": "consistent-character-with-pose",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Consistent Character with Pose"
+    },
+    {
+      "id": "consistent-character-AI-neolemon-v3",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Consistent Character AI Neolemon v3"
+    },
+    {
+      "id": "flux-pulid",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux Pulid"
+    },
+    {
+      "id": "flux-ipadapter",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux IPAdapter"
+    },
+    {
+      "id": "flux-inpaint",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux Inpaint"
+    },
+    {
+      "id": "flux-controlnet",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux ControlNet"
+    },
+    {
+      "id": "text-overlay",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Text Overlay"
+    },
+    {
+      "id": "consistent-character-AI-neolemon-v2",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Consistent Character AI Neolemon v2"
+    },
+    {
+      "id": "sam-v2-image",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SAM v2 Image"
+    },
+    {
+      "id": "consistent-character-ai-neolemon",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Consistent Character AI Neolemon"
+    },
+    {
+      "id": "flux-img2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Flux Img2Img"
+    },
+    {
+      "id": "ai-product-photo-editor",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "AI Product Photo Editor"
+    },
+    {
+      "id": "sd3-med-tile",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SD 3 Med Tile"
+    },
+    {
+      "id": "sd3-med-canny",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SD 3 Med Canny"
+    },
+    {
+      "id": "sd3-med-pose",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SD 3 Med Pose"
+    },
+    {
+      "id": "superimpose-v2",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Superimpose v2"
+    },
+    {
+      "id": "aura-flow",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Aura Flow"
+    },
+    {
+      "id": "kolors",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Kolors"
+    },
+    {
+      "id": "superimpose",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Superimpose"
+    },
+    {
+      "id": "sdxl-img2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL Img2Img"
+    },
+    {
+      "id": "sdxl-controlnet",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL ControlNet"
+    },
+    {
+      "id": "storydiffusion",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "StoryDiffusion"
+    },
+    {
+      "id": "omni-zero",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Omni Zero"
+    },
+    {
+      "id": "ic-light",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "IC Light"
+    },
+    {
+      "id": "automatic-mask-generator",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Automatic Mask Generator"
+    },
+    {
+      "id": "magic-eraser",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Magic Eraser"
+    },
+    {
+      "id": "inpaint-mask-maker",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Inpaint Mask Maker"
+    },
+    {
+      "id": "clarity-upscaler",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Clarity Upscaler"
+    },
+    {
+      "id": "consistent-character",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Consistent Character"
+    },
+    {
+      "id": "idm-vton",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "IDM-VTON"
+    },
+    {
+      "id": "fooocus",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Fooocus"
+    },
+    {
+      "id": "style-transfer",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Style Transfer"
+    },
+    {
+      "id": "become-image",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Become Image"
+    },
+    {
+      "id": "illusion-diffusion-hq",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Illusion Diffusion HQ"
+    },
+    {
+      "id": "pulid-base",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Pulid Base"
+    },
+    {
+      "id": "pulid-lightning",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Pulid Lightning"
+    },
+    {
+      "id": "fashion-ai",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Fashion AI"
+    },
+    {
+      "id": "face-to-many",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Face-to-Many"
+    },
+    {
+      "id": "face-to-sticker",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Face-to-Sticker"
+    },
+    {
+      "id": "material-transfer",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Material Transfer"
+    },
+    {
+      "id": "faceswap-v2",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "FaceSwap v2"
+    },
+    {
+      "id": "insta-depth",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Insta Depth"
+    },
+    {
+      "id": "bg-removal-v2",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "BG Removal v2"
+    },
+    {
+      "id": "focus-outpaint",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Focus Outpaint"
+    },
+    {
+      "id": "instantid",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Instantid"
+    },
+    {
+      "id": "ip-sdxl-openpose",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "IP-SDXL OpenPose"
+    },
+    {
+      "id": "ip-sdxl-canny",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "IP-SDXL Canny"
+    },
+    {
+      "id": "ip-sdxl-depth",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "IP-SDXL Depth"
+    },
+    {
+      "id": "ssd-img2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SSD Img2Img"
+    },
+    {
+      "id": "sdxl-openpose",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SDXL OpenPose"
+    },
+    {
+      "id": "ssd-depth",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SSD Depth"
+    },
+    {
+      "id": "ssd-canny",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SSD Canny"
+    },
+    {
+      "id": "w2imgsd1.5-img2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "W2ImgSD 1.5 Img2Img"
+    },
+    {
+      "id": "sd1.5-img2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Img2Img"
+    },
+    {
+      "id": "sd1.5-outpaint",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 Outpaint"
+    },
+    {
+      "id": "sd1.5-controlnet-softedge",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 ControlNet Softedge"
+    },
+    {
+      "id": "sd1.5-controlnet-scribble",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 ControlNet Scribble"
+    },
+    {
+      "id": "sd1.5-controlnet-depth",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 ControlNet Depth"
+    },
+    {
+      "id": "sd1.5-controlnet-canny",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 ControlNet Canny"
+    },
+    {
+      "id": "codeformer",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "CodeFormer"
+    },
+    {
+      "id": "sam-img2img",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "SAM Img2Img"
+    },
+    {
+      "id": "sd2.1-faceswapper",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 2.1 FaceSwapper"
+    },
+    {
+      "id": "bg-removal",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "BG Removal"
+    },
+    {
+      "id": "esrgan",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "ESRGAN"
+    },
+    {
+      "id": "sd1.5-controlnet-openpose",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Stable Diffusion 1.5 ControlNet OpenPose"
+    },
+    {
+      "id": "o1-preview",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "O1 Preview"
+    },
+    {
+      "id": "llama-v3p1-405b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Llama V3P1 405B Instruct"
+    },
+    {
+      "id": "llama-v3p1-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Llama V3P1 70B Instruct"
+    },
+    {
+      "id": "llama-v3p1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Llama V3P1 8B Instruct"
+    },
+    {
+      "id": "claude-3-haiku",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Claude 3 Haiku"
+    },
+    {
+      "id": "claude-3-opus",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Claude 3 Opus"
+    },
+    {
+      "id": "gemini-1.5-pro",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Gemini 1.5 Pro"
+    },
+    {
+      "id": "gemini-1.5-flash",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Gemini 1.5 Flash"
+    },
+    {
+      "id": "claude-3.5-sonnet",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Claude 3.5 Sonnet"
+    },
+    {
+      "id": "llava-13b",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "LLaMA 13B"
+    },
+    {
+      "id": "gpt-4-turbo",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "GPT-4 Turbo"
+    },
+    {
+      "id": "gpt-4o",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "GPT-4 0"
+    },
+    {
+      "id": "gpt-4",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "GPT-4"
+    },
+    {
+      "id": "mixtral-8x7b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Mixtral 8x7B Instruct"
+    },
+    {
+      "id": "mixtral-8x22b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Mixtral 8x22B Instruct"
+    },
+    {
+      "id": "llama-v3-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Llama V3 8B Instruct"
+    },
+    {
+      "id": "llama-v3-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "Segmind"
+      },
+      "name": "Llama V3 70B Instruct"
+    },
+    {
+      "id": "moonshot-v1-8k",
+      "object": "model",
+      "provider": {
+        "id": "moonshot"
+      },
+      "name": "Moonshot (8k Context)"
+    },
+    {
+      "id": "moonshot-v1-32k",
+      "object": "model",
+      "provider": {
+        "id": "moonshot"
+      },
+      "name": "Moonshot (132k Context)"
+    },
+    {
+      "id": "moonshot-v1-128k",
+      "object": "model",
+      "provider": {
+        "id": "moonshot"
+      },
+      "name": "Moonshot (128k Context)"
+    },
+    {
+      "id": "nomic-embed-vision-v1",
+      "object": "model",
+      "provider": {
+        "id": "nomic"
+      },
+      "name": "Nomic Embed vision v1"
+    },
+    {
+      "id": "nomic-embed-vision-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "nomic"
+      },
+      "name": "Nomic Embed vision v1.5"
+    },
+    {
+      "id": "nomic-embed-text-v1",
+      "object": "model",
+      "provider": {
+        "id": "nomic"
+      },
+      "name": "Nomic Embed v1"
+    },
+    {
+      "id": "nomic-embed-text-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "nomic"
+      },
+      "name": "Nomic Embed v1.5"
+    },
+    {
+      "id": "deepseek-coder-v2-lite-instruct",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "DeepSeek Coder v2 Lite Instruct"
+    },
+    {
+      "id": "Meta-Llama-3.2-1B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "sambanova"
+      },
+      "name": "Llama 3.2 1B"
+    },
+    {
+      "id": "Meta-Llama-3.2-3B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "sambanova"
+      },
+      "name": "Llama 3.2 3B"
+    },
+    {
+      "id": "Llama-3.2-11B-Vision-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "sambanova"
+      },
+      "name": "Llama 3.2 11B"
+    },
+    {
+      "id": "Llama-3.2-90B-Vision-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "sambanova"
+      },
+      "name": "Llama 3.2 90B"
+    },
+    {
+      "id": "Meta-Llama-3.1-8B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "sambanova"
+      },
+      "name": "Llama 3.1 8B"
+    },
+    {
+      "id": "Meta-Llama-3.1-70B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "sambanova"
+      },
+      "name": "Llama 3.1 70B"
+    },
+    {
+      "id": "Meta-Llama-3.1-405B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "sambanova"
+      },
+      "name": "Llama 3.1 405B"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3.1-8B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3.1 8B Instruct Turbo"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3.1-70B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3.1 70B Instruct Turbo"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3.1-405B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3.1 405B Instruct Turbo"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3-8B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3 8B Instruct Turbo"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3-70B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3 70B Instruct Turbo"
+    },
+    {
+      "id": "meta-llama/Llama-3.2-3B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3.2 3B Instruct Turbo"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3-8B-Instruct-Lite",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3 8B Instruct Lite"
+    },
+    {
+      "id": "meta-llama/Meta-Llama-3-70B-Instruct-Lite",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3 70B Instruct Lite"
+    },
+    {
+      "id": "meta-llama/Llama-3-8b-chat-hf",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3 8B Instruct Reference"
+    },
+    {
+      "id": "meta-llama/Llama-3-70b-chat-hf",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3 70B Instruct Reference"
+    },
+    {
+      "id": "microsoft/WizardLM-2-8x22B",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "WizardLM-2 8x22B"
+    },
+    {
+      "id": "google/gemma-2-27b-it",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Gemma 2 27B"
+    },
+    {
+      "id": "google/gemma-2-9b-it",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Gemma 2 9B"
+    },
+    {
+      "id": "databricks/dbrx-instruct",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "DBRX Instruct"
+    },
+    {
+      "id": "deepseek-ai/deepseek-llm-67b-chat",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "DeepSeek LLM Chat (67B)"
+    },
+    {
+      "id": "google/gemma-2b-it",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Gemma Instruct (2B)"
+    },
+    {
+      "id": "Gryphe/MythoMax-L2-13b",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "MythoMax-L2 (13B)"
+    },
+    {
+      "id": "meta-llama/Llama-2-13b-chat-hf",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "LLaMA-2 Chat (13B)"
+    },
+    {
+      "id": "mistralai/Mistral-7B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Mistral (7B) Instruct"
+    },
+    {
+      "id": "mistralai/Mistral-7B-Instruct-v0.2",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Mistral (7B) Instruct v0.2"
+    },
+    {
+      "id": "mistralai/Mistral-7B-Instruct-v0.3",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Mistral (7B) Instruct v0.3"
+    },
+    {
+      "id": "mistralai/Mixtral-8x7B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Mixtral-8x7B Instruct (46.7B)"
+    },
+    {
+      "id": "mistralai/Mixtral-8x22B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Mixtral-8x22B Instruct (141B)"
+    },
+    {
+      "id": "NousResearch/Nous-Hermes-2-Mixtral-8x7B-DPO",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Nous Hermes 2 - Mixtral 8x7B-DPO (46.7B)"
+    },
+    {
+      "id": "Qwen/Qwen2.5-7B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Qwen 2.5 7B Instruct Turbo"
+    },
+    {
+      "id": "Qwen/Qwen2.5-72B-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Qwen 2.5 72B Instruct Turbo"
+    },
+    {
+      "id": "Qwen/Qwen2-72B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Qwen 2 Instruct (72B)"
+    },
+    {
+      "id": "togethercomputer/StripedHyena-Nous-7B",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "StripedHyena Nous (7B)"
+    },
+    {
+      "id": "upstage/SOLAR-10.7B-Instruct-v1.0",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Upstage SOLAR Instruct v1 (11B)"
+    },
+    {
+      "id": "black-forest-labs/FLUX.1-schnell-Free",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Flux.1 [schnell] (free)*"
+    },
+    {
+      "id": "black-forest-labs/FLUX.1-schnell",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Flux.1 [schnell] (Turbo)"
+    },
+    {
+      "id": "black-forest-labs/FLUX.1.1-pro",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Flux1.1 [pro]"
+    },
+    {
+      "id": "black-forest-labs/FLUX.1-pro",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Flux.1 [pro]"
+    },
+    {
+      "id": "stabilityai/stable-diffusion-xl-base-1.0",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Stable Diffusion XL 1.0"
+    },
+    {
+      "id": "togethercomputer/m2-bert-80M-2k-retrieval",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "M2-BERT-80M-2K-Retrieval"
+    },
+    {
+      "id": "togethercomputer/m2-bert-80M-8k-retrieval",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "M2-BERT-80M-8K-Retrieval"
+    },
+    {
+      "id": "togethercomputer/m2-bert-80M-32k-retrieval",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "M2-BERT-80M-32K-Retrieval"
+    },
+    {
+      "id": "WhereIsAI/UAE-Large-V1",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "UAE-Large-v1"
+    },
+    {
+      "id": "BAAI/bge-large-en-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "BGE-Large-EN-v1.5"
+    },
+    {
+      "id": "BAAI/bge-base-en-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "BGE-Base-EN-v1.5"
+    },
+    {
+      "id": "sentence-transformers/msmarco-bert-base-dot-v5",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Sentence-BERT"
+    },
+    {
+      "id": "bert-base-uncased",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "BERT"
+    },
+    {
+      "id": "meta-llama/Llama-Vision-Free",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "(Free) Llama 3.2 11B Vision Instruct Turbo*"
+    },
+    {
+      "id": "meta-llama/Llama-3.2-11B-Vision-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3.2 11B Vision Instruct Turbo"
+    },
+    {
+      "id": "meta-llama/Llama-3.2-90B-Vision-Instruct-Turbo",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama 3.2 90B Vision Instruct Turbo"
+    },
+    {
+      "id": "meta-llama/Llama-2-70b-hf",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "LLaMA-2 (70B)"
+    },
+    {
+      "id": "mistralai/Mistral-7B-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Mistral (7B)"
+    },
+    {
+      "id": "mistralai/Mixtral-8x7B-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Mixtral-8x7B (46.7B)"
+    },
+    {
+      "id": "Meta-Llama/Llama-Guard-7b",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "Llama Guard (7B)"
+    },
+    {
+      "id": "Salesforce/Llama-Rank-v1",
+      "object": "model",
+      "provider": {
+        "id": "together-ai"
+      },
+      "name": "LlamaRank"
+    },
+    {
+      "id": "dracarys2-72b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Dracarys 2 72B Instruct"
+    },
+    {
+      "id": "hermes3-405b",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Hermes 3 405B"
+    },
+    {
+      "id": "hermes3-405b-fp8-128k",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Hermes 3 405B FP8 128K"
+    },
+    {
+      "id": "hermes3-70b",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Hermes 3 70B"
+    },
+    {
+      "id": "hermes3-8b",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Hermes 3 8B"
+    },
+    {
+      "id": "lfm-40b",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "LFM 40B"
+    },
+    {
+      "id": "llama3.1-405b-instruct-fp8",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Llama 3.1 405B Instruct FP8"
+    },
+    {
+      "id": "llama3.1-70b-instruct-fp8",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Llama 3.1 70B Instruct FP8"
+    },
+    {
+      "id": "llama3.1-8b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Llama 3.1 8B Instruct"
+    },
+    {
+      "id": "llama3.2-3b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Llama 3.2 3B Instruct"
+    },
+    {
+      "id": "llama3.1-nemotron-70b-instruct",
+      "object": "model",
+      "provider": {
+        "id": "lambda"
+      },
+      "name": "Llama 3.1 Nemotron 70B Instruct"
+    },
+    {
+      "id": "llama-8b-chat",
+      "object": "model",
+      "provider": {
+        "id": "lemonfox-ai"
+      },
+      "name": "Llama 3.1 8B"
+    },
+    {
+      "id": "llama-70b-chat",
+      "object": "model",
+      "provider": {
+        "id": "lemonfox-ai"
+      },
+      "name": "Llama 3.1 70B"
+    },
+    {
+      "id": "mixtral-chat",
+      "object": "model",
+      "provider": {
+        "id": "lemonfox-ai"
+      },
+      "name": "Mixtral Chat"
+    },
+    {
+      "id": "embedding-query",
+      "object": "model",
+      "provider": {
+        "id": "upstage"
+      },
+      "name": "Embedding Query"
+    },
+    {
+      "id": "embedding-passage",
+      "object": "model",
+      "provider": {
+        "id": "upstage"
+      },
+      "name": "Embedding Passage"
+    },
+    {
+      "id": "solar-pro-preview-240910",
+      "object": "model",
+      "provider": {
+        "id": "upstage"
+      },
+      "name": "Solar Pro Preview"
+    },
+    {
+      "id": "solar-mini-240612",
+      "object": "model",
+      "provider": {
+        "id": "upstage"
+      },
+      "name": "Solar Mini"
+    },
+    {
+      "id": "solar-mini-ja-240612",
+      "object": "model",
+      "provider": {
+        "id": "upstage"
+      },
+      "name": "Solar Mini Japanese"
+    },
+    {
+      "id": "stable-diffusion-3.5-medium",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Diffusion 3.5 Medium"
+    },
+    {
+      "id": "stable-diffusion-3.5-large",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Diffusion 3.5 Large"
+    },
+    {
+      "id": "stable-diffusion-3.5-large-turbo",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Diffusion 3.5 Large Turbo"
+    },
+    {
+      "id": "stable-diffusion-3-medium",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Diffusion 3 Medium"
+    },
+    {
+      "id": "sdxl-turbo",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Diffusion XL Turbo"
+    },
+    {
+      "id": "sd-turbo",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Diffusion Turbo"
+    },
+    {
+      "id": "stable-video-diffusion-img2vid",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Video Diffusion Img2Vid"
+    },
+    {
+      "id": "stable-video-diffusion-img2vid-xt",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Video Diffusion Img2Vid XT"
+    },
+    {
+      "id": "stable-video-diffusion-img2vid-xt-1-1",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Video Diffusion Img2Vid XT 1.1"
+    },
+    {
+      "id": "japanese-stable-diffusion-xl",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Japanese Stable Diffusion XL"
+    },
+    {
+      "id": "japanese-stable-clip-vit-l-16",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Japanese Stable Diffusion CLIP Vit-L-16"
+    },
+    {
+      "id": "stablelm-2-12b",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "StableLM 2 12B"
+    },
+    {
+      "id": "lityai/stablelm-2-1_6b-zephyr",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "StableLM 2 1.6B Zephyr"
+    },
+    {
+      "id": "stablelm-zephyr-3b",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "StableLM Zephyr 3B"
+    },
+    {
+      "id": "japanese-stablelm-2-instruct-1_6b",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Japanese StableLM 2 Instruct 1.6B"
+    },
+    {
+      "id": "japanese-stable-vlm",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Japanese StableVLM"
+    },
+    {
+      "id": "stable-code-3b",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Code 3B"
+    },
+    {
+      "id": "stable-fast-3d",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Fast 3D"
+    },
+    {
+      "id": "stable-zero123",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Zero123"
+    },
+    {
+      "id": "sv3d",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable 3D"
+    },
+    {
+      "id": "stable-audio-open-1.0",
+      "object": "model",
+      "provider": {
+        "id": "stability-ai"
+      },
+      "name": "Stable Audio Open 1.0"
+    },
+    {
+      "id": "gemini-1.5-pro-002",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Gemini 1.5 Pro"
+    },
+    {
+      "id": "gemini-1.5-flash-002",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Gemini 1.5 Flash"
+    },
+    {
+      "id": "gemini-pro",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Gemini 1.0 Pro"
+    },
+    {
+      "id": "gemini-pro-vision",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Gemini 1.0 Pro Vision"
+    },
+    {
+      "id": "imagen-3.0-generate-001",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Imagen for Generation and Editing"
+    },
+    {
+      "id": "imagegeneration",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Imagen 2 for Generation and Editing"
+    },
+    {
+      "id": "claude-3-5-sonnet-v2",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Claude 3.5 Sonnet v2"
+    },
+    {
+      "id": "claude-3-opus",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Claude 3 Opus"
+    },
+    {
+      "id": "claude-3-haiku",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Claude 3 Haiku"
+    },
+    {
+      "id": "gemma2",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Gemma 2"
+    },
+    {
+      "id": "paligemma",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "PaliGemma"
+    },
+    {
+      "id": "gemma",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Gemma"
+    },
+    {
+      "id": "codegemma",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "CodeGemma"
+    },
+    {
+      "id": "llama-3.1-405b-instruct-maas",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Llama 3.1 API Service"
+    },
+    {
+      "id": "llama-3.2-90b-vision-instruct-maas",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Llama 3.2 API Service"
+    },
+    {
+      "id": "llama3_1",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Llama 3.1"
+    },
+    {
+      "id": "llama3-2",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Llama 3.2"
+    },
+    {
+      "id": "llama3",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Llama 3"
+    },
+    {
+      "id": "llama-guard",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Llama Guard"
+    },
+    {
+      "id": "prompt-guard",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Prompt Guard"
+    },
+    {
+      "id": "llama2",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Llama 2"
+    },
+    {
+      "id": "mistral-large",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Mistral Large (2407)"
+    },
+    {
+      "id": "mistral-nemo",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Mistral Nemo"
+    },
+    {
+      "id": "codestral",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Codestral"
+    },
+    {
+      "id": "jamba-1.5-large",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Jamba 1.5 Large (Preview)"
+    },
+    {
+      "id": "jamba-1.5-mini",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Jamba 1.5 Mini (Preview)"
+    },
+    {
+      "id": "mixtral",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Mixtral"
+    },
+    {
+      "id": "chat-bison",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "PaLM 2 Chat Bison"
+    },
+    {
+      "id": "text-bison",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "PaLM 2 Text Bison"
+    },
+    {
+      "id": "claude-3-5-sonnet",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Claude 3.5 Sonnet"
+    },
+    {
+      "id": "claude-3-sonnet",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Claude 3 Sonnet"
+    },
+    {
+      "id": "whisper-large",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Whisper Large"
+    },
+    {
+      "id": "chirp-2",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Chirp 2"
+    },
+    {
+      "id": "image-segmentation-001",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Vertex Image Segmentation"
+    },
+    {
+      "id": "flux1-schnell",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Flux"
+    },
+    {
+      "id": "phi3",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Phi-3"
+    },
+    {
+      "id": "qwen2",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Qwen2"
+    },
+    {
+      "id": "mammut",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "MaMMUT"
+    },
+    {
+      "id": "e5",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "E5 Text Embedding"
+    },
+    {
+      "id": "timesfm",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "TimesFM 1.0"
+    },
+    {
+      "id": "stable-diffusion-xl-lightning",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Stable Diffusion XL Lightning"
+    },
+    {
+      "id": "instant-id",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Instant ID"
+    },
+    {
+      "id": "stable-diffusion-xl-lcm",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Stable Diffusion XL LCM"
+    },
+    {
+      "id": "pytorch-llava",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "LLaVA 1.5"
+    },
+    {
+      "id": "lama",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "LaMa (Large Mask Inpainting)"
+    },
+    {
+      "id": "lmsys-vicuna-7b",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Vicuna"
+    },
+    {
+      "id": "bio-gpt",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "BioGPT"
+    },
+    {
+      "id": "jax-owl-vit-v2",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "OWL-ViT v2"
+    },
+    {
+      "id": "dito",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "DITO"
+    },
+    {
+      "id": "microsoft-biomedclip",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "BiomedCLIP"
+    },
+    {
+      "id": "mistral",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Mistral Self-host (7B & Nemo)"
+    },
+    {
+      "id": "nllb",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "NLLB"
+    },
+    {
+      "id": "codellama-7b-hf",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Code Llama"
+    },
+    {
+      "id": "stable-diffusion-xl-base",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Stable Diffusion XL"
+    },
+    {
+      "id": "openclip",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "OpenCLIP"
+    },
+    {
+      "id": "f-vlm-jax",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "F-VLM"
+    },
+    {
+      "id": "llama-2-quantized",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Llama 2 (Quantized)"
+    },
+    {
+      "id": "stable-diffusion-2-1",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Stable Diffusion v2.1"
+    },
+    {
+      "id": "bert-base-uncased",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "BERT (PEFT)"
+    },
+    {
+      "id": "falcon-instruct-7b-peft",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Falcon-instruct (PEFT)"
+    },
+    {
+      "id": "openllama",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "OpenLLaMA (PEFT)"
+    },
+    {
+      "id": "roberta-large",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "RoBERTa-large (PEFT)"
+    },
+    {
+      "id": "xlm-roberta-large",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "XLM-RoBERTa-large (PEFT)"
+    },
+    {
+      "id": "stable-diffusion-4x-upscaler",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Stable-diffusion-4x-upscaler"
+    },
+    {
+      "id": "segment-anything",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Segment Anything (SAM)"
+    },
+    {
+      "id": "bart-large-cnn",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Bart-large-cnn"
+    },
+    {
+      "id": "dolly-v2",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Dolly-v2"
+    },
+    {
+      "id": "imagetext",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Imagen for Captioning & VQA"
+    },
+    {
+      "id": "stable-diffusion-v1-4",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Stable Diffusion 1.4 (Keras)"
+    },
+    {
+      "id": "chirp-rnnt1",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Chirp"
+    },
+    {
+      "id": "label-detector-pali-001",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Label detector (PaLI zero-shot)"
+    },
+    {
+      "id": "codechat-bison",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Codey for Code Chat"
+    },
+    {
+      "id": "code-bison",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Codey for Code Generation"
+    },
+    {
+      "id": "code-gecko",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Codey for Code Completion"
+    },
+    {
+      "id": "text-unicorn",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "PaLM 2 Text Unicorn"
+    },
+    {
+      "id": "textembedding-gecko",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Embeddings for Text"
+    },
+    {
+      "id": "t5-flan",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "T5-FLAN"
+    },
+    {
+      "id": "t5-1.1",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "T5-1.1"
+    },
+    {
+      "id": "blip2-opt-2.7-b",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "BLIP2"
+    },
+    {
+      "id": "instruct-pix2pix",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "InstructPix2Pix"
+    },
+    {
+      "id": "stable-diffusion-inpainting",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Stable Diffusion Inpainting"
+    },
+    {
+      "id": "control-net",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "ControlNet"
+    },
+    {
+      "id": "bert-base",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "BERT"
+    },
+    {
+      "id": "layoutlm-document-qa",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "LayoutLM for VQA"
+    },
+    {
+      "id": "vilt-b32-finetuned-vqa",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "ViLT VQA"
+    },
+    {
+      "id": "vit-gpt2-image-captioning",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "ViT GPT2"
+    },
+    {
+      "id": "owlvit-base-patch32",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "OWL-ViT"
+    },
+    {
+      "id": "clip-vit-base-patch32",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "CLIP"
+    },
+    {
+      "id": "blip-vqa-base",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "BLIP VQA"
+    },
+    {
+      "id": "blip-image-captioning-base",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "BLIP image captioning"
+    },
+    {
+      "id": "multimodalembedding",
+      "object": "model",
+      "provider": {
+        "id": "vertex-ai"
+      },
+      "name": "Embeddings for Multimodal"
+    },
+    {
+      "id": "Gryphe/MythoMax-L2-13b",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "MythoMax L2 13B"
+    },
+    {
+      "id": "Gryphe/MythoMax-L2-13b-turbo",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "MythoMax L2 13B Turbo"
+    },
+    {
+      "id": "HuggingFaceH4/zephyr-orpo-141b-A35b-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Zephyr Orpo 141B A35b v0.1"
+    },
+    {
+      "id": "KoboldAI/LLaMA2-13B-Tiefighter",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "LLaMA 2 13B Tiefighter"
+    },
+    {
+      "id": "NousResearch/Hermes-3-Llama-3.1-405B",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Hermes 3 Llama 3.1 405B"
+    },
+    {
+      "id": "Phind/Phind-CodeLlama-34B-v2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Phind CodeLlama 34B v2"
+    },
+    {
+      "id": "Qwen/Qwen2-72B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Qwen 2 72B Instruct"
+    },
+    {
+      "id": "Qwen/Qwen2.5-Coder-7B",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Qwen 2.5 Coder 7B"
+    },
+    {
+      "id": "Sao10K/L3-70B-Euryale-v2.1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "L3 70B Euryale v2.1"
+    },
+    {
+      "id": "Sao10K/L3.1-70B-Euryale-v2.2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "L3.1 70B Euryale v2.2"
+    },
+    {
+      "id": "bigcode/starcoder2-15b",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Starcoder 2 15B"
+    },
+    {
+      "id": "bigcode/starcoder2-15b-instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Starcoder 2 15B Instruct v0.1"
+    },
+    {
+      "id": "codellama/CodeLlama-34b-Instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "CodeLlama 34B Instruct HF"
+    },
+    {
+      "id": "codellama/CodeLlama-70b-Instruct-hf",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "CodeLlama 70B Instruct HF"
+    },
+    {
+      "id": "cognitivecomputations/dolphin-2.6-mixtral-8x7b",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Dolphin 2.6 Mixtral 8x7B"
+    },
+    {
+      "id": "cognitivecomputations/dolphin-2.9.1-llama-3-70b",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Dolphin 2.9.1 Llama 3 70B"
+    },
+    {
+      "id": "databricks/dbrx-instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "DBRX Instruct"
+    },
+    {
+      "id": "deepinfra/airoboros-70b",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Airoboros 70B"
+    },
+    {
+      "id": "google/codegemma-7b-it",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "CodeGemma 7B IT"
+    },
+    {
+      "id": "google/gemma-1.1-7b-it",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Gemma 1.1 7B IT"
+    },
+    {
+      "id": "google/gemma-2-27b-it",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Gemma 2 27B IT"
+    },
+    {
+      "id": "google/gemma-2-9b-it",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Gemma 2 9B IT"
+    },
+    {
+      "id": "lizpreciatior/lzlv_70b_fp16_hf",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "LzLV 70B FP16 HF"
+    },
+    {
+      "id": "mattshumer/Reflection-Llama-3.1-70B",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Reflection Llama 3.1 70B"
+    },
+    {
+      "id": "Llama-2-13b-chat-hf",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Llama 2 13B Chat HF"
+    },
+    {
+      "id": "Llama-2-70b-chat-hf",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Llama 2 70B Chat HF"
+    },
+    {
+      "id": "Llama-2-7b-chat-hf",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Llama 2 7B Chat HF"
+    },
+    {
+      "id": "Llama-3.2-1B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Llama 3.2 1B Instruct"
+    },
+    {
+      "id": "Llama-3.2-3B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Llama 3.2 3B Instruct"
+    },
+    {
+      "id": "Meta-Llama-3-70B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Meta Llama 3 70B Instruct"
+    },
+    {
+      "id": "Meta-Llama-3-8B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Meta Llama 3 8B Instruct"
+    },
+    {
+      "id": "Phi-3-medium-4k-instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Phi 3 Medium 4K Instruct"
+    },
+    {
+      "id": "WizardLM-2-7B",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "WizardLM 2 7B"
+    },
+    {
+      "id": "Mistral-7B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Mistral 7B Instruct v0.1"
+    },
+    {
+      "id": "Mistral-7B-Instruct-v0.2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Mistral 7B Instruct v0.2"
+    },
+    {
+      "id": "Mistral-7B-Instruct-v0.3",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Mistral 7B Instruct v0.3"
+    },
+    {
+      "id": "Mistral-Nemo-Instruct-2407",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Mistral Nemo Instruct 2407"
+    },
+    {
+      "id": "Mixtral-8x22B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Mixtral 8x22B Instruct v0.1"
+    },
+    {
+      "id": "Mixtral-8x22B-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Mixtral 8x22B v0.1"
+    },
+    {
+      "id": "Mixtral-8x7B-Instruct-v0.1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Mixtral 8x7B Instruct v0.1"
+    },
+    {
+      "id": "Nemotron-4-340B-Instruct",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Nemotron 4 340B Instruct"
+    },
+    {
+      "id": "MiniCPM-Llama3-V-2_5",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "MiniCPM Llama3 V 2.5"
+    },
+    {
+      "id": "openchat/openchat_3.5",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "OpenChat 3.5"
+    },
+    {
+      "id": "openchat/openchat-3.6-8b",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "OpenChat 3.6 8B"
+    },
+    {
+      "id": "stabilityai/sd3.5",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Stable Diffusion 3.5"
+    },
+    {
+      "id": "black-forest-labs/FLUX-1.1-pro",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "FLUX 1.1 Pro"
+    },
+    {
+      "id": "black-forest-labs/FLUX-1-schnell",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "FLUX 1 Schnell"
+    },
+    {
+      "id": "black-forest-labs/FLUX-1-dev",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "FLUX 1 Dev"
+    },
+    {
+      "id": "black-forest-labs/FLUX-pro",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "FLUX Pro"
+    },
+    {
+      "id": "stabilityai/sd3.5-medium",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Stable Diffusion 3.5 Medium"
+    },
+    {
+      "id": "CompVis/stable-diffusion-v1-4",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Stable Diffusion v1-4"
+    },
+    {
+      "id": "XpucT/Deliberate",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Deliberate"
+    },
+    {
+      "id": "prompthero/openjourney",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "OpenJourney"
+    },
+    {
+      "id": "runwayml/stable-diffusion-v1-5",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Stable Diffusion v1-5"
+    },
+    {
+      "id": "stabilityai/sdxl-turbo",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "SDXL Turbo"
+    },
+    {
+      "id": "stabilityai/stable-diffusion-2-1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Stable Diffusion 2.1"
+    },
+    {
+      "id": "openai/whisper-large-v3-turbo",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Large v3 Turbo"
+    },
+    {
+      "id": "openai/whisper-large-v3",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Large v3"
+    },
+    {
+      "id": "distil-whisper/distil-large-v3",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Distil Whisper Large v3"
+    },
+    {
+      "id": "openai/whisper-base",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Base"
+    },
+    {
+      "id": "openai/whisper-base.en",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Base English"
+    },
+    {
+      "id": "openai/whisper-large",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Large"
+    },
+    {
+      "id": "openai/whisper-medium",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Medium"
+    },
+    {
+      "id": "openai/whisper-medium.en",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Medium English"
+    },
+    {
+      "id": "openai/whisper-small",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Small"
+    },
+    {
+      "id": "openai/whisper-small.en",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Small English"
+    },
+    {
+      "id": "openai/whisper-timestamped-medium",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Timestamped Medium"
+    },
+    {
+      "id": "openai/whisper-timestamped-medium.en",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Timestamped Medium English"
+    },
+    {
+      "id": "openai/whisper-tiny",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Tiny"
+    },
+    {
+      "id": "openai/whisper-tiny.en",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Whisper Tiny English"
+    },
+    {
+      "id": "BAAI/bge-base-en-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "BGE Base EN v1.5"
+    },
+    {
+      "id": "BAAI/bge-large-en-v1.5",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "BGE Large EN v1.5"
+    },
+    {
+      "id": "BAAI/bge-m3",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "BGE M3"
+    },
+    {
+      "id": "intfloat/e5-base-v2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "E5 Base v2"
+    },
+    {
+      "id": "intfloat/e5-large-v2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "E5 Large v2"
+    },
+    {
+      "id": "intfloat/multilingual-e5-large",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Multilingual E5 Large"
+    },
+    {
+      "id": "sentence-transformers/all-MiniLM-L12-v2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "All-MiniLM-L12-v2"
+    },
+    {
+      "id": "sentence-transformers/all-MiniLM-L6-v2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "All-MiniLM-L6-v2"
+    },
+    {
+      "id": "sentence-transformers/all-mpnet-base-v2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "All-MPNet-base-v2"
+    },
+    {
+      "id": "sentence-transformers/clip-ViT-B-32",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "CLIP ViT-B-32"
+    },
+    {
+      "id": "sentence-transformers/clip-ViT-B-32-multilingual-v1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "CLIP ViT-B-32 Multilingual v1"
+    },
+    {
+      "id": "sentence-transformers/multi-qa-mpnet-base-dot-v1",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Multi-QA-MPNet-base-dot-v1"
+    },
+    {
+      "id": "sentence-transformers/paraphrase-MiniLM-L6-v2",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Paraphrase-MiniLM-L6-v2"
+    },
+    {
+      "id": "shibing624/text2vec-base-chinese",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "Text2Vec-Base-Chinese"
+    },
+    {
+      "id": "thenlper/gte-base",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "GTE Base"
+    },
+    {
+      "id": "thenlper/gte-large",
+      "object": "model",
+      "provider": {
+        "id": "deepinfra"
+      },
+      "name": "GTE Large"
+    },
+    {
+      "id": "jina-embeddings-v2-base-en",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Embeddings v2 Base English"
+    },
+    {
+      "id": "jina-embeddings-v2-base-zh",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Embeddings v2 Base Chinese"
+    },
+    {
+      "id": "jina-embeddings-v2-base-de",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Embeddings v2 Base German"
+    },
+    {
+      "id": "jina-embeddings-v2-base-code",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Embeddings v2 Base Code"
+    },
+    {
+      "id": "jina-embeddings-v2-base-es",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Embeddings v2 Base Spanish"
+    },
+    {
+      "id": "jina-colbert-v1-en",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Colbert v1 English"
+    },
+    {
+      "id": "jina-reranker-v1-base-en",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Reranker v1 Base English"
+    },
+    {
+      "id": "jina-reranker-v1-turbo-en",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Reranker v1 Turbo English"
+    },
+    {
+      "id": "jina-reranker-v1-tiny-en",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Reranker v1 Tiny English"
+    },
+    {
+      "id": "jina-clip-v1",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina CLIP v1"
+    },
+    {
+      "id": "jina-reranker-v2-base-multilingual",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Reranker v2 Base Multilingual"
+    },
+    {
+      "id": "jina-colbert-v2",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Colbert v2"
+    },
+    {
+      "id": "jina-embeddings-v3",
+      "object": "model",
+      "provider": {
+        "id": "jina"
+      },
+      "name": "Jina Embeddings v3"
+    }
+  ]
 }

--- a/src/data/providers.json
+++ b/src/data/providers.json
@@ -1,307 +1,307 @@
 {
-    "object": "list",
-    "version": "1.0.0",
-    "data": [
-        {
-            "id": "ai21",
-            "name": "AI21",
-            "object": "provider",
-            "description": "AI21 Labs specializes in developing advanced natural language processing models, notably their flagship model, Jurassic-2. They focus on creating tools that enhance human-computer interaction, enabling applications like text generation, summarization, and dialogue systems. Their platform encourages developers to build and integrate AI capabilities into various applications through user-friendly APIs.",
-            "base_url": "https://api.ai21.com/studio/v1"
-        },
-        {
-            "id": "anthropic",
-            "name": "Anthropic",
-            "object": "provider",
-            "description": "Anthropic is an AI research company focused on creating safe and interpretable AI systems. Their flagship model, Claude, is designed to prioritize user alignment and ethical considerations in AI interactions. Anthropic emphasizes transparency and safety in AI development, aiming to build models that can be trusted in sensitive applications.",
-            "base_url": "https://api.anthropic.com/v1/messages"
-        },
-        {
-            "id": "anyscale",
-            "name": "Anyscale",
-            "object": "provider",
-            "description": "Anyscale provides a platform for building and deploying distributed applications with a focus on large language models. Their technology simplifies the scaling of machine learning workloads, enabling developers to efficiently run LLMs in production. Anyscale's tools support various frameworks and enhance collaboration among data scientists and engineers.",
-            "base_url": "https://api.endpoints.anyscale.com/v1"
-        },
-        {
-            "id": "bedrock",
-            "name": "AWS Bedrock",
-            "object": "provider",
-            "description": "AWS Bedrock is a fully managed service that offers access to high-performing foundation models from leading AI companies. It allows users to customize these models with their own data while providing a secure environment for building generative AI applications. The platform streamlines experimentation and integration into existing workflows without requiring infrastructure management.",
-            "base_url": ""
-        },
-        {
-            "id": "azure-openai",
-            "name": "Azure OpenAI",
-            "object": "provider",
-            "description": "Azure OpenAI Service integrates OpenAI's powerful models into Microsoft's cloud ecosystem, enabling businesses to leverage advanced AI capabilities securely. Users can access models like GPT-4 for various applications such as chatbots, content generation, and more. Azure's infrastructure ensures scalability and compliance with enterprise standards.",
-            "base_url": ""
-        },
-        {
-            "id": "cerebras",
-            "name": "Cerebras",
-            "object": "provider",
-            "description": "Cerebras Systems focuses on high-performance computing solutions for deep learning, featuring the world's largest chip designed specifically for AI workloads. Their technology accelerates model training and inference, making it suitable for large-scale deployments of language models. Cerebras aims to reduce the time and cost associated with training complex neural networks.",
-            "base_url": "https://api.cerebras.ai/v1"
-        },
-        {
-            "id": "cohere",
-            "name": "Cohere",
-            "object": "provider",
-            "description": "Cohere specializes in providing natural language processing capabilities through its API, allowing developers to build applications that understand and generate human-like text. Their models are designed for tasks such as semantic search, content creation, and chatbots. Cohere emphasizes ease of use and accessibility for businesses looking to implement NLP solutions.",
-            "base_url": "https://api.cohere.ai/v1"
-        },
-        {
-            "id": "deepbricks",
-            "name": "Deepbricks",
-            "object": "provider",
-            "description": "Deepbricks offers a platform for building and deploying large language models tailored for specific business needs. They focus on providing customizable solutions that enhance productivity across various sectors. Deepbricks aims to simplify the integration of AI into existing workflows while ensuring high performance.",
-            "base_url": "https://api.deepbricks.ai/v1"
-        },
-        {
-            "id": "deepinfra",
-            "name": "Deepinfra",
-            "object": "provider",
-            "description": "Deepinfra specializes in optimizing the deployment of machine learning models at scale. Their platform provides tools for managing infrastructure requirements efficiently while ensuring low-latency access to AI capabilities. Deepinfra focuses on enhancing operational efficiency for businesses leveraging LLMs.",
-            "base_url": "https://api.deepinfra.com/v1/openai"
-        },
-        {
-            "id": "deepseek",
-            "name": "DeepSeek",
-            "object": "provider",
-            "description": "DeepSeek develops advanced search technologies powered by large language models. Their solutions aim to improve information retrieval across various domains by enhancing search accuracy and relevance. DeepSeek focuses on integrating AI into existing search infrastructures to provide smarter results.",
-            "base_url": "https://api.deepseek.com"
-        },
-        {
-            "id": "fireworks-ai",
-            "name": "Fireworks",
-            "object": "provider",
-            "description": "Fireworks is a platform that leverages large language models to automate workflows in various industries. It provides tools for integrating AI into everyday tasks, enhancing productivity through intelligent automation. Fireworks aims to simplify complex processes by using natural language understanding.",
-            "base_url": "https://api.fireworks.ai/inference/v1"
-        },
-        {
-            "id": "google",
-            "name": "Google Gemini",
-            "object": "provider",
-            "description": "Google Gemini is part of Google's suite of AI tools designed for natural language understanding and generation. It focuses on providing robust solutions for developers looking to integrate conversational AI capabilities into their applications. Gemini emphasizes scalability and performance within Google's cloud ecosystem.",
-            "base_url": "https://generativelanguage.googleapis.com/v1beta"
-        },
-        {
-            "id": "palm",
-            "name": "Google Palm",
-            "object": "provider",
-            "description": "Google's PaLM (Pathways Language Model) is designed for advanced natural language understanding tasks, supporting a wide range of applications from chatbots to content generation. PaLM utilizes cutting-edge architecture to improve efficiency and accuracy in processing language-based tasks.",
-            "base_url": "https://generativelanguage.googleapis.com/v1beta3"
-        },
-        {
-            "id": "vertex-ai",
-            "name": "Google Vertex AI",
-            "object": "provider",
-            "description": "Google Vertex AI offers a comprehensive suite of tools for building, deploying, and managing machine learning models at scale. It integrates seamlessly with other Google Cloud services, providing developers with robust resources for leveraging large language models in their applications.",
-            "base_url": ""
-        },
-        {
-            "id": "groq",
-            "name": "Groq",
-            "object": "provider",
-            "description": "Groq specializes in high-performance inference solutions for large language models, boasting significant speed advantages over competitors. Their custom hardware architecture is optimized for running LLMs efficiently, making it suitable for real-time applications where low latency is crucial.",
-            "base_url": "https://api.groq.com/openai/v1"
-        },
-        {
-            "id": "huggingface",
-            "name": "Hugging Face",
-            "object": "provider",
-            "description": "Hugging Face is a leading platform in the open-source machine learning community, known for its Transformers library that provides access to numerous pre-trained LLMs. The platform fosters collaboration among researchers and developers while offering tools for fine-tuning and deploying NLP models across various use cases.",
-            "base_url": ""
-        },
-        {
-            "id": "inference-net",
-            "name": "Inference.net",
-            "object": "provider",
-            "description": "Inference.net focuses on delivering scalable inference solutions tailored for large language models. Their platform aims to optimize the deployment of ML models in production environments, ensuring low latency and high throughput for real-time applications.",
-            "base_url": "https://api.inference.net/v1"
-        },
-        {
-            "id": "jina",
-            "name": "Jina AI",
-            "object": "provider",
-            "description": "Jina AI specializes in neural search technologies powered by large language models. Their framework allows developers to build search engines that understand natural language queries effectively, enhancing information retrieval across diverse datasets.",
-            "base_url": "https://api.jina.ai/v1"
-        },
-        {
-            "id": "lingyi",
-            "name": "Lingyi (01.ai)",
-            "object": "provider",
-            "description": "Lingyi (01.ai) develops cutting-edge natural language processing technologies aimed at improving human-computer interaction through conversational interfaces. They focus on creating user-friendly tools that enable businesses to integrate advanced NLP capabilities seamlessly.",
-            "base_url": "https://api.lingyiwanwu.com"
-        },
-        {
-            "id": "localai",
-            "name": "LocalAI",
-            "object": "provider",
-            "description": "LocalAI provides solutions that enable organizations to run large language models locally rather than relying on cloud services. This approach enhances data privacy and control while allowing users to customize their LLM deployments according to specific needs.",
-            "base_url": ""
-        },
-        {
-            "id": "mistral-ai",
-            "name": "Mistral AI",
-            "object": "provider",
-            "description": "Mistral AI focuses on developing efficient large language models optimized for performance across various tasks such as text generation and question answering. Their technology aims at reducing computational costs while maintaining high-quality outputs suitable for enterprise applications.",
-            "base_url": "https://api.mistral.ai/v1"
-        },
-        {
-            "id": "monsterapi",
-            "name": "Monster API",
-            "object": "provider",
-            "description": "Monster API offers an accessible interface for integrating various large language models into applications, focusing on ease of use and flexibility. The platform enables developers to leverage powerful NLP capabilities without extensive technical knowledge or infrastructure overhead.",
-            "base_url": "https://llm.monsterapi.ai/v1"
-        },
-        {
-            "id": "moonshot",
-            "name": "Moonshot",
-            "object": "provider",
-            "description": "Moonshot develops innovative solutions leveraging large language models aimed at enhancing creativity in content generation processes. Their tools are designed to assist creators by providing intelligent suggestions and automating repetitive tasks within creative workflows.",
-            "base_url": "https://api.moonshot.cn"
-        },
-        {
-            "id": "nomic",
-            "name": "Nomic",
-            "object": "provider",
-            "description": "Nomic focuses on building collaborative tools powered by large language models that facilitate group decision-making processes. Their platform allows teams to harness the power of NLP in brainstorming sessions and project management activities effectively.",
-            "base_url": "https://api-atlas.nomic.ai/v1"
-        },
-        {
-            "id": "novita-ai",
-            "name": "Novita AI",
-            "object": "provider",
-            "description": "Novita AI specializes in creating tailored LLM solutions that cater specifically to industry needs such as finance or healthcare. They emphasize customization and integration capabilities that allow businesses to leverage NLP technologies effectively within their operations.",
-            "base_url": "https://api.novita.ai/v3/openai"
-        },
-        {
-            "id": "ollama",
-            "name": "Ollama",
-            "object": "provider",
-            "description": "Ollama offers a streamlined platform for deploying large language models with an emphasis on user-friendly interfaces and accessibility. They aim to simplify the integration of NLP capabilities into existing systems while providing robust support for developers.",
-            "base_url": ""
-        },
-        {
-            "id": "openai",
-            "name": "OpenAI",
-            "object": "provider",
-            "description": "OpenAI is renowned for its development of advanced artificial intelligence technologies, including the GPT series of large language models. They focus on ensuring safe deployment practices while advancing the state-of-the-art in natural language understanding and generation across various domains.",
-            "base_url": "https://api.openai.com/v1"
-        },
-        {
-            "id": "openrouter",
-            "name": "OpenRouter",
-            "object": "provider",
-            "description": "OpenRouter is an innovative platform that provides unified access to multiple large language models through a single interface. It enables businesses and developers to integrate diverse AI capabilities efficiently while focusing on scalability and cost-effectiveness in their applications.",
-            "base_url": "https://openrouter.ai/api"
-        },
-        {
-            "id": "perplexity-ai",
-            "name": "Perplexity AI",
-            "object": "provider",
-            "description": "Perplexity AI is an advanced research tool designed as a conversational search engine that generates answers using natural language processing techniques. It integrates real-time web data into its responses while offering both free and paid access options tailored towards different user needs.",
-            "base_url": "https://api.perplexity.ai"
-        },
-        {
-            "id": "predibase",
-            "name": "Predibase",
-            "object": "provider",
-            "description": "Predibase specializes in fine-tuning large language models efficiently, providing a robust environment for customizing pre-trained LLMs according to specific tasks or domains. Their platform emphasizes speed, reliability, and cost-effectiveness in serving fine-tuned models at scale.",
-            "base_url": "https://serving.app.predibase.com"
-        },
-        {
-            "id": "reka",
-            "name": "Reka AI",
-            "object": "provider",
-            "description": "Reka AI develops specialized LLMs aimed at enhancing educational technologies through personalized learning experiences. Their focus lies in creating adaptive systems that respond intelligently to individual learner needs using natural language processing techniques.",
-            "base_url": "https://api.reka.ai"
-        },
-        {
-            "id": "sambanova",
-            "name": "SambaNova",
-            "object": "provider",
-            "description": "SambaNova Systems provides hardware-software integrated solutions optimized specifically for running large-scale machine learning workloads efficiently. Their technology aims at accelerating model training times while ensuring high performance during inference phases across diverse applications.",
-            "base_url": "https://api.sambanova.ai"
-        },
-        {
-            "id": "segmind",
-            "name": "Segmind",
-            "object": "provider",
-            "description": "Segmind focuses on simplifying the deployment of machine learning pipelines tailored towards specific business needs involving large language models. Their platform enables organizations to manage model lifecycles effectively while ensuring optimal performance metrics are achieved consistently.",
-            "base_url": "https://api.segmind.com/v1"
-        },
-        {
-            "id": "siliconflow",
-            "name": "SiliconFlow",
-            "object": "provider",
-            "description": "SiliconFlow develops infrastructure solutions designed specifically for optimizing the deployment of artificial intelligence workloads including LLMs at scale within enterprise environments focusing on reliability & performance enhancements throughout all stages from training through inference execution phases effectively minimizing downtime risks associated typically seen during transitions between these stages involved here too!",
-            "base_url": "https://api.siliconflow.cn/v1"
-        },
-        {
-            "id": "stability-ai",
-            "name": "Stability AI",
-            "object": "provider",
-            "description": "Stability AI specializes in creating open-source frameworks around generative artificial intelligence technologies including text-to-image synthesis & other creative outputs leveraging advancements made possible via breakthroughs achieved recently within areas surrounding deep learning methodologies employed throughout this process ensuring accessibility remains key priority here too!",
-            "base_url": "https://api.stability.ai/v1"
-        },
-        {
-            "id": "together-ai",
-            "name": "Together AI",
-            "object": "provider",
-            "description": "Together AI is dedicated to developing open-source large language model frameworks such as OpenChatKit aimed at empowering developers & researchers alike with versatile tools necessary facilitating collaboration within rapidly evolving landscapes surrounding artificial intelligence today!",
-            "base_url": "https://api.together.xyz"
-        },
-        {
-            "id": "voyage",
-            "name": "Voyage AI",
-            "object": "provider",
-            "description": "Voyage AI focuses on developing autonomous navigation systems powered by advanced artificial intelligence techniques including those found within recent iterations seen across various types involving deep reinforcement learning methodologies applied here too!",
-            "base_url": "https://api.voyageai.com/v1"
-        },
-        {
-            "id": "workers-ai",
-            "name": "Workers AI",
-            "object": "provider",
-            "description": "Workers AI by Cloudflare is a platform that leverages Cloudflare's global network to provide developers and businesses with serverless AI infrastructure. It enables scalable, low-latency AI processing directly at the edge, allowing users to deploy machine learning models closer to their data and applications. With easy integration and powerful tools, Workers AI helps optimize workflows, enhance performance, and reduce operational complexity by harnessing the power of AI at a global scale.",
-            "base_url": ""
-        },
-        {
-            "id": "zhipu",
-            "name": "ZhipuAI",
-            "object": "provider",
-            "description": "ZhipuAI specializes in creating conversational agents powered by advanced natural language processing techniques aimed at enhancing customer engagement experiences across diverse industries focusing primarily upon delivering personalized interactions tailored towards individual preferences expressed during engagements encountered here too!",
-            "base_url": "https://open.bigmodel.cn/api/paas/v4"
-        },
-        {
-            "id": "lambda",
-            "name": "Lambda Labs",
-            "object": "provider",
-            "description": "Lambda Labs specializes in AI infrastructure and tools, providing powerful solutions for machine learning and deep learning applications. They offer a range of products, including GPUs optimized for AI workloads, and a comprehensive suite of software tools that streamline the development and deployment of AI models. Their focus is on delivering high-performance computing resources to researchers and enterprises looking to harness the power of artificial intelligence effectively.",
-            "base_url": "https://api.lambdalabs.com/v1"
-        },
-        {
-            "id": "lemonfox-ai",
-            "name": "Lemonfox AI",
-            "object": "provider",
-            "description": "Lemonfox AI is a cost-effective platform that provides advanced capabilities in text generation, chat support, and image creation. It offers an OpenAI-compatible API, making it easy for developers to integrate its features into applications. With support for over 50 languages and tools like the Stable Diffusion XL model for image generation, Lemonfox aims to deliver high-quality results at a fraction of the cost of competitors, making it an attractive option for businesses looking to leverage AI technology.",
-            "base_url": "https://api.lemonfox.ai/v1"
-        },
-        {
-            "id": "upstage",
-            "name": "Upstage",
-            "object": "provider",
-            "description": "Upstage is a South Korean AI company focused on developing innovative large language models (LLMs) and document processing solutions. Their flagship product, Solar LLM, utilizes advanced techniques to deliver high-performance AI capabilities across multiple languages. Upstage emphasizes automation and data-driven insights to enhance business operations, partnering with AWS to expand their generative AI solutions globally and cater to various industry needs.",
-            "base_url": "https://api.upstage.ai/v1/solar"
-        },
-        {
-            "id": "dashscope",
-            "name": "Dashscope",
-            "object": "provider",
-            "description": "Dashscope provides intelligent analytics solutions designed to help businesses visualize and interpret complex data effectively. Their platform integrates advanced machine learning algorithms to generate real-time insights from diverse datasets, enabling organizations to make informed decisions quickly. Dashscope focuses on enhancing data accessibility and usability, empowering teams to leverage analytics for strategic planning and operational efficiency.",
-            "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1"
-        }
-    ]
+  "object": "list",
+  "version": "1.0.0",
+  "data": [
+    {
+      "id": "ai21",
+      "name": "AI21",
+      "object": "provider",
+      "description": "AI21 Labs specializes in developing advanced natural language processing models, notably their flagship model, Jurassic-2. They focus on creating tools that enhance human-computer interaction, enabling applications like text generation, summarization, and dialogue systems. Their platform encourages developers to build and integrate AI capabilities into various applications through user-friendly APIs.",
+      "base_url": "https://api.ai21.com/studio/v1"
+    },
+    {
+      "id": "anthropic",
+      "name": "Anthropic",
+      "object": "provider",
+      "description": "Anthropic is an AI research company focused on creating safe and interpretable AI systems. Their flagship model, Claude, is designed to prioritize user alignment and ethical considerations in AI interactions. Anthropic emphasizes transparency and safety in AI development, aiming to build models that can be trusted in sensitive applications.",
+      "base_url": "https://api.anthropic.com/v1/messages"
+    },
+    {
+      "id": "anyscale",
+      "name": "Anyscale",
+      "object": "provider",
+      "description": "Anyscale provides a platform for building and deploying distributed applications with a focus on large language models. Their technology simplifies the scaling of machine learning workloads, enabling developers to efficiently run LLMs in production. Anyscale's tools support various frameworks and enhance collaboration among data scientists and engineers.",
+      "base_url": "https://api.endpoints.anyscale.com/v1"
+    },
+    {
+      "id": "bedrock",
+      "name": "AWS Bedrock",
+      "object": "provider",
+      "description": "AWS Bedrock is a fully managed service that offers access to high-performing foundation models from leading AI companies. It allows users to customize these models with their own data while providing a secure environment for building generative AI applications. The platform streamlines experimentation and integration into existing workflows without requiring infrastructure management.",
+      "base_url": ""
+    },
+    {
+      "id": "azure-openai",
+      "name": "Azure OpenAI",
+      "object": "provider",
+      "description": "Azure OpenAI Service integrates OpenAI's powerful models into Microsoft's cloud ecosystem, enabling businesses to leverage advanced AI capabilities securely. Users can access models like GPT-4 for various applications such as chatbots, content generation, and more. Azure's infrastructure ensures scalability and compliance with enterprise standards.",
+      "base_url": ""
+    },
+    {
+      "id": "cerebras",
+      "name": "Cerebras",
+      "object": "provider",
+      "description": "Cerebras Systems focuses on high-performance computing solutions for deep learning, featuring the world's largest chip designed specifically for AI workloads. Their technology accelerates model training and inference, making it suitable for large-scale deployments of language models. Cerebras aims to reduce the time and cost associated with training complex neural networks.",
+      "base_url": "https://api.cerebras.ai/v1"
+    },
+    {
+      "id": "cohere",
+      "name": "Cohere",
+      "object": "provider",
+      "description": "Cohere specializes in providing natural language processing capabilities through its API, allowing developers to build applications that understand and generate human-like text. Their models are designed for tasks such as semantic search, content creation, and chatbots. Cohere emphasizes ease of use and accessibility for businesses looking to implement NLP solutions.",
+      "base_url": "https://api.cohere.ai/v1"
+    },
+    {
+      "id": "deepbricks",
+      "name": "Deepbricks",
+      "object": "provider",
+      "description": "Deepbricks offers a platform for building and deploying large language models tailored for specific business needs. They focus on providing customizable solutions that enhance productivity across various sectors. Deepbricks aims to simplify the integration of AI into existing workflows while ensuring high performance.",
+      "base_url": "https://api.deepbricks.ai/v1"
+    },
+    {
+      "id": "deepinfra",
+      "name": "Deepinfra",
+      "object": "provider",
+      "description": "Deepinfra specializes in optimizing the deployment of machine learning models at scale. Their platform provides tools for managing infrastructure requirements efficiently while ensuring low-latency access to AI capabilities. Deepinfra focuses on enhancing operational efficiency for businesses leveraging LLMs.",
+      "base_url": "https://api.deepinfra.com/v1/openai"
+    },
+    {
+      "id": "deepseek",
+      "name": "DeepSeek",
+      "object": "provider",
+      "description": "DeepSeek develops advanced search technologies powered by large language models. Their solutions aim to improve information retrieval across various domains by enhancing search accuracy and relevance. DeepSeek focuses on integrating AI into existing search infrastructures to provide smarter results.",
+      "base_url": "https://api.deepseek.com"
+    },
+    {
+      "id": "fireworks-ai",
+      "name": "Fireworks",
+      "object": "provider",
+      "description": "Fireworks is a platform that leverages large language models to automate workflows in various industries. It provides tools for integrating AI into everyday tasks, enhancing productivity through intelligent automation. Fireworks aims to simplify complex processes by using natural language understanding.",
+      "base_url": "https://api.fireworks.ai/inference/v1"
+    },
+    {
+      "id": "google",
+      "name": "Google Gemini",
+      "object": "provider",
+      "description": "Google Gemini is part of Google's suite of AI tools designed for natural language understanding and generation. It focuses on providing robust solutions for developers looking to integrate conversational AI capabilities into their applications. Gemini emphasizes scalability and performance within Google's cloud ecosystem.",
+      "base_url": "https://generativelanguage.googleapis.com/v1beta"
+    },
+    {
+      "id": "palm",
+      "name": "Google Palm",
+      "object": "provider",
+      "description": "Google's PaLM (Pathways Language Model) is designed for advanced natural language understanding tasks, supporting a wide range of applications from chatbots to content generation. PaLM utilizes cutting-edge architecture to improve efficiency and accuracy in processing language-based tasks.",
+      "base_url": "https://generativelanguage.googleapis.com/v1beta3"
+    },
+    {
+      "id": "vertex-ai",
+      "name": "Google Vertex AI",
+      "object": "provider",
+      "description": "Google Vertex AI offers a comprehensive suite of tools for building, deploying, and managing machine learning models at scale. It integrates seamlessly with other Google Cloud services, providing developers with robust resources for leveraging large language models in their applications.",
+      "base_url": ""
+    },
+    {
+      "id": "groq",
+      "name": "Groq",
+      "object": "provider",
+      "description": "Groq specializes in high-performance inference solutions for large language models, boasting significant speed advantages over competitors. Their custom hardware architecture is optimized for running LLMs efficiently, making it suitable for real-time applications where low latency is crucial.",
+      "base_url": "https://api.groq.com/openai/v1"
+    },
+    {
+      "id": "huggingface",
+      "name": "Hugging Face",
+      "object": "provider",
+      "description": "Hugging Face is a leading platform in the open-source machine learning community, known for its Transformers library that provides access to numerous pre-trained LLMs. The platform fosters collaboration among researchers and developers while offering tools for fine-tuning and deploying NLP models across various use cases.",
+      "base_url": ""
+    },
+    {
+      "id": "inference-net",
+      "name": "Inference.net",
+      "object": "provider",
+      "description": "Inference.net focuses on delivering scalable inference solutions tailored for large language models. Their platform aims to optimize the deployment of ML models in production environments, ensuring low latency and high throughput for real-time applications.",
+      "base_url": "https://api.inference.net/v1"
+    },
+    {
+      "id": "jina",
+      "name": "Jina AI",
+      "object": "provider",
+      "description": "Jina AI specializes in neural search technologies powered by large language models. Their framework allows developers to build search engines that understand natural language queries effectively, enhancing information retrieval across diverse datasets.",
+      "base_url": "https://api.jina.ai/v1"
+    },
+    {
+      "id": "lingyi",
+      "name": "Lingyi (01.ai)",
+      "object": "provider",
+      "description": "Lingyi (01.ai) develops cutting-edge natural language processing technologies aimed at improving human-computer interaction through conversational interfaces. They focus on creating user-friendly tools that enable businesses to integrate advanced NLP capabilities seamlessly.",
+      "base_url": "https://api.lingyiwanwu.com"
+    },
+    {
+      "id": "localai",
+      "name": "LocalAI",
+      "object": "provider",
+      "description": "LocalAI provides solutions that enable organizations to run large language models locally rather than relying on cloud services. This approach enhances data privacy and control while allowing users to customize their LLM deployments according to specific needs.",
+      "base_url": ""
+    },
+    {
+      "id": "mistral-ai",
+      "name": "Mistral AI",
+      "object": "provider",
+      "description": "Mistral AI focuses on developing efficient large language models optimized for performance across various tasks such as text generation and question answering. Their technology aims at reducing computational costs while maintaining high-quality outputs suitable for enterprise applications.",
+      "base_url": "https://api.mistral.ai/v1"
+    },
+    {
+      "id": "monsterapi",
+      "name": "Monster API",
+      "object": "provider",
+      "description": "Monster API offers an accessible interface for integrating various large language models into applications, focusing on ease of use and flexibility. The platform enables developers to leverage powerful NLP capabilities without extensive technical knowledge or infrastructure overhead.",
+      "base_url": "https://llm.monsterapi.ai/v1"
+    },
+    {
+      "id": "moonshot",
+      "name": "Moonshot",
+      "object": "provider",
+      "description": "Moonshot develops innovative solutions leveraging large language models aimed at enhancing creativity in content generation processes. Their tools are designed to assist creators by providing intelligent suggestions and automating repetitive tasks within creative workflows.",
+      "base_url": "https://api.moonshot.cn"
+    },
+    {
+      "id": "nomic",
+      "name": "Nomic",
+      "object": "provider",
+      "description": "Nomic focuses on building collaborative tools powered by large language models that facilitate group decision-making processes. Their platform allows teams to harness the power of NLP in brainstorming sessions and project management activities effectively.",
+      "base_url": "https://api-atlas.nomic.ai/v1"
+    },
+    {
+      "id": "novita-ai",
+      "name": "Novita AI",
+      "object": "provider",
+      "description": "Novita AI specializes in creating tailored LLM solutions that cater specifically to industry needs such as finance or healthcare. They emphasize customization and integration capabilities that allow businesses to leverage NLP technologies effectively within their operations.",
+      "base_url": "https://api.novita.ai/v3/openai"
+    },
+    {
+      "id": "ollama",
+      "name": "Ollama",
+      "object": "provider",
+      "description": "Ollama offers a streamlined platform for deploying large language models with an emphasis on user-friendly interfaces and accessibility. They aim to simplify the integration of NLP capabilities into existing systems while providing robust support for developers.",
+      "base_url": ""
+    },
+    {
+      "id": "openai",
+      "name": "OpenAI",
+      "object": "provider",
+      "description": "OpenAI is renowned for its development of advanced artificial intelligence technologies, including the GPT series of large language models. They focus on ensuring safe deployment practices while advancing the state-of-the-art in natural language understanding and generation across various domains.",
+      "base_url": "https://api.openai.com/v1"
+    },
+    {
+      "id": "openrouter",
+      "name": "OpenRouter",
+      "object": "provider",
+      "description": "OpenRouter is an innovative platform that provides unified access to multiple large language models through a single interface. It enables businesses and developers to integrate diverse AI capabilities efficiently while focusing on scalability and cost-effectiveness in their applications.",
+      "base_url": "https://openrouter.ai/api"
+    },
+    {
+      "id": "perplexity-ai",
+      "name": "Perplexity AI",
+      "object": "provider",
+      "description": "Perplexity AI is an advanced research tool designed as a conversational search engine that generates answers using natural language processing techniques. It integrates real-time web data into its responses while offering both free and paid access options tailored towards different user needs.",
+      "base_url": "https://api.perplexity.ai"
+    },
+    {
+      "id": "predibase",
+      "name": "Predibase",
+      "object": "provider",
+      "description": "Predibase specializes in fine-tuning large language models efficiently, providing a robust environment for customizing pre-trained LLMs according to specific tasks or domains. Their platform emphasizes speed, reliability, and cost-effectiveness in serving fine-tuned models at scale.",
+      "base_url": "https://serving.app.predibase.com"
+    },
+    {
+      "id": "reka",
+      "name": "Reka AI",
+      "object": "provider",
+      "description": "Reka AI develops specialized LLMs aimed at enhancing educational technologies through personalized learning experiences. Their focus lies in creating adaptive systems that respond intelligently to individual learner needs using natural language processing techniques.",
+      "base_url": "https://api.reka.ai"
+    },
+    {
+      "id": "sambanova",
+      "name": "SambaNova",
+      "object": "provider",
+      "description": "SambaNova Systems provides hardware-software integrated solutions optimized specifically for running large-scale machine learning workloads efficiently. Their technology aims at accelerating model training times while ensuring high performance during inference phases across diverse applications.",
+      "base_url": "https://api.sambanova.ai"
+    },
+    {
+      "id": "segmind",
+      "name": "Segmind",
+      "object": "provider",
+      "description": "Segmind focuses on simplifying the deployment of machine learning pipelines tailored towards specific business needs involving large language models. Their platform enables organizations to manage model lifecycles effectively while ensuring optimal performance metrics are achieved consistently.",
+      "base_url": "https://api.segmind.com/v1"
+    },
+    {
+      "id": "siliconflow",
+      "name": "SiliconFlow",
+      "object": "provider",
+      "description": "SiliconFlow develops infrastructure solutions designed specifically for optimizing the deployment of artificial intelligence workloads including LLMs at scale within enterprise environments focusing on reliability & performance enhancements throughout all stages from training through inference execution phases effectively minimizing downtime risks associated typically seen during transitions between these stages involved here too!",
+      "base_url": "https://api.siliconflow.cn/v1"
+    },
+    {
+      "id": "stability-ai",
+      "name": "Stability AI",
+      "object": "provider",
+      "description": "Stability AI specializes in creating open-source frameworks around generative artificial intelligence technologies including text-to-image synthesis & other creative outputs leveraging advancements made possible via breakthroughs achieved recently within areas surrounding deep learning methodologies employed throughout this process ensuring accessibility remains key priority here too!",
+      "base_url": "https://api.stability.ai/v1"
+    },
+    {
+      "id": "together-ai",
+      "name": "Together AI",
+      "object": "provider",
+      "description": "Together AI is dedicated to developing open-source large language model frameworks such as OpenChatKit aimed at empowering developers & researchers alike with versatile tools necessary facilitating collaboration within rapidly evolving landscapes surrounding artificial intelligence today!",
+      "base_url": "https://api.together.xyz"
+    },
+    {
+      "id": "voyage",
+      "name": "Voyage AI",
+      "object": "provider",
+      "description": "Voyage AI focuses on developing autonomous navigation systems powered by advanced artificial intelligence techniques including those found within recent iterations seen across various types involving deep reinforcement learning methodologies applied here too!",
+      "base_url": "https://api.voyageai.com/v1"
+    },
+    {
+      "id": "workers-ai",
+      "name": "Workers AI",
+      "object": "provider",
+      "description": "Workers AI by Cloudflare is a platform that leverages Cloudflare's global network to provide developers and businesses with serverless AI infrastructure. It enables scalable, low-latency AI processing directly at the edge, allowing users to deploy machine learning models closer to their data and applications. With easy integration and powerful tools, Workers AI helps optimize workflows, enhance performance, and reduce operational complexity by harnessing the power of AI at a global scale.",
+      "base_url": ""
+    },
+    {
+      "id": "zhipu",
+      "name": "ZhipuAI",
+      "object": "provider",
+      "description": "ZhipuAI specializes in creating conversational agents powered by advanced natural language processing techniques aimed at enhancing customer engagement experiences across diverse industries focusing primarily upon delivering personalized interactions tailored towards individual preferences expressed during engagements encountered here too!",
+      "base_url": "https://open.bigmodel.cn/api/paas/v4"
+    },
+    {
+      "id": "lambda",
+      "name": "Lambda Labs",
+      "object": "provider",
+      "description": "Lambda Labs specializes in AI infrastructure and tools, providing powerful solutions for machine learning and deep learning applications. They offer a range of products, including GPUs optimized for AI workloads, and a comprehensive suite of software tools that streamline the development and deployment of AI models. Their focus is on delivering high-performance computing resources to researchers and enterprises looking to harness the power of artificial intelligence effectively.",
+      "base_url": "https://api.lambdalabs.com/v1"
+    },
+    {
+      "id": "lemonfox-ai",
+      "name": "Lemonfox AI",
+      "object": "provider",
+      "description": "Lemonfox AI is a cost-effective platform that provides advanced capabilities in text generation, chat support, and image creation. It offers an OpenAI-compatible API, making it easy for developers to integrate its features into applications. With support for over 50 languages and tools like the Stable Diffusion XL model for image generation, Lemonfox aims to deliver high-quality results at a fraction of the cost of competitors, making it an attractive option for businesses looking to leverage AI technology.",
+      "base_url": "https://api.lemonfox.ai/v1"
+    },
+    {
+      "id": "upstage",
+      "name": "Upstage",
+      "object": "provider",
+      "description": "Upstage is a South Korean AI company focused on developing innovative large language models (LLMs) and document processing solutions. Their flagship product, Solar LLM, utilizes advanced techniques to deliver high-performance AI capabilities across multiple languages. Upstage emphasizes automation and data-driven insights to enhance business operations, partnering with AWS to expand their generative AI solutions globally and cater to various industry needs.",
+      "base_url": "https://api.upstage.ai/v1/solar"
+    },
+    {
+      "id": "dashscope",
+      "name": "Dashscope",
+      "object": "provider",
+      "description": "Dashscope provides intelligent analytics solutions designed to help businesses visualize and interpret complex data effectively. Their platform integrates advanced machine learning algorithms to generate real-time insights from diverse datasets, enabling organizations to make informed decisions quickly. Dashscope focuses on enhancing data accessibility and usability, empowering teams to leverage analytics for strategic planning and operational efficiency.",
+      "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    }
+  ]
 }

--- a/src/data/providers.json
+++ b/src/data/providers.json
@@ -1,0 +1,307 @@
+{
+    "object": "list",
+    "version": "1.0.0",
+    "data": [
+        {
+            "id": "ai21",
+            "name": "AI21",
+            "object": "provider",
+            "description": "AI21 Labs specializes in developing advanced natural language processing models, notably their flagship model, Jurassic-2. They focus on creating tools that enhance human-computer interaction, enabling applications like text generation, summarization, and dialogue systems. Their platform encourages developers to build and integrate AI capabilities into various applications through user-friendly APIs.",
+            "base_url": "https://api.ai21.com/studio/v1"
+        },
+        {
+            "id": "anthropic",
+            "name": "Anthropic",
+            "object": "provider",
+            "description": "Anthropic is an AI research company focused on creating safe and interpretable AI systems. Their flagship model, Claude, is designed to prioritize user alignment and ethical considerations in AI interactions. Anthropic emphasizes transparency and safety in AI development, aiming to build models that can be trusted in sensitive applications.",
+            "base_url": "https://api.anthropic.com/v1/messages"
+        },
+        {
+            "id": "anyscale",
+            "name": "Anyscale",
+            "object": "provider",
+            "description": "Anyscale provides a platform for building and deploying distributed applications with a focus on large language models. Their technology simplifies the scaling of machine learning workloads, enabling developers to efficiently run LLMs in production. Anyscale's tools support various frameworks and enhance collaboration among data scientists and engineers.",
+            "base_url": "https://api.endpoints.anyscale.com/v1"
+        },
+        {
+            "id": "bedrock",
+            "name": "AWS Bedrock",
+            "object": "provider",
+            "description": "AWS Bedrock is a fully managed service that offers access to high-performing foundation models from leading AI companies. It allows users to customize these models with their own data while providing a secure environment for building generative AI applications. The platform streamlines experimentation and integration into existing workflows without requiring infrastructure management.",
+            "base_url": ""
+        },
+        {
+            "id": "azure-openai",
+            "name": "Azure OpenAI",
+            "object": "provider",
+            "description": "Azure OpenAI Service integrates OpenAI's powerful models into Microsoft's cloud ecosystem, enabling businesses to leverage advanced AI capabilities securely. Users can access models like GPT-4 for various applications such as chatbots, content generation, and more. Azure's infrastructure ensures scalability and compliance with enterprise standards.",
+            "base_url": ""
+        },
+        {
+            "id": "cerebras",
+            "name": "Cerebras",
+            "object": "provider",
+            "description": "Cerebras Systems focuses on high-performance computing solutions for deep learning, featuring the world's largest chip designed specifically for AI workloads. Their technology accelerates model training and inference, making it suitable for large-scale deployments of language models. Cerebras aims to reduce the time and cost associated with training complex neural networks.",
+            "base_url": "https://api.cerebras.ai/v1"
+        },
+        {
+            "id": "cohere",
+            "name": "Cohere",
+            "object": "provider",
+            "description": "Cohere specializes in providing natural language processing capabilities through its API, allowing developers to build applications that understand and generate human-like text. Their models are designed for tasks such as semantic search, content creation, and chatbots. Cohere emphasizes ease of use and accessibility for businesses looking to implement NLP solutions.",
+            "base_url": "https://api.cohere.ai/v1"
+        },
+        {
+            "id": "deepbricks",
+            "name": "Deepbricks",
+            "object": "provider",
+            "description": "Deepbricks offers a platform for building and deploying large language models tailored for specific business needs. They focus on providing customizable solutions that enhance productivity across various sectors. Deepbricks aims to simplify the integration of AI into existing workflows while ensuring high performance.",
+            "base_url": "https://api.deepbricks.ai/v1"
+        },
+        {
+            "id": "deepinfra",
+            "name": "Deepinfra",
+            "object": "provider",
+            "description": "Deepinfra specializes in optimizing the deployment of machine learning models at scale. Their platform provides tools for managing infrastructure requirements efficiently while ensuring low-latency access to AI capabilities. Deepinfra focuses on enhancing operational efficiency for businesses leveraging LLMs.",
+            "base_url": "https://api.deepinfra.com/v1/openai"
+        },
+        {
+            "id": "deepseek",
+            "name": "DeepSeek",
+            "object": "provider",
+            "description": "DeepSeek develops advanced search technologies powered by large language models. Their solutions aim to improve information retrieval across various domains by enhancing search accuracy and relevance. DeepSeek focuses on integrating AI into existing search infrastructures to provide smarter results.",
+            "base_url": "https://api.deepseek.com"
+        },
+        {
+            "id": "fireworks-ai",
+            "name": "Fireworks",
+            "object": "provider",
+            "description": "Fireworks is a platform that leverages large language models to automate workflows in various industries. It provides tools for integrating AI into everyday tasks, enhancing productivity through intelligent automation. Fireworks aims to simplify complex processes by using natural language understanding.",
+            "base_url": "https://api.fireworks.ai/inference/v1"
+        },
+        {
+            "id": "google",
+            "name": "Google Gemini",
+            "object": "provider",
+            "description": "Google Gemini is part of Google's suite of AI tools designed for natural language understanding and generation. It focuses on providing robust solutions for developers looking to integrate conversational AI capabilities into their applications. Gemini emphasizes scalability and performance within Google's cloud ecosystem.",
+            "base_url": "https://generativelanguage.googleapis.com/v1beta"
+        },
+        {
+            "id": "palm",
+            "name": "Google Palm",
+            "object": "provider",
+            "description": "Google's PaLM (Pathways Language Model) is designed for advanced natural language understanding tasks, supporting a wide range of applications from chatbots to content generation. PaLM utilizes cutting-edge architecture to improve efficiency and accuracy in processing language-based tasks.",
+            "base_url": "https://generativelanguage.googleapis.com/v1beta3"
+        },
+        {
+            "id": "vertex-ai",
+            "name": "Google Vertex AI",
+            "object": "provider",
+            "description": "Google Vertex AI offers a comprehensive suite of tools for building, deploying, and managing machine learning models at scale. It integrates seamlessly with other Google Cloud services, providing developers with robust resources for leveraging large language models in their applications.",
+            "base_url": ""
+        },
+        {
+            "id": "groq",
+            "name": "Groq",
+            "object": "provider",
+            "description": "Groq specializes in high-performance inference solutions for large language models, boasting significant speed advantages over competitors. Their custom hardware architecture is optimized for running LLMs efficiently, making it suitable for real-time applications where low latency is crucial.",
+            "base_url": "https://api.groq.com/openai/v1"
+        },
+        {
+            "id": "huggingface",
+            "name": "Hugging Face",
+            "object": "provider",
+            "description": "Hugging Face is a leading platform in the open-source machine learning community, known for its Transformers library that provides access to numerous pre-trained LLMs. The platform fosters collaboration among researchers and developers while offering tools for fine-tuning and deploying NLP models across various use cases.",
+            "base_url": ""
+        },
+        {
+            "id": "inference-net",
+            "name": "Inference.net",
+            "object": "provider",
+            "description": "Inference.net focuses on delivering scalable inference solutions tailored for large language models. Their platform aims to optimize the deployment of ML models in production environments, ensuring low latency and high throughput for real-time applications.",
+            "base_url": "https://api.inference.net/v1"
+        },
+        {
+            "id": "jina",
+            "name": "Jina AI",
+            "object": "provider",
+            "description": "Jina AI specializes in neural search technologies powered by large language models. Their framework allows developers to build search engines that understand natural language queries effectively, enhancing information retrieval across diverse datasets.",
+            "base_url": "https://api.jina.ai/v1"
+        },
+        {
+            "id": "lingyi",
+            "name": "Lingyi (01.ai)",
+            "object": "provider",
+            "description": "Lingyi (01.ai) develops cutting-edge natural language processing technologies aimed at improving human-computer interaction through conversational interfaces. They focus on creating user-friendly tools that enable businesses to integrate advanced NLP capabilities seamlessly.",
+            "base_url": "https://api.lingyiwanwu.com"
+        },
+        {
+            "id": "localai",
+            "name": "LocalAI",
+            "object": "provider",
+            "description": "LocalAI provides solutions that enable organizations to run large language models locally rather than relying on cloud services. This approach enhances data privacy and control while allowing users to customize their LLM deployments according to specific needs.",
+            "base_url": ""
+        },
+        {
+            "id": "mistral-ai",
+            "name": "Mistral AI",
+            "object": "provider",
+            "description": "Mistral AI focuses on developing efficient large language models optimized for performance across various tasks such as text generation and question answering. Their technology aims at reducing computational costs while maintaining high-quality outputs suitable for enterprise applications.",
+            "base_url": "https://api.mistral.ai/v1"
+        },
+        {
+            "id": "monsterapi",
+            "name": "Monster API",
+            "object": "provider",
+            "description": "Monster API offers an accessible interface for integrating various large language models into applications, focusing on ease of use and flexibility. The platform enables developers to leverage powerful NLP capabilities without extensive technical knowledge or infrastructure overhead.",
+            "base_url": "https://llm.monsterapi.ai/v1"
+        },
+        {
+            "id": "moonshot",
+            "name": "Moonshot",
+            "object": "provider",
+            "description": "Moonshot develops innovative solutions leveraging large language models aimed at enhancing creativity in content generation processes. Their tools are designed to assist creators by providing intelligent suggestions and automating repetitive tasks within creative workflows.",
+            "base_url": "https://api.moonshot.cn"
+        },
+        {
+            "id": "nomic",
+            "name": "Nomic",
+            "object": "provider",
+            "description": "Nomic focuses on building collaborative tools powered by large language models that facilitate group decision-making processes. Their platform allows teams to harness the power of NLP in brainstorming sessions and project management activities effectively.",
+            "base_url": "https://api-atlas.nomic.ai/v1"
+        },
+        {
+            "id": "novita-ai",
+            "name": "Novita AI",
+            "object": "provider",
+            "description": "Novita AI specializes in creating tailored LLM solutions that cater specifically to industry needs such as finance or healthcare. They emphasize customization and integration capabilities that allow businesses to leverage NLP technologies effectively within their operations.",
+            "base_url": "https://api.novita.ai/v3/openai"
+        },
+        {
+            "id": "ollama",
+            "name": "Ollama",
+            "object": "provider",
+            "description": "Ollama offers a streamlined platform for deploying large language models with an emphasis on user-friendly interfaces and accessibility. They aim to simplify the integration of NLP capabilities into existing systems while providing robust support for developers.",
+            "base_url": ""
+        },
+        {
+            "id": "openai",
+            "name": "OpenAI",
+            "object": "provider",
+            "description": "OpenAI is renowned for its development of advanced artificial intelligence technologies, including the GPT series of large language models. They focus on ensuring safe deployment practices while advancing the state-of-the-art in natural language understanding and generation across various domains.",
+            "base_url": "https://api.openai.com/v1"
+        },
+        {
+            "id": "openrouter",
+            "name": "OpenRouter",
+            "object": "provider",
+            "description": "OpenRouter is an innovative platform that provides unified access to multiple large language models through a single interface. It enables businesses and developers to integrate diverse AI capabilities efficiently while focusing on scalability and cost-effectiveness in their applications.",
+            "base_url": "https://openrouter.ai/api"
+        },
+        {
+            "id": "perplexity-ai",
+            "name": "Perplexity AI",
+            "object": "provider",
+            "description": "Perplexity AI is an advanced research tool designed as a conversational search engine that generates answers using natural language processing techniques. It integrates real-time web data into its responses while offering both free and paid access options tailored towards different user needs.",
+            "base_url": "https://api.perplexity.ai"
+        },
+        {
+            "id": "predibase",
+            "name": "Predibase",
+            "object": "provider",
+            "description": "Predibase specializes in fine-tuning large language models efficiently, providing a robust environment for customizing pre-trained LLMs according to specific tasks or domains. Their platform emphasizes speed, reliability, and cost-effectiveness in serving fine-tuned models at scale.",
+            "base_url": "https://serving.app.predibase.com"
+        },
+        {
+            "id": "reka",
+            "name": "Reka AI",
+            "object": "provider",
+            "description": "Reka AI develops specialized LLMs aimed at enhancing educational technologies through personalized learning experiences. Their focus lies in creating adaptive systems that respond intelligently to individual learner needs using natural language processing techniques.",
+            "base_url": "https://api.reka.ai"
+        },
+        {
+            "id": "sambanova",
+            "name": "SambaNova",
+            "object": "provider",
+            "description": "SambaNova Systems provides hardware-software integrated solutions optimized specifically for running large-scale machine learning workloads efficiently. Their technology aims at accelerating model training times while ensuring high performance during inference phases across diverse applications.",
+            "base_url": "https://api.sambanova.ai"
+        },
+        {
+            "id": "segmind",
+            "name": "Segmind",
+            "object": "provider",
+            "description": "Segmind focuses on simplifying the deployment of machine learning pipelines tailored towards specific business needs involving large language models. Their platform enables organizations to manage model lifecycles effectively while ensuring optimal performance metrics are achieved consistently.",
+            "base_url": "https://api.segmind.com/v1"
+        },
+        {
+            "id": "siliconflow",
+            "name": "SiliconFlow",
+            "object": "provider",
+            "description": "SiliconFlow develops infrastructure solutions designed specifically for optimizing the deployment of artificial intelligence workloads including LLMs at scale within enterprise environments focusing on reliability & performance enhancements throughout all stages from training through inference execution phases effectively minimizing downtime risks associated typically seen during transitions between these stages involved here too!",
+            "base_url": "https://api.siliconflow.cn/v1"
+        },
+        {
+            "id": "stability-ai",
+            "name": "Stability AI",
+            "object": "provider",
+            "description": "Stability AI specializes in creating open-source frameworks around generative artificial intelligence technologies including text-to-image synthesis & other creative outputs leveraging advancements made possible via breakthroughs achieved recently within areas surrounding deep learning methodologies employed throughout this process ensuring accessibility remains key priority here too!",
+            "base_url": "https://api.stability.ai/v1"
+        },
+        {
+            "id": "together-ai",
+            "name": "Together AI",
+            "object": "provider",
+            "description": "Together AI is dedicated to developing open-source large language model frameworks such as OpenChatKit aimed at empowering developers & researchers alike with versatile tools necessary facilitating collaboration within rapidly evolving landscapes surrounding artificial intelligence today!",
+            "base_url": "https://api.together.xyz"
+        },
+        {
+            "id": "voyage",
+            "name": "Voyage AI",
+            "object": "provider",
+            "description": "Voyage AI focuses on developing autonomous navigation systems powered by advanced artificial intelligence techniques including those found within recent iterations seen across various types involving deep reinforcement learning methodologies applied here too!",
+            "base_url": "https://api.voyageai.com/v1"
+        },
+        {
+            "id": "workers-ai",
+            "name": "Workers AI",
+            "object": "provider",
+            "description": "Workers AI by Cloudflare is a platform that leverages Cloudflare's global network to provide developers and businesses with serverless AI infrastructure. It enables scalable, low-latency AI processing directly at the edge, allowing users to deploy machine learning models closer to their data and applications. With easy integration and powerful tools, Workers AI helps optimize workflows, enhance performance, and reduce operational complexity by harnessing the power of AI at a global scale.",
+            "base_url": ""
+        },
+        {
+            "id": "zhipu",
+            "name": "ZhipuAI",
+            "object": "provider",
+            "description": "ZhipuAI specializes in creating conversational agents powered by advanced natural language processing techniques aimed at enhancing customer engagement experiences across diverse industries focusing primarily upon delivering personalized interactions tailored towards individual preferences expressed during engagements encountered here too!",
+            "base_url": "https://open.bigmodel.cn/api/paas/v4"
+        },
+        {
+            "id": "lambda",
+            "name": "Lambda Labs",
+            "object": "provider",
+            "description": "Lambda Labs specializes in AI infrastructure and tools, providing powerful solutions for machine learning and deep learning applications. They offer a range of products, including GPUs optimized for AI workloads, and a comprehensive suite of software tools that streamline the development and deployment of AI models. Their focus is on delivering high-performance computing resources to researchers and enterprises looking to harness the power of artificial intelligence effectively.",
+            "base_url": "https://api.lambdalabs.com/v1"
+        },
+        {
+            "id": "lemonfox-ai",
+            "name": "Lemonfox AI",
+            "object": "provider",
+            "description": "Lemonfox AI is a cost-effective platform that provides advanced capabilities in text generation, chat support, and image creation. It offers an OpenAI-compatible API, making it easy for developers to integrate its features into applications. With support for over 50 languages and tools like the Stable Diffusion XL model for image generation, Lemonfox aims to deliver high-quality results at a fraction of the cost of competitors, making it an attractive option for businesses looking to leverage AI technology.",
+            "base_url": "https://api.lemonfox.ai/v1"
+        },
+        {
+            "id": "upstage",
+            "name": "Upstage",
+            "object": "provider",
+            "description": "Upstage is a South Korean AI company focused on developing innovative large language models (LLMs) and document processing solutions. Their flagship product, Solar LLM, utilizes advanced techniques to deliver high-performance AI capabilities across multiple languages. Upstage emphasizes automation and data-driven insights to enhance business operations, partnering with AWS to expand their generative AI solutions globally and cater to various industry needs.",
+            "base_url": "https://api.upstage.ai/v1/solar"
+        },
+        {
+            "id": "dashscope",
+            "name": "Dashscope",
+            "object": "provider",
+            "description": "Dashscope provides intelligent analytics solutions designed to help businesses visualize and interpret complex data effectively. Their platform integrates advanced machine learning algorithms to generate real-time insights from diverse datasets, enabling organizations to make informed decisions quickly. Dashscope focuses on enhancing data accessibility and usability, empowering teams to leverage analytics for strategic planning and operational efficiency.",
+            "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1"
+        }
+    ]
+}

--- a/src/handlers/modelsHandler.ts
+++ b/src/handlers/modelsHandler.ts
@@ -1,0 +1,27 @@
+import { Context } from 'hono';
+import models from '../data/models.json';
+import providers from '../data/providers.json';
+
+/**
+ * Handles the models request. Returns a list of models supported by the Ai gateway.
+ * Allows filters in query params for the provider
+ * @param c - The Hono context
+ * @returns - The response
+ */
+export async function modelsHandler(c: Context): Promise<Response> {
+  // If the request does not contain a provider query param, return all models
+  const provider = c.req.query('provider');
+  if (!provider) {
+    return c.json(models);
+  } else {
+    // Filter the models by the provider
+    const filteredModels = models.data.filter(
+      (model) => model.provider.id === provider
+    );
+    return c.json(filteredModels);
+  }
+}
+
+export async function providersHandler(c: Context): Promise<Response> {
+  return c.json(providers);
+}

--- a/src/handlers/modelsHandler.ts
+++ b/src/handlers/modelsHandler.ts
@@ -9,19 +9,29 @@ import providers from '../data/providers.json';
  * @returns - The response
  */
 export async function modelsHandler(c: Context): Promise<Response> {
-  // If the request does not contain a provider query param, return all models
+  // If the request does not contain a provider query param, return all models. Add a count as well.
   const provider = c.req.query('provider');
   if (!provider) {
-    return c.json(models);
+    return c.json({
+      ...models,
+      count: models.data.length,
+    });
   } else {
     // Filter the models by the provider
     const filteredModels = models.data.filter(
-      (model) => model.provider.id === provider
+      (model: any) => model.provider.id === provider
     );
-    return c.json(filteredModels);
+    return c.json({
+      ...models,
+      data: filteredModels,
+      count: filteredModels.length,
+    });
   }
 }
 
 export async function providersHandler(c: Context): Promise<Response> {
-  return c.json(providers);
+  return c.json({
+    ...providers,
+    count: providers.data.length,
+  });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ import { createSpeechHandler } from './handlers/createSpeechHandler';
 import conf from '../conf.json';
 import { createTranscriptionHandler } from './handlers/createTranscriptionHandler';
 import { createTranslationHandler } from './handlers/createTranslationHandler';
+import { modelsHandler, providersHandler } from './handlers/modelsHandler';
 
 // Create a new Hono server instance
 const app = new Hono();
@@ -164,6 +165,9 @@ app.post('/v1/prompts/*', requestValidator, (c) => {
     message: 'prompt completions error: Something went wrong',
   });
 });
+
+app.get('/v1/reference/models', modelsHandler);
+app.get('/v1/reference/providers', providersHandler);
 
 /**
  * @deprecated


### PR DESCRIPTION
Added 2 new routes - `/v1/reference/models` and `/v1/reference/providers` that provide a reference to all supported providers and models on the AI gateway.
