### PR TITLE
return the tool output as json object without parsing it as a string in bedrock

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -416,7 +416,7 @@ export const AnthropicChatCompleteResponseTransform: (
           type: 'function',
           function: {
             name: item.name,
-            arguments: JSON.stringify(item.input),
+            arguments: item.input,
           },
         });
       }


### PR DESCRIPTION
Verified that bedrock `input` object in tool response is a json object
<img width="959" alt="image" src="https://github.com/user-attachments/assets/34100bc4-fbf8-4e7d-b71e-68f80a5e89f7">

**Related Issues:** (optional)
- #768 
