### PR TITLE
Stringify bedrock tool call arguments

### DIFF
--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -366,7 +366,7 @@ export const BedrockChatCompleteResponseTransform: (
         type: 'function',
         function: {
           name: content.toolUse.name,
-          arguments: content.toolUse.input,
+          arguments: JSON.stringify(content.toolUse.input),
         },
       }));
     if (toolCalls.length > 0)


### PR DESCRIPTION
Verified that bedrock returns a json object for arguments
<img width="959" alt="image" src="https://github.com/user-attachments/assets/2c33b2f5-cb67-4ae4-9170-ef9adcec6c8f">

**Related Issues:** (optional)
- #768 
