### PR TITLE
support sagemaker as provider

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -75,6 +75,7 @@ export const UPSTAGE: string = 'upstage';
 export const LAMBDA: string = 'lambda';
 export const DASHSCOPE: string = 'dashscope';
 export const X_AI: string = 'x-ai';
+export const SAGEMAKER: string = 'sagemaker';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -123,6 +124,7 @@ export const VALID_PROVIDERS = [
   LAMBDA,
   DASHSCOPE,
   X_AI,
+  SAGEMAKER,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -49,6 +49,7 @@ import { LambdaProviderConfig } from './lambda';
 import { DashScopeConfig } from './dashscope';
 import XAIConfig from './x-ai';
 import QdrantConfig from './qdrant';
+import SagemakerConfig from './sagemaker';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -98,6 +99,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   dashscope: DashScopeConfig,
   'x-ai': XAIConfig,
   qdrant: QdrantConfig,
+  sagemaker: SagemakerConfig,
 };
 
 export default Providers;

--- a/src/providers/sagemaker/api.ts
+++ b/src/providers/sagemaker/api.ts
@@ -1,0 +1,113 @@
+import { GatewayError } from '../../errors/GatewayError';
+import {
+  generateAWSHeaders,
+  getAssumedRoleCredentials,
+} from '../bedrock/utils';
+import { ProviderAPIConfig } from '../types';
+import { env } from 'hono/adapter';
+const SagemakerAPIConfig: ProviderAPIConfig = {
+  getBaseURL: ({ providerOptions }) => {
+    return `https://runtime.sagemaker.${providerOptions.awsRegion}.amazonaws.com`;
+  },
+  headers: async ({
+    providerOptions,
+    transformedRequestBody,
+    transformedRequestUrl,
+    c,
+  }) => {
+    const headers: Record<string, string> = {
+      'content-type': 'application/json',
+    };
+
+    if (providerOptions.awsAuthType === 'assumedRole') {
+      try {
+        // Assume the role in the source account
+        const sourceRoleCredentials = await getAssumedRoleCredentials(
+          c,
+          env(c).AWS_ASSUME_ROLE_SOURCE_ARN, // Role ARN in the source account
+          env(c).AWS_ASSUME_ROLE_SOURCE_EXTERNAL_ID || '', // External ID for source role (if needed)
+          providerOptions.awsRegion || ''
+        );
+
+        if (!sourceRoleCredentials) {
+          throw new Error('Server Error while assuming internal role');
+        }
+
+        // Assume role in destination account using temporary creds obtained in first step
+        const { accessKeyId, secretAccessKey, sessionToken } =
+          (await getAssumedRoleCredentials(
+            c,
+            providerOptions.awsRoleArn || '',
+            providerOptions.awsExternalId || '',
+            providerOptions.awsRegion || '',
+            {
+              accessKeyId: sourceRoleCredentials.accessKeyId,
+              secretAccessKey: sourceRoleCredentials.secretAccessKey,
+              sessionToken: sourceRoleCredentials.sessionToken,
+            }
+          )) || {};
+        providerOptions.awsAccessKeyId = accessKeyId;
+        providerOptions.awsSecretAccessKey = secretAccessKey;
+        providerOptions.awsSessionToken = sessionToken;
+      } catch (e) {
+        throw new GatewayError('Error while assuming sagemaker role');
+      }
+    }
+
+    const awsHeaders = await generateAWSHeaders(
+      transformedRequestBody,
+      headers,
+      transformedRequestUrl,
+      'POST',
+      'sagemaker',
+      providerOptions.awsRegion || '',
+      providerOptions.awsAccessKeyId || '',
+      providerOptions.awsSecretAccessKey || '',
+      providerOptions.awsSessionToken || ''
+    );
+
+    if (providerOptions.sagemakerCustomAttributes) {
+      awsHeaders['x-amzn-sagemaker-custom-attributes'] =
+        providerOptions.sagemakerCustomAttributes;
+    }
+
+    if (providerOptions.sagemakerTargetModel) {
+      awsHeaders['x-amzn-sagemaker-target-model'] =
+        providerOptions.sagemakerTargetModel;
+    }
+
+    if (providerOptions.sagemakerTargetVariant) {
+      awsHeaders['x-amzn-sagemaker-target-variant'] =
+        providerOptions.sagemakerTargetVariant;
+    }
+
+    if (providerOptions.sagemakerTargetContainerHostname) {
+      awsHeaders['x-amzn-sagemaker-target-container-hostname'] =
+        providerOptions.sagemakerTargetContainerHostname;
+    }
+
+    if (providerOptions.sagemakerInferenceId) {
+      awsHeaders['x-amzn-sagemaker-inference-id'] =
+        providerOptions.sagemakerInferenceId;
+    }
+
+    if (providerOptions.sagemakerEnableExplanations) {
+      awsHeaders['x-amzn-sagemaker-enable-explanations'] =
+        providerOptions.sagemakerEnableExplanations;
+    }
+
+    if (providerOptions.sagemakerInferenceComponent) {
+      awsHeaders['x-amzn-sagemaker-inference-component'] =
+        providerOptions.sagemakerInferenceComponent;
+    }
+
+    if (providerOptions.sagemakerSessionId) {
+      awsHeaders['x-amzn-sagemaker-session-id'] =
+        providerOptions.sagemakerSessionId;
+    }
+    return awsHeaders;
+  },
+  getEndpoint: ({ gatewayRequestURL }) => gatewayRequestURL.split('/v1')[1],
+};
+
+export default SagemakerAPIConfig;

--- a/src/providers/sagemaker/index.ts
+++ b/src/providers/sagemaker/index.ts
@@ -1,0 +1,8 @@
+import { ProviderConfigs } from '../types';
+import SagemakerAPIConfig from './api';
+
+const SagemakerConfig: ProviderConfigs = {
+  api: SagemakerAPIConfig,
+};
+
+export default SagemakerConfig;

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -78,7 +78,7 @@ export interface Options {
   requestTimeout?: number;
   /** This is used to determine if the request should be transformed to formData Example: Stability V2 */
   transformToFormData?: boolean;
-  /** AWS Bedrock specific */
+  /** AWS specific (used for Bedrock and Sagemaker) */
   awsSecretAccessKey?: string;
   awsAccessKeyId?: string;
   awsSessionToken?: string;
@@ -86,6 +86,16 @@ export interface Options {
   awsAuthType?: string;
   awsRoleArn?: string;
   awsExternalId?: string;
+
+  /** Sagemaker specific */
+  sagemakerCustomAttributes?: string;
+  sagemakerTargetModel?: string;
+  sagemakerTargetVariant?: string;
+  sagemakerTargetContainerHostname?: string;
+  sagemakerInferenceId?: string;
+  sagemakerEnableExplanations?: string;
+  sagemakerInferenceComponent?: string;
+  sagemakerSessionId?: string;
 
   /** Stability AI specific */
   stabilityClientId?: string;


### PR DESCRIPTION
Tested by making requests to sagemaker
```curl
curl --location 'http://localhost:8787/v1/endpoints/PortkeyGuardrails-gibberish/invocations' \
--header 'x-portkey-provider: sagemaker' \
--header 'x-portkey-aws-region: us-east-1' \
--header 'x-portkey-aws-access-key-id: asd' \
--header 'x-portkey-aws-secret-access-key: asd' \
--header 'x-portkey-amzn-sagemaker-inference-component: asd' \
--header 'Content-Type: application/json' \
--data '{
    "inputs": "asdajsdhasbhjda hello there"
}'
```

**Related Issues:** (optional)
- #774 
