### PR TITLE
improvement: inject plugins through HooksManager constructor

### DIFF
--- a/src/middlewares/hooks/index.ts
+++ b/src/middlewares/hooks/index.ts
@@ -174,7 +174,7 @@ export class HooksManager {
   private spans: Record<string, HookSpan> = {};
   private plugins: any;
 
-  constructor() {
+  constructor(plugins?: any) {
     this.plugins = plugins;
   }
 
@@ -442,7 +442,7 @@ export class HooksManager {
 }
 
 export const hooks = (c: Context, next: any) => {
-  const hooksManager = new HooksManager();
+  const hooksManager = new HooksManager(plugins);
   c.set('hooksManager', hooksManager);
   c.set('executeHooks', hooksManager.executeHooks.bind(hooksManager));
   return next();


### PR DESCRIPTION
Inject plugins through HooksManager constructor instead of directly define in it.

**Motivation:**
In our sveltekit project, we're using this repo as a submodule and import some part to create Hono instance and attach it to our backend. When we deploy it to Cloudflare Pages, it failed because the plugins in HooksManager depend on Node API (#601). So we copied `middlewares/hooks/index.ts` and commented out the plugins part, and use the hooks middleware in our Hono instance.

```ts
export class HookSpan { ... }

export class HooksManager {
  private spans: Record<string, HookSpan> = {}
  private plugins: any

  constructor() {
    // this.plugins = plugins // ←
  }
}

export const hooks = (c: Context, next: any) => {
  const hooksManager = new HooksManager();
  c.set('hooksManager', hooksManager);
  c.set('executeHooks', hooksManager.executeHooks.bind(hooksManager));
  return next();
};
```

if plugins are injectable through HooksManager constructor, we only need to copy the hooks middleware part.
```ts
export const hooks = (c: Context, next: any) => {
  const hooksManager = new HooksManager(plugins);
  // const hooksManager = new HooksManager(); // we will change here, pass nothing, or custom something
  c.set('hooksManager', hooksManager);
  c.set('executeHooks', hooksManager.executeHooks.bind(hooksManager));
  return next();
};
```

**Related Issues:**
- #738 
