### PR TITLE
fix: redirect public to public slash for logs ui

### DIFF
--- a/src/start-server.ts
+++ b/src/start-server.ts
@@ -43,8 +43,12 @@ if (
 
     // Set up routes
     app.get('/public/logs', serveIndex);
-    app.get('/public', serveIndex);
     app.get('/public/', serveIndex);
+
+    // Redirect `/public` to `/public/`
+    app.get('/public', (c: Context) => {
+      return c.redirect('/public/');
+    });
 
     // Serve other static files
     app.use(


### PR DESCRIPTION
**Title:** 
- Redirect /public to /public/ to render logs and help page UI without issues

**Description:** (optional)
- Redirect added for /public route

**Motivation:** (optional)
- To fix CSS loading issue for logs UI

**Related Issues:** (optional)
- #829 
