### PR TITLE
fix: add docs link in help page

### DIFF
--- a/src/public/index.html
+++ b/src/public/index.html
@@ -879,7 +879,7 @@
           src="https://media.dev.to/dynamic/image/width=320,height=320,fit=cover,gravity=auto,format=auto/https%3A%2F%2Fdev-to-uploads.s3.amazonaws.com%2Fuploads%2Forganization%2Fprofile_image%2F8056%2F39f656e2-eff4-4755-b84b-44d61d7c98b5.jpg"
           alt="Portkey AI Gateway" class="logo-image">
           <div class="header-links">
-            <a href="#">Docs</a>
+            <a href="https://portkey.ai/docs">Docs</a>
           </div>
       </div>
       <nav class="tabs-container">


### PR DESCRIPTION
**Title:** 
- Add docs page link in help page HTML

**Related Issues:** (optional)
- Closes #845 
