### PR TITLE
chore: streamline bedrock plugin creds naming convention

### DIFF
--- a/plugins/bedrock/bedrock.test.ts
+++ b/plugins/bedrock/bedrock.test.ts
@@ -34,9 +34,9 @@ describe('Credentials check', () => {
     };
     const parameters: PluginParameters<BedrockParameters['credentials']> = {
       credentials: {
-        accessKeyId: '',
-        accessKeySecret: '',
-        region: '',
+        awsAccessKeyId: '',
+        awsSecretAccessKey: '',
+        awsRegion: '',
       },
       guardrailId: '',
       guardrailVersion: '',
@@ -72,9 +72,9 @@ describe('Credentials check', () => {
     };
     const parameters: PluginParameters<BedrockParameters['credentials']> = {
       credentials: {
-        accessKeyId: 'accessKeyID',
-        region: 'us-east-1',
-        accessKeySecret: 'accessKeySecret',
+        awsAccessKeyId: 'accessKeyID',
+        awsRegion: 'us-east-1',
+        awsSecretAccessKey: 'accessKeySecret',
       },
       guardrailId: 'guardrailID',
       guardrailVersion: 'guardrailVersion',

--- a/plugins/bedrock/index.ts
+++ b/plugins/bedrock/index.ts
@@ -7,7 +7,11 @@ import {
 import { BedrockBody, BedrockParameters } from './type';
 import { bedrockPost, redactPii } from './util';
 
-const REQUIRED_CREDENTIAL_KEYS = ['accessKeyId', 'accessKeySecret', 'region'];
+const REQUIRED_CREDENTIAL_KEYS = [
+  'awsAccessKeyId',
+  'awsSecretAccessKey',
+  'awsRegion',
+];
 
 export const validateCreds = (
   credentials?: BedrockParameters['credentials']

--- a/plugins/bedrock/type.ts
+++ b/plugins/bedrock/type.ts
@@ -89,10 +89,10 @@ export interface BedrockResponse {
 
 export interface BedrockParameters {
   credentials: {
-    accessKeyId: string;
-    accessKeySecret: string;
+    awsAccessKeyId: string;
+    awsSecretAccessKey: string;
     awsSessionToken?: string;
-    region: string;
+    awsRegion: string;
   };
   guardrailVersion: string;
   guardrailId: string;

--- a/plugins/bedrock/util.ts
+++ b/plugins/bedrock/util.ts
@@ -51,7 +51,7 @@ export const bedrockPost = async (
   credentials: Record<string, string>,
   body: BedrockBody
 ) => {
-  const url = `https://bedrock-runtime.${credentials?.region}.amazonaws.com/guardrail/${credentials?.guardrailId}/version/${credentials?.guardrailVersion}/apply`;
+  const url = `https://bedrock-runtime.${credentials?.awsRegion}.amazonaws.com/guardrail/${credentials?.guardrailId}/version/${credentials?.guardrailVersion}/apply`;
 
   const headers = await generateAWSHeaders(
     body,
@@ -61,9 +61,9 @@ export const bedrockPost = async (
     url,
     'POST',
     'bedrock',
-    credentials?.region ?? 'us-east-1',
-    credentials?.accessKeyId!,
-    credentials?.accessKeySecret!,
+    credentials?.awsRegion ?? 'us-east-1',
+    credentials?.awsAccessKeyId!,
+    credentials?.awsSecretAccessKey!,
     credentials?.awsSessionToken || ''
   );
 


### PR DESCRIPTION
**Title:** 
- streamline bedrock plugin creds naming convention

**Description:** (optional)
- Detailed change 1
- Detailed change 2

**Motivation:** (optional)
- Why this change is necessary or beneficial

**Related Issues:** (optional)
- Closes #894 
