### PR TITLE
chore: transform request even for before request hooks failure

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -351,6 +351,18 @@ export async function tryPost(
   } = await beforeRequestHookHandler(c, hookSpan.id));
 
   if (brhResponse) {
+    if (!providerConfig?.requestHandlers?.[fn]) {
+      transformedRequestBody =
+        method === 'POST'
+          ? transformToProviderRequest(
+              provider,
+              params,
+              requestBody,
+              fn,
+              requestHeaders
+            )
+          : requestBody;
+    }
     return createResponse(brhResponse, undefined, false, false);
   }
 


### PR DESCRIPTION
**Title:** 
- transform request even for before request hooks failure

**Description:** (optional)
- After the redaction guardrails went live, before_request_hooks now have the capability of updating request body. So the request body transform (OAI to provider format) was moved after the hook execution to use the hook-transformed request for the final provider request transformation. But if a hook fails with deny=true (446 response status code), then we are not transforming the request body to provider format. Its getting set as {} in the request options.
- It does not affect any of the gateway functionalities but its better to keep the logic streamlined. 


**Related Issues:** (optional)
- Related #889 
