### PR TITLE
chore: allow azure-ai to accept the extra-params from the headers

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -914,6 +914,7 @@ export function constructConfigFromRequestHeaders(
       requestHeaders[`x-${POWERED_BY}-azure-deployment-type`],
     azureApiVersion: requestHeaders[`x-${POWERED_BY}-azure-api-version`],
     azureEndpointName: requestHeaders[`x-${POWERED_BY}-azure-endpoint-name`],
+    azureExtraParams: requestHeaders[`x-${POWERED_BY}-azure-extra-params`],
   };
 
   const awsConfig = {

--- a/src/providers/azure-ai-inference/api.ts
+++ b/src/providers/azure-ai-inference/api.ts
@@ -20,11 +20,15 @@ const AzureAIInferenceAPI: ProviderAPIConfig = {
     return `https://${azureEndpointName}.${azureRegion}.inference.ml.azure.com/score`;
   },
   headers: ({ providerOptions }) => {
-    const { apiKey, azureDeploymentType, azureDeploymentName } =
-      providerOptions;
+    const {
+      apiKey,
+      azureDeploymentType,
+      azureDeploymentName,
+      azureExtraParams,
+    } = providerOptions;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${apiKey}`,
-      'extra-parameters': 'ignore',
+      'extra-parameters': azureExtraParams || 'pass-through',
     };
     if (azureDeploymentType === 'managed' && azureDeploymentName) {
       headers['azureml-model-deployment'] = azureDeploymentName;

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -126,6 +126,7 @@ export interface Options {
   azureDeploymentType?: 'managed' | 'serverless';
   azureEndpointName?: string;
   azureApiVersion?: string;
+  azureExtraParams?: string;
 
   /** The parameter to determine if extra non-openai compliant fields should be returned in response */
   strictOpenAiCompliance?: boolean;


### PR DESCRIPTION
ref https://github.com/Portkey-AI/gateway/pull/534/files/c5b5cd397957e65fa4de2327d49870dbc1cf0bba#r1933769819

doc: https://learn.microsoft.com/en-us/azure/ai-foundry/model-inference/reference/reference-model-inference-chat-completions#request-header