### PR TITLE
Feat: support assumedRole auth type in bedrock guardrail plugin

### DIFF
--- a/plugins/bedrock/type.ts
+++ b/plugins/bedrock/type.ts
@@ -1,3 +1,18 @@
+export type BedrockAccessKeyCreds = {
+  awsAuthType?: 'accessKey';
+  awsAccessKeyId: string;
+  awsSecretAccessKey: string;
+  awsSessionToken?: string;
+  awsRegion: string;
+};
+
+export type BedrockAssumedRoleCreds = {
+  awsAuthType: 'assumedRole';
+  awsRoleArn: string;
+  awsExternalId: string;
+  awsRegion: string;
+};
+
 export type BedrockBody = {
   source: 'INPUT' | 'OUTPUT';
   content: { text: { text: string } }[];
@@ -88,12 +103,7 @@ export interface BedrockResponse {
 }
 
 export interface BedrockParameters {
-  credentials: {
-    awsAccessKeyId: string;
-    awsSecretAccessKey: string;
-    awsSessionToken?: string;
-    awsRegion: string;
-  };
+  credentials: BedrockAccessKeyCreds | BedrockAssumedRoleCreds;
   guardrailVersion: string;
   guardrailId: string;
 }

--- a/plugins/bedrock/util.ts
+++ b/plugins/bedrock/util.ts
@@ -134,3 +134,116 @@ export const redactPii = (text: string, result: BedrockResponse | null) => {
     return null;
   }
 };
+
+export async function getAssumedRoleCredentials(
+  getFromCacheByKey: Function | undefined,
+  putInCacheWithValue: Function | undefined,
+  env: Record<string, any>,
+  awsRoleArn: string,
+  awsExternalId: string,
+  awsRegion: string,
+  creds?: {
+    accessKeyId: string;
+    secretAccessKey: string;
+    sessionToken?: string;
+  }
+) {
+  const cacheKey = `${awsRoleArn}/${awsExternalId}/${awsRegion}`;
+  const resp = getFromCacheByKey
+    ? await getFromCacheByKey(env, cacheKey)
+    : null;
+
+  if (resp) {
+    return resp;
+  }
+
+  // Determine which credentials to use
+  let accessKeyId: string;
+  let secretAccessKey: string;
+  let sessionToken: string | undefined;
+
+  if (creds) {
+    // Use provided credentials
+    accessKeyId = creds.accessKeyId;
+    secretAccessKey = creds.secretAccessKey;
+    sessionToken = creds.sessionToken;
+  } else {
+    // Use environment credentials
+    const { AWS_ASSUME_ROLE_ACCESS_KEY_ID, AWS_ASSUME_ROLE_SECRET_ACCESS_KEY } =
+      env;
+    accessKeyId = AWS_ASSUME_ROLE_ACCESS_KEY_ID || '';
+    secretAccessKey = AWS_ASSUME_ROLE_SECRET_ACCESS_KEY || '';
+  }
+
+  const region = awsRegion || 'us-east-1';
+  const service = 'sts';
+  const hostname = `sts.${region}.amazonaws.com`;
+  const signer = new SignatureV4({
+    service,
+    region,
+    credentials: {
+      accessKeyId,
+      secretAccessKey,
+      sessionToken,
+    },
+    sha256: Sha256,
+  });
+  const date = new Date();
+  const sessionName = `${date.getFullYear()}${date.getMonth()}${date.getDay()}`;
+  const url = `https://${hostname}?Action=AssumeRole&Version=2011-06-15&RoleArn=${awsRoleArn}&RoleSessionName=${sessionName}${awsExternalId ? `&ExternalId=${awsExternalId}` : ''}`;
+  const urlObj = new URL(url);
+  const requestHeaders = { host: hostname };
+  const options = {
+    method: 'GET',
+    path: urlObj.pathname,
+    protocol: urlObj.protocol,
+    hostname: urlObj.hostname,
+    headers: requestHeaders,
+    query: Object.fromEntries(urlObj.searchParams),
+  };
+  const { headers } = await signer.sign(options);
+
+  let credentials: any;
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers: headers,
+    });
+
+    if (!response.ok) {
+      const resp = await response.text();
+      console.error({ message: resp });
+      throw new Error(`HTTP error! status: ${response.status}`);
+    }
+
+    const xmlData = await response.text();
+    credentials = parseXml(xmlData);
+    if (putInCacheWithValue) {
+      putInCacheWithValue(env, cacheKey, credentials, 60); //1 minute
+    }
+  } catch (error) {
+    console.error({ message: `Error assuming role:, ${error}` });
+  }
+  return credentials;
+}
+
+function parseXml(xml: string) {
+  // Simple XML parser for this specific use case
+  const getTagContent = (tag: string) => {
+    const regex = new RegExp(`<${tag}>(.*?)</${tag}>`, 's');
+    const match = xml.match(regex);
+    return match ? match[1] : null;
+  };
+
+  const credentials = getTagContent('Credentials');
+  if (!credentials) {
+    throw new Error('Failed to parse Credentials from XML response');
+  }
+
+  return {
+    accessKeyId: getTagContent('AccessKeyId'),
+    secretAccessKey: getTagContent('SecretAccessKey'),
+    sessionToken: getTagContent('SessionToken'),
+    expiration: getTagContent('Expiration'),
+  };
+}

--- a/plugins/bedrock/util.ts
+++ b/plugins/bedrock/util.ts
@@ -148,6 +148,9 @@ export async function getAssumedRoleCredentials(
     sessionToken?: string;
   }
 ) {
+  if (!awsRoleArn) {
+    return;
+  }
   const cacheKey = `${awsRoleArn}/${awsExternalId}/${awsRegion}`;
   const resp = getFromCacheByKey
     ? await getFromCacheByKey(env, cacheKey)

--- a/plugins/types.ts
+++ b/plugins/types.ts
@@ -26,5 +26,7 @@ export type PluginHandler<P = Record<string, string>> = (
   eventType: HookEventType,
   options?: {
     env: Record<string, any>;
+    getFromCacheByKey?: (key: string) => Promise<any>;
+    putInCacheWithValue?: (key: string, value: any) => Promise<any>;
   }
 ) => Promise<PluginHandlerResponse>;

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -1325,7 +1325,11 @@ export async function beforeRequestHookHandler(
     const hooksResult = await hooksManager.executeHooks(
       hookSpanId,
       ['syncBeforeRequestHook'],
-      { env: env(c) }
+      {
+        env: env(c),
+        getFromCacheByKey: c.get('getFromCacheByKey'),
+        putInCacheWithValue: c.get('putInCacheWithValue'),
+      }
     );
 
     span = hooksManager.getSpan(hookSpanId) as HookSpan;

--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -218,9 +218,15 @@ export async function afterRequestHookHandler(
       hooksManager.getSpan(hookSpanId).resetHookResult('afterRequestHook');
     }
 
-    const { shouldDeny } = await hooksManager.executeHooks(hookSpanId, [
-      'syncAfterRequestHook',
-    ]);
+    const { shouldDeny } = await hooksManager.executeHooks(
+      hookSpanId,
+      ['syncAfterRequestHook'],
+      {
+        env: env(c),
+        getFromCacheByKey: c.get('getFromCacheByKey'),
+        putInCacheWithValue: c.get('putInCacheWithValue'),
+      }
+    );
 
     if (!responseJSON) {
       return response;


### PR DESCRIPTION
**Title:** 
- support assumedRole auth type in bedrock guardrail plugin

**Description:** (optional)
- Added support assumedRole auth type same as the bedrock provider

**Motivation:** (optional)
- Why this change is necessary or beneficial

**Related Issues:** (optional)
- Closes #907 
