### PR TITLE
cache vertex generated token

### DIFF
--- a/src/providers/google-vertex-ai/api.ts
+++ b/src/providers/google-vertex-ai/api.ts
@@ -41,11 +41,11 @@ export const GoogleApiConfig: ProviderAPIConfig = {
 
     return `https://${vertexRegion}-aiplatform.googleapis.com`;
   },
-  headers: async ({ providerOptions }) => {
+  headers: async ({ c, providerOptions }) => {
     const { apiKey, vertexServiceAccountJson } = providerOptions;
     let authToken = apiKey;
     if (vertexServiceAccountJson) {
-      authToken = await getAccessToken(vertexServiceAccountJson);
+      authToken = await getAccessToken(c, vertexServiceAccountJson);
     }
 
     return {

--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -94,7 +94,6 @@ export const getAccessToken = async (
     } catch (err) {}
 
     const scope = 'https://www.googleapis.com/auth/cloud-platform';
-    ``;
     const iat = Math.floor(Date.now() / 1000);
     const exp = iat + 3600; // Token expiration time (1 hour)
 

--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -134,7 +134,7 @@ export const getAccessToken = async (
     const tokenJson: Record<string, any> = await tokenResponse.json();
     const putInCacheWithValue = c.get('putInCacheWithValue');
     if (putInCacheWithValue && cacheKey) {
-      await putInCacheWithValue(env(c), cacheKey, tokenJson.access_token, 1800); // 30 minutes
+      await putInCacheWithValue(env(c), cacheKey, tokenJson.access_token, 3000); // 50 minutes
     }
 
     return tokenJson.access_token;


### PR DESCRIPTION
Testing done:
- [X] validated caching behaviour, made requests at 0, 1min, 15min, 51min

Note:
The generated token is valid for 1hour, I've put the default cache time as 50min

#915 