### PR TITLE
Fix fail condition in link checker

### DIFF
--- a/.github/workflows/link-checker.yml
+++ b/.github/workflows/link-checker.yml
@@ -20,7 +20,8 @@ jobs:
       - name: Link Checker
         uses: lycheeverse/lychee-action@v1.8.0
         with:
-          args: --verbose --no-progress --fail './**/*.md'
+          args: --verbose --no-progress './**/*.md'
+          fail: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
**Fix fail condition for lychee link checker:** 
The link checker is currently misconfigured and fails with an error message:

```sh
Run lycheeverse/lychee-action@v1.8.0
Run curl -sLO "https://github.com/lycheeverse/lychee/releases/download/v0.13.0/lychee-v0.13.0-x86_64-unknown-linux-gnu.tar.gz"
lychee
Run /home/runner/work/_actions/lycheeverse/lychee-action/v1.8.0/entrypoint.sh
error: unexpected argument '--fail' found

  note: to pass '--fail' as a value, use '-- --fail'

Usage: lychee --format <FORMAT> --output <OUTPUT> --no-progress <--verbose...|--quiet...> <inputs>...

For more information, try '--help'.
```

The reason is that the syntax is incorrect. `--fail` is not a flag of lychee, but a parameter of `lychee-action`.

**Description:**
- Fixes the syntax and passes `fail: true` to the action.
- Removes the non-existent `--fail` flag

**Motivation:**
The misconfigured action silently ignored link checking issues.
As a consequence, some links are currently broken, but that's a separate issue.

