### PR TITLE
feat: allow azure openai to pass custom uri

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -896,6 +896,7 @@ export function constructConfigFromRequestHeaders(
     openaiBeta:
       requestHeaders[`x-${POWERED_BY}-openai-beta`] ||
       requestHeaders[`openai-beta`],
+    azureCustomUri: requestHeaders[`x-${POWERED_BY}-azure-custom-uri`],
   };
 
   const stabilityAiConfig = {

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -65,6 +65,7 @@ export interface Options {
   azureEntraClientId?: string;
   azureEntraClientSecret?: string;
   azureEntraTenantId?: string;
+  azureCustomUri?: string;
   /** Workers AI specific */
   workersAiAccountId?: string;
   /** The parameter to set custom base url */


### PR DESCRIPTION
**Title:** 
feat: allow azure openai to pass custom uri

**Description:** (optional)
This pull request introduces support for a custom Azure URI for OpenAI requests. The following changes have been made:

**Header Handling:**
Updated constructConfigFromRequestHeaders to extract the azureCustomUri from the incoming request headers. This enables the passing of a custom URI from the client.

**Provider Configuration:**
Modified AzureOpenAIAPIConfig in src/providers/azure-openai/api.ts to use the azureCustomUri when constructing the base URL for API requests.
Updated the endpoint resolution logic so that if a custom URI is provided, the URL structure is adapted accordingly (e.g., DeepSeek-R1 on Azure uses {resourceName}.services.ai.azure.com/models).

**Type Definitions:**
Extended the Options interface in src/types/requestBody.ts to include the azureCustomUri field.

**Motivation:** (optional)
This enhancement is necessary to support scenarios where a non-standard Azure endpoint is required (such as DeepSeek-R1). By allowing users to pass a custom URI, we provide greater flexibility and ensure compatibility with alternative endpoint configurations.

**Related Issues:** (optional)
- #issue-number
