### PR TITLE
fix: use correct param azure file id

### DIFF
--- a/src/providers/azure-openai/api.ts
+++ b/src/providers/azure-openai/api.ts
@@ -77,7 +77,12 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
     }
 
     const segments = gatewayRequestURL?.split('/');
-    const id = segments?.at(-1) ?? '';
+    let id = '';
+    if (['retrieveFileContent'].includes(mappedFn)) {
+      id = segments?.at(-2) ?? '';
+    } else {
+      id = segments?.at(-1) ?? '';
+    }
 
     switch (mappedFn) {
       case 'complete': {


### PR DESCRIPTION
**Title:** 
- Use correct placeholder for the fileid param.


**Motivation:** (optional)
- Get File content is failing because of wrong index for `id`.

**Related Issues:** (optional)
- #918
