### PR TITLE
handle usage chunk in streaming responses and map model in gemini model response

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -824,7 +824,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
     id: fallbackId,
     object: 'chat.completion.chunk',
     created: Math.floor(Date.now() / 1000),
-    model: '',
+    model: parsedChunk.modelVersion,
     provider: GOOGLE_VERTEX_AI,
     choices:
       parsedChunk.candidates?.map((generation, index) => {

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -653,7 +653,7 @@ export const GoogleChatCompleteResponseTransform: (
       id: 'portkey-' + crypto.randomUUID(),
       object: 'chat_completion',
       created: Math.floor(Date.now() / 1000),
-      model: 'Unknown',
+      model: response.modelVersion,
       provider: GOOGLE_VERTEX_AI,
       choices:
         response.candidates?.map((generation, index) => {

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -879,7 +879,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
             : {}),
         };
       }) ?? [],
-    usage: usageMetadata,
+    ...(parsedChunk.usageMetadata?.candidatesTokenCount && {
+      usage: usageMetadata,
+    }),
   };
 
   return `data: ${JSON.stringify(dataChunk)}\n\n`;

--- a/src/providers/google-vertex-ai/types.ts
+++ b/src/providers/google-vertex-ai/types.ts
@@ -67,6 +67,7 @@ export interface GoogleResponseCandidate {
 }
 
 export interface GoogleGenerateContentResponse {
+  modelVersion: string;
   candidates: GoogleResponseCandidate[];
   promptFeedback: {
     safetyRatings: {

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -626,6 +626,15 @@ export const GoogleChatCompleteStreamChunkTransform: (
 
   const parsedChunk: GoogleGenerateContentResponse = JSON.parse(chunk);
 
+  let usageMetadata;
+  if (parsedChunk.usageMetadata) {
+    usageMetadata = {
+      prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
+      completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
+      total_tokens: parsedChunk.usageMetadata.totalTokenCount,
+    };
+  }
+
   return (
     `data: ${JSON.stringify({
       id: fallbackId,
@@ -690,11 +699,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
               : {}),
           };
         }) ?? [],
-      usage: {
-        prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
-        completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
-        total_tokens: parsedChunk.usageMetadata.totalTokenCount,
-      },
+      ...(parsedChunk.usageMetadata?.candidatesTokenCount && {
+        usage: usageMetadata,
+      }),
     })}` + '\n\n'
   );
 };

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -466,6 +466,7 @@ interface GoogleResponseCandidate {
 }
 
 interface GoogleGenerateContentResponse {
+  modelVersion: string;
   candidates: GoogleResponseCandidate[];
   promptFeedback: {
     safetyRatings: {
@@ -522,7 +523,7 @@ export const GoogleChatCompleteResponseTransform: (
       id: 'portkey-' + crypto.randomUUID(),
       object: 'chat_completion',
       created: Math.floor(Date.now() / 1000),
-      model: 'Unknown',
+      model: response.modelVersion,
       provider: 'google',
       choices:
         response.candidates?.map((generation, idx) => {

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -646,7 +646,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
       id: fallbackId,
       object: 'chat.completion.chunk',
       created: Math.floor(Date.now() / 1000),
-      model: '',
+      model: parsedChunk.modelVersion,
       provider: 'google',
       choices:
         parsedChunk.candidates?.map((generation, index) => {


### PR DESCRIPTION
**Description:** (optional)
- #934 

**Sanity:**
- [X] test with gemini-2.0-flash for both vertex-ai and google providers
- [X] test with gemini-1.5-flash for both vertex-ai and google providers
