### PR TITLE
feat: support new openai routes as unified endpoints

### DIFF
--- a/src/handlers/chatCompletionsHandler.ts
+++ b/src/handlers/chatCompletionsHandler.ts
@@ -34,7 +34,7 @@ export function chatCompletionsHandler(endpoint: endpointStrings) {
 
       return tryTargetsResponse;
     } catch (err: any) {
-      console.log(`${endpoint} error`, err.message);
+      console.log(`${endpoint} error: ${err.message}`);
       let statusCode = 500;
       let errorMessage = 'Something went wrong';
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -118,7 +118,36 @@ app.onError((err, c) => {
  * POST route for '/v1/chat/completions'.
  * Handles requests by passing them to the chatCompletionsHandler.
  */
-app.post('/v1/chat/completions', requestValidator, chatCompletionsHandler);
+app.post(
+  '/v1/chat/completions',
+  requestValidator,
+  chatCompletionsHandler('chatComplete')
+);
+app.get(
+  '/v1/chat/completions',
+  requestValidator,
+  chatCompletionsHandler('listChatCompletions')
+);
+app.get(
+  '/v1/chat/completions/:completionId',
+  requestValidator,
+  chatCompletionsHandler('getChatCompletion')
+);
+app.get(
+  '/v1/chat/completions/:completionId/messages',
+  requestValidator,
+  chatCompletionsHandler('getChatCompletionMessages')
+);
+app.post(
+  '/v1/chat/completions/:completionId',
+  requestValidator,
+  chatCompletionsHandler('updateChatCompletion')
+);
+app.delete(
+  '/v1/chat/completions/:completionId',
+  requestValidator,
+  chatCompletionsHandler('deleteChatCompletion')
+);
 
 /**
  * POST route for '/v1/completions'.
@@ -168,12 +197,7 @@ app.get(
   requestValidator,
   filesHandler('retrieveFileContent', 'GET')
 );
-app.post(
-  '/v1/files',
-
-  requestValidator,
-  filesHandler('uploadFile', 'POST')
-);
+app.post('/v1/files', requestValidator, filesHandler('uploadFile', 'POST'));
 app.delete(
   '/v1/files/:id',
   requestValidator,
@@ -209,7 +233,7 @@ app.get('/v1/batches', requestValidator, batchesHandler('listBatches', 'GET'));
  */
 app.post('/v1/prompts/*', requestValidator, (c) => {
   if (c.req.url.endsWith('/v1/chat/completions')) {
-    return chatCompletionsHandler(c);
+    return chatCompletionsHandler('chatComplete')(c);
   } else if (c.req.url.endsWith('/v1/completions')) {
     return completionsHandler(c);
   }

--- a/src/providers/azure-openai/api.ts
+++ b/src/providers/azure-openai/api.ts
@@ -76,13 +76,6 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
       }
     }
 
-    const segments = gatewayRequestURL?.split('/');
-    let id = '';
-    if (['retrieveFileContent'].includes(mappedFn)) {
-      id = segments?.at(-2) ?? '';
-    } else {
-      id = segments?.at(-1) ?? '';
-    }
     const path = gatewayRequestURL.split('/v1')?.[1];
     const apiVersionQueryParam = path.includes('?')
       ? `&api-version=${apiVersion}`

--- a/src/providers/azure-openai/api.ts
+++ b/src/providers/azure-openai/api.ts
@@ -84,7 +84,9 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
       id = segments?.at(-1) ?? '';
     }
     const path = gatewayRequestURL.split('/v1')?.[1];
-    const apiVersionQueryParam = path.includes('?') ? `&api-version=${apiVersion}` : `?api-version=${apiVersion}`;
+    const apiVersionQueryParam = path.includes('?')
+      ? `&api-version=${apiVersion}`
+      : `?api-version=${apiVersion}`;
 
     switch (mappedFn) {
       case 'complete': {

--- a/src/providers/azure-openai/api.ts
+++ b/src/providers/azure-openai/api.ts
@@ -54,7 +54,8 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
     }
     return headersObj;
   },
-  getEndpoint: ({ providerOptions, fn, gatewayRequestURL }) => {
+  getEndpoint: ({ providerOptions, fn, gatewayRequestURL, c }) => {
+    const gatewayRequestPath = c.req.url.split('/v1')[0];
     const { apiVersion, urlToFetch, deploymentId } = providerOptions;
     let mappedFn = fn;
 
@@ -83,6 +84,9 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
     } else {
       id = segments?.at(-1) ?? '';
     }
+    const azureSpecificQueryParams = gatewayRequestPath.includes('?')
+      ? `&${apiVersion}&deployment=${providerOptions.deploymentId}`
+      : `?${apiVersion}&deployment=${providerOptions.deploymentId}`;
 
     switch (mappedFn) {
       case 'complete': {
@@ -119,6 +123,16 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
         return `/files/${id}?api-version=${apiVersion}`;
       case 'retrieveFileContent':
         return `/files/${id}/content?api-version=${apiVersion}`;
+      case 'listChatCompletions':
+        return gatewayRequestPath + azureSpecificQueryParams;
+      case 'getChatCompletion':
+        return gatewayRequestPath + azureSpecificQueryParams;
+      case 'getChatCompletionMessages':
+        return gatewayRequestPath + azureSpecificQueryParams;
+      case 'updateChatCompletion':
+        return gatewayRequestPath + azureSpecificQueryParams;
+      case 'deleteChatCompletion':
+        return gatewayRequestPath + azureSpecificQueryParams;
       default:
         return '';
     }

--- a/src/providers/azure-openai/api.ts
+++ b/src/providers/azure-openai/api.ts
@@ -85,8 +85,8 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
       id = segments?.at(-1) ?? '';
     }
     const azureSpecificQueryParams = gatewayRequestPath.includes('?')
-      ? `&${apiVersion}&deployment=${providerOptions.deploymentId}`
-      : `?${apiVersion}&deployment=${providerOptions.deploymentId}`;
+      ? `&api-version=${apiVersion}&deployment=${providerOptions.deploymentId}`
+      : `?api-version=${apiVersion}&deployment=${providerOptions.deploymentId}`;
 
     switch (mappedFn) {
       case 'complete': {

--- a/src/providers/azure-openai/api.ts
+++ b/src/providers/azure-openai/api.ts
@@ -76,10 +76,12 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
       }
     }
 
-    const path = gatewayRequestURL.split('/v1')?.[1];
-    const apiVersionQueryParam = path.includes('?')
-      ? `&api-version=${apiVersion}`
-      : `?api-version=${apiVersion}`;
+    const url = new URL(gatewayRequestURL);
+    if (apiVersion) {
+      url.searchParams.set('api-version', apiVersion);
+    }
+    const path = url.pathname;
+    const searchParams = url.searchParams.toString();
 
     switch (mappedFn) {
       case 'complete': {
@@ -107,41 +109,41 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
         return `/realtime?api-version=${apiVersion}&deployment=${deploymentId}`;
       }
       case 'uploadFile':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'retrieveFile':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'listFiles':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'deleteFile':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'retrieveFileContent':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'createFinetune':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'retrieveFinetune':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'listFinetunes':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'cancelFinetune':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'createBatch':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'retrieveBatch':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'cancelBatch':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'listBatches':
-        return `${path}?api-version=${apiVersion}`;
+        return `${path}?${searchParams}`;
       case 'listChatCompletions':
-        return `/deployments/${deploymentId}/${path}` + apiVersionQueryParam;
+        return `/deployments/${deploymentId}/${path}?${searchParams}`;
       case 'getChatCompletion':
-        return `/deployments/${deploymentId}/${path}` + apiVersionQueryParam;
+        return `/deployments/${deploymentId}/${path}?${searchParams}`;
       case 'getChatCompletionMessages':
-        return `/deployments/${deploymentId}/${path}` + apiVersionQueryParam;
+        return `/deployments/${deploymentId}/${path}?${searchParams}`;
       case 'updateChatCompletion':
-        return `/deployments/${deploymentId}/${path}` + apiVersionQueryParam;
+        return `/deployments/${deploymentId}/${path}?${searchParams}`;
       case 'deleteChatCompletion':
-        return `/deployments/${deploymentId}/${path}` + apiVersionQueryParam;
+        return `/deployments/${deploymentId}/${path}?${searchParams}`;
       default:
         return '';
     }

--- a/src/providers/azure-openai/index.ts
+++ b/src/providers/azure-openai/index.ts
@@ -24,6 +24,7 @@ import { AzureOpenAICreateTranscriptionResponseTransform } from './createTranscr
 import { AzureOpenAICreateTranslationResponseTransform } from './createTranslation';
 import { AzureOpenAIResponseTransform } from './utils';
 import { AzureOpenAIRequestTransform } from './uploadFile';
+import { AzureOpenAIUpdateChatCompletionConfig } from './updateChatCompletion';
 
 const AzureOpenAIConfig: ProviderConfigs = {
   complete: AzureOpenAICompleteConfig,
@@ -35,6 +36,7 @@ const AzureOpenAIConfig: ProviderConfigs = {
   createTranscription: {},
   createTranslation: {},
   realtime: {},
+  updateChatCompletion: AzureOpenAIUpdateChatCompletionConfig,
   responseTransforms: {
     complete: AzureOpenAICompleteResponseTransform,
     chatComplete: AzureOpenAIChatCompleteResponseTransform,
@@ -49,6 +51,11 @@ const AzureOpenAIConfig: ProviderConfigs = {
     retrieveFile: AzureOpenAIResponseTransform,
     deleteFile: AzureOpenAIResponseTransform,
     retrieveFileContent: AzureOpenAIResponseTransform,
+    listChatCompletions: AzureOpenAIResponseTransform,
+    getChatCompletion: AzureOpenAIResponseTransform,
+    getChatCompletionMessages: AzureOpenAIResponseTransform,
+    updateChatCompletion: AzureOpenAIResponseTransform,
+    deleteChatCompletion: AzureOpenAIResponseTransform,
   },
   requestTransforms: {
     uploadFile: AzureOpenAIRequestTransform,

--- a/src/providers/azure-openai/index.ts
+++ b/src/providers/azure-openai/index.ts
@@ -22,13 +22,13 @@ import {
 } from './createSpeech';
 import { AzureOpenAICreateTranscriptionResponseTransform } from './createTranscription';
 import { AzureOpenAICreateTranslationResponseTransform } from './createTranslation';
-import { AzureOpenAIUpdateChatCompletionConfig } from './updateChatCompletion';
 import { OpenAICreateFinetuneConfig } from '../openai/createFinetune';
 import { AzureTransformFinetuneBody } from './createFinetune';
 import { OpenAIFileUploadRequestTransform } from '../openai/uploadFile';
 import { AzureOpenAIFinetuneResponseTransform } from './utils';
 import { AzureOpenAICreateBatchConfig } from './createBatch';
 import { AzureOpenAIGetBatchOutputRequestHandler } from './getBatchOutput';
+import { OpenAIUpdateChatCompletionConfig } from '../openai/updateChatCompletions';
 
 const AzureOpenAIConfig: ProviderConfigs = {
   complete: AzureOpenAICompleteConfig,
@@ -41,7 +41,7 @@ const AzureOpenAIConfig: ProviderConfigs = {
   createTranscription: {},
   createTranslation: {},
   realtime: {},
-  updateChatCompletion: AzureOpenAIUpdateChatCompletionConfig,
+  updateChatCompletion: OpenAIUpdateChatCompletionConfig,
   cancelFinetune: {},
   cancelBatch: {},
   createBatch: AzureOpenAICreateBatchConfig,

--- a/src/providers/azure-openai/index.ts
+++ b/src/providers/azure-openai/index.ts
@@ -22,7 +22,6 @@ import {
 } from './createSpeech';
 import { AzureOpenAICreateTranscriptionResponseTransform } from './createTranscription';
 import { AzureOpenAICreateTranslationResponseTransform } from './createTranslation';
-import { AzureOpenAIRequestTransform } from './uploadFile';
 import { AzureOpenAIUpdateChatCompletionConfig } from './updateChatCompletion';
 import { OpenAICreateFinetuneConfig } from '../openai/createFinetune';
 import { AzureTransformFinetuneBody } from './createFinetune';

--- a/src/providers/azure-openai/updateChatCompletion.ts
+++ b/src/providers/azure-openai/updateChatCompletion.ts
@@ -1,0 +1,8 @@
+import { ProviderConfig } from '../types';
+
+export const AzureOpenAIUpdateChatCompletionConfig: ProviderConfig = {
+  metadata: {
+    param: 'metadata',
+    required: true,
+  },
+};

--- a/src/providers/azure-openai/updateChatCompletion.ts
+++ b/src/providers/azure-openai/updateChatCompletion.ts
@@ -1,8 +1,0 @@
-import { ProviderConfig } from '../types';
-
-export const AzureOpenAIUpdateChatCompletionConfig: ProviderConfig = {
-  metadata: {
-    param: 'metadata',
-    required: true,
-  },
-};

--- a/src/providers/openai/api.ts
+++ b/src/providers/openai/api.ts
@@ -64,6 +64,16 @@ const OpenAIAPIConfig: ProviderAPIConfig = {
         return basePath;
       case 'listBatches':
         return basePath;
+      case 'listChatCompletions':
+        return basePath;
+      case 'getChatCompletion':
+        return basePath;
+      case 'getChatCompletionMessages':
+        return basePath;
+      case 'updateChatCompletion':
+        return basePath;
+      case 'deleteChatCompletion':
+        return basePath;
       default:
         return '';
     }

--- a/src/providers/openai/deleteChatCompletions.ts
+++ b/src/providers/openai/deleteChatCompletions.ts
@@ -1,0 +1,17 @@
+import { OPEN_AI } from '../../globals';
+import { ErrorResponse, DeleteChatCompletionResponse } from '../types';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAIDeleteChatCompletionResponseTransform: (
+  response: DeleteChatCompletionResponse | ErrorResponse,
+  responseStatus: number
+) => DeleteChatCompletionResponse | ErrorResponse = (
+  response,
+  responseStatus
+) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};

--- a/src/providers/openai/getChatCompletion.ts
+++ b/src/providers/openai/getChatCompletion.ts
@@ -1,0 +1,18 @@
+import { OPEN_AI } from '../../globals';
+import { ErrorResponse } from '../types';
+import { OpenAIChatCompleteResponse } from './chatComplete';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAIGetChatCompletionResponseTransform: (
+  response: OpenAIChatCompleteResponse | ErrorResponse,
+  responseStatus: number
+) => OpenAIChatCompleteResponse | ErrorResponse = (
+  response,
+  responseStatus
+) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};

--- a/src/providers/openai/getChatMessages.ts
+++ b/src/providers/openai/getChatMessages.ts
@@ -1,0 +1,14 @@
+import { OPEN_AI } from '../../globals';
+import { ErrorResponse, GetChatMessagesResponse } from '../types';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAIGetChatMessagesResponseTransform: (
+  response: GetChatMessagesResponse | ErrorResponse,
+  responseStatus: number
+) => GetChatMessagesResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};

--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -34,6 +34,14 @@ import { OpenAIRetrieveBatchResponseTransform } from './retrieveBatch';
 import { OpenAICancelBatchResponseTransform } from './cancelBatch';
 import { OpenAIListBatchesResponseTransform } from './listBatches';
 import { OpenAIGetBatchOutputRequestHandler } from './getBatchOutput';
+import { OpenAIListChatCompletionsResponseTransform } from './listChatCompletions';
+import { OpenAIGetChatMessagesResponseTransform } from './getChatMessages';
+import { OpenAIDeleteChatCompletionResponseTransform } from './deleteChatCompletions';
+import { OpenAIGetChatCompletionResponseTransform } from './getChatCompletion';
+import {
+  OpenAIUpdateChatCompletionResponseTransform,
+  OpenAIUpdateChatCompletionConfig,
+} from './updateChatCompletions';
 
 const OpenAIConfig: ProviderConfigs = {
   complete: OpenAICompleteConfig,
@@ -47,6 +55,7 @@ const OpenAIConfig: ProviderConfigs = {
   realtime: {},
   createBatch: OpenAICreateBatchConfig,
   cancelBatch: {},
+  updateChatCompletion: OpenAIUpdateChatCompletionConfig,
   requestHandlers: {
     getBatchOutput: OpenAIGetBatchOutputRequestHandler,
   },
@@ -73,6 +82,11 @@ const OpenAIConfig: ProviderConfigs = {
     retrieveBatch: OpenAIRetrieveBatchResponseTransform,
     cancelBatch: OpenAICancelBatchResponseTransform,
     listBatches: OpenAIListBatchesResponseTransform,
+    listChatCompletions: OpenAIListChatCompletionsResponseTransform,
+    getChatCompletion: OpenAIGetChatCompletionResponseTransform,
+    getChatCompletionMessages: OpenAIGetChatMessagesResponseTransform,
+    updateChatCompletion: OpenAIUpdateChatCompletionResponseTransform,
+    deleteChatCompletion: OpenAIDeleteChatCompletionResponseTransform,
   },
 };
 

--- a/src/providers/openai/listChatCompletions.ts
+++ b/src/providers/openai/listChatCompletions.ts
@@ -1,0 +1,18 @@
+import { OPEN_AI } from '../../globals';
+import { ErrorResponse } from '../types';
+import { OpenAIChatCompleteResponse } from './chatComplete';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAIListChatCompletionsResponseTransform: (
+  response: OpenAIChatCompleteResponse[] | ErrorResponse,
+  responseStatus: number
+) => OpenAIChatCompleteResponse[] | ErrorResponse = (
+  response,
+  responseStatus
+) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};

--- a/src/providers/openai/updateChatCompletions.ts
+++ b/src/providers/openai/updateChatCompletions.ts
@@ -1,0 +1,25 @@
+import { OPEN_AI } from '../../globals';
+import { ErrorResponse, ProviderConfig } from '../types';
+import { OpenAIChatCompleteResponse } from './chatComplete';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAIUpdateChatCompletionConfig: ProviderConfig = {
+  metadata: {
+    param: 'metadata',
+    required: true,
+  },
+};
+
+export const OpenAIUpdateChatCompletionResponseTransform: (
+  response: OpenAIChatCompleteResponse | ErrorResponse,
+  responseStatus: number
+) => OpenAIChatCompleteResponse | ErrorResponse = (
+  response,
+  responseStatus
+) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -91,7 +91,12 @@ export type endpointStrings =
   | 'retrieveBatch'
   | 'cancelBatch'
   | 'listBatches'
-  | 'getBatchOutput';
+  | 'getBatchOutput'
+  | 'listChatCompletions'
+  | 'getChatCompletion'
+  | 'getChatCompletionMessages'
+  | 'deleteChatCompletion'
+  | 'updateChatCompletion';
 /**
  * A collection of API configurations for multiple AI providers.
  * @interface
@@ -297,4 +302,18 @@ export interface CancelBatchResponse extends Batch {}
 export interface ListBatchesResponse {
   object: string | 'list';
   data: Batch[];
+}
+
+export interface DeleteChatCompletionResponse {
+  object: string;
+  deleted: boolean;
+  id: string;
+}
+
+export interface GetChatMessagesResponse {
+  object: string;
+  data: Message[];
+  first_id: string;
+  last_id: string;
+  has_more: boolean;
 }


### PR DESCRIPTION
#953 

This adds support for the new chat completions endpoints for both openai and azure openai
https://platform.openai.com/docs/api-reference/chat
https://learn.microsoft.com/en-us/azure/ai-services/openai/how-to/stored-completions?tabs=python-secure

1. GET /chat/completions/:completionId
2. GET /chat/completions
3. POST /chat/completions/:completionId
4. GET /chat/completions/:completionId/messages
5. DELETE /chat/completions/:completionId


**Testing Done**
- [X] Tested all the new routes for openai
- [ ] Tested all the new routes for azure-openai 