### PR TITLE
fix: use bedrock job_id and job_arn for response

### DIFF
--- a/src/providers/bedrock/createFinetune.ts
+++ b/src/providers/bedrock/createFinetune.ts
@@ -41,8 +41,11 @@ export const BedrockCreateFinetuneConfig: ProviderConfig = {
     param: 'validationDataConfig',
     required: false,
     transform: (value: FinetuneRequest) => {
+      if (!value.validation_file) {
+        return undefined;
+      }
       return {
-        s3Uri: decodeURIComponent(value.validation_file ?? ''),
+        s3Uri: decodeURIComponent(value.validation_file),
       };
     },
   },

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -306,7 +306,8 @@ export const bedrockFinetuneToOpenAI = (finetune: BedrockFinetuneRecord) => {
       break;
   }
   return {
-    id: finetune.jobName,
+    id: encodeURIComponent(finetune.jobArn),
+    job_name: finetune.jobName,
     object: 'finetune',
     status: status,
     created_at: new Date(finetune.creationTime).getTime(),

--- a/src/providers/google-vertex-ai/getBatchOutput.ts
+++ b/src/providers/google-vertex-ai/getBatchOutput.ts
@@ -143,11 +143,13 @@ export const BatchOutputRequestHandler: RequestHandler = async ({
     },
   });
 
+  const [safeStream] = responseStream.readable.tee();
+
   // Pipe the node stream through the line splitter and then to the response stream.
   const lineSplitter = createLineSplitter();
   reader.pipeThrough(lineSplitter).pipeTo(responseStream.writable);
 
-  return new Response(responseStream.readable, {
+  return new Response(safeStream, {
     headers: { 'Content-Type': 'application/octet-stream' },
   });
 };


### PR DESCRIPTION
**Title:** 
- Return both jobArn and jobId for bedrock finetune apis.

**Related Issues:** (optional)
- #943
