### PR TITLE
support returning raw_response for anthropic for enabling thinking mode as a beta feature

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -14,6 +14,7 @@ export const HEADER_KEYS: Record<string, string> = {
   CUSTOM_HOST: `x-${POWERED_BY}-custom-host`,
   REQUEST_TIMEOUT: `x-${POWERED_BY}-request-timeout`,
   STRICT_OPEN_AI_COMPLIANCE: `x-${POWERED_BY}-strict-open-ai-compliance`,
+  INCLUDE_RAW_RESPONSE: `x-${POWERED_BY}-include-raw-response`,
   CONTENT_TYPE: `Content-Type`,
 };
 

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -266,11 +266,16 @@ export async function tryPost(
       : { ...requestBody, ...overrideParams };
   const isStreamingMode = params.stream ? true : false;
   let strictOpenAiCompliance = true;
+  let includeRawResponse = false;
 
   if (requestHeaders[HEADER_KEYS.STRICT_OPEN_AI_COMPLIANCE] === 'false') {
     strictOpenAiCompliance = false;
   } else if (providerOption.strictOpenAiCompliance === false) {
     strictOpenAiCompliance = false;
+  }
+
+  if (requestHeaders[HEADER_KEYS.INCLUDE_RAW_RESPONSE] === 'true') {
+    includeRawResponse = true;
   }
 
   let metadata: Record<string, string> = {};
@@ -463,7 +468,8 @@ export async function tryPost(
           isCacheHit,
           params,
           strictOpenAiCompliance,
-          c.req.url
+          c.req.url,
+          includeRawResponse
         ));
     }
 
@@ -555,6 +561,7 @@ export async function tryPost(
       requestHeaders,
       hookSpan.id,
       strictOpenAiCompliance,
+      includeRawResponse,
       requestBody
     ));
 
@@ -1172,6 +1179,7 @@ export async function recursiveAfterRequestHookHandler(
   requestHeaders: Record<string, string>,
   hookSpanId: string,
   strictOpenAiCompliance: boolean,
+  includeRawResponse: boolean = false,
   requestBody?: ReadableStream | FormData | Params | ArrayBuffer
 ): Promise<{
   mappedResponse: Response;
@@ -1228,7 +1236,8 @@ export async function recursiveAfterRequestHookHandler(
     false,
     gatewayParams,
     strictOpenAiCompliance,
-    c.req.url
+    c.req.url,
+    includeRawResponse
   );
 
   const arhResponse = await afterRequestHookHandler(
@@ -1258,7 +1267,8 @@ export async function recursiveAfterRequestHookHandler(
       fn,
       requestHeaders,
       hookSpanId,
-      strictOpenAiCompliance
+      strictOpenAiCompliance,
+      includeRawResponse
     );
   }
 

--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -104,8 +104,7 @@ export async function responseHandler(
         provider,
         responseTransformerFunction,
         requestURL,
-        strictOpenAiCompliance,
-        includeRawResponse
+        strictOpenAiCompliance
       ),
       responseJson: null,
     };

--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -41,7 +41,8 @@ export async function responseHandler(
   isCacheHit: boolean = false,
   gatewayRequest: Params,
   strictOpenAiCompliance: boolean,
-  gatewayRequestUrl: string
+  gatewayRequestUrl: string,
+  includeRawResponse: boolean = false
 ): Promise<{
   response: Response;
   responseJson: Record<string, any> | null;
@@ -103,7 +104,8 @@ export async function responseHandler(
         provider,
         responseTransformerFunction,
         requestURL,
-        strictOpenAiCompliance
+        strictOpenAiCompliance,
+        includeRawResponse
       ),
       responseJson: null,
     };
@@ -149,7 +151,8 @@ export async function responseHandler(
     response,
     responseTransformerFunction,
     strictOpenAiCompliance,
-    gatewayRequestUrl
+    gatewayRequestUrl,
+    includeRawResponse
   );
 
   return {

--- a/src/handlers/streamHandler.ts
+++ b/src/handlers/streamHandler.ts
@@ -13,28 +13,6 @@ import { OpenAIChatCompleteResponse } from '../providers/openai/chatComplete';
 import { OpenAICompleteResponse } from '../providers/openai/complete';
 import { getStreamModeSplitPattern, type SplitPatternType } from '../utils';
 
-const appendRawResponseToChunks = (
-  chunk: string,
-  rawResponse: Record<string, any>
-) => {
-  try {
-    if (chunk !== undefined) {
-      const parts = chunk.split('\n\n');
-      for (let i = 0; i < parts.length; i++) {
-        let part = parts[i];
-        if (part.startsWith('data: ')) {
-          const json = JSON.parse(part.slice(6));
-          json.raw_response = rawResponse;
-          parts[i] = 'data: ' + JSON.stringify(json);
-        }
-      }
-      return parts.join('\n\n');
-    }
-  } catch (error) {
-    return chunk;
-  }
-};
-
 function readUInt32BE(buffer: Uint8Array, offset: number) {
   return (
     ((buffer[offset] << 24) |

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -108,6 +108,7 @@ export const configSchema: any = z
     // AzureOpenAI specific
     azure_model_name: z.string().optional(),
     strict_open_ai_compliance: z.boolean().optional(),
+    include_raw_response: z.boolean().optional(),
   })
   .refine(
     (value) => {

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -420,19 +420,10 @@ export const AnthropicChatCompleteResponseTransform: (
     const shouldSendCacheUsage =
       cache_creation_input_tokens || cache_read_input_tokens;
 
-    let content;
+    let content = '';
     if (response.content.length && response.content[0].type === 'text') {
       content = response.content[0].text;
     }
-
-    content = response.content.reduce((acc, item) => {
-      if (item.type === 'text') {
-        acc += item.text;
-      } else if (item.type === 'thinking') {
-        acc += item.thinking;
-      }
-      return acc;
-    }, '');
 
     let toolCalls: any = [];
     response.content.forEach((item) => {
@@ -636,13 +627,6 @@ export const AnthropicChatCompleteStreamChunkTransform: (
     });
   }
 
-  let content = null;
-  if (parsedChunk.delta?.text) {
-    content = parsedChunk.delta.text;
-  } else if (parsedChunk.delta?.thinking) {
-    content = parsedChunk.delta.thinking;
-  }
-
   return (
     `data: ${JSON.stringify({
       id: fallbackId,
@@ -653,7 +637,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
       choices: [
         {
           delta: {
-            content,
+            content: parsedChunk.delta?.text,
             tool_calls: toolCalls.length ? toolCalls : undefined,
           },
           index: 0,

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -61,12 +61,10 @@ const transformAssistantMessage = (msg: Message): AnthropicMessage => {
     typeof msg.content === 'object' &&
     msg.content.length
   ) {
-    if (msg.content[0].text) {
-      content.push({
-        type: 'text',
-        text: msg.content[0].text,
-      });
-    }
+    msg.content.forEach((item) => {
+      if (['text', 'thinking'].includes(item.type))
+        content.push(item as AnthropicContentItem);
+    });
   }
   if (containsToolCalls) {
     msg.tool_calls.forEach((toolCall: any) => {

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -420,10 +420,17 @@ export const AnthropicChatCompleteResponseTransform: (
     const shouldSendCacheUsage =
       cache_creation_input_tokens || cache_read_input_tokens;
 
-    let content = '';
+    let content;
     if (response.content.length && response.content[0].type === 'text') {
       content = response.content[0].text;
     }
+
+    content = response.content.reduce((acc, item) => {
+      if (item.type === 'text') {
+        acc += item.text;
+      }
+      return acc;
+    }, '');
 
     let toolCalls: any = [];
     response.content.forEach((item) => {

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -489,11 +489,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
   response: string,
   fallbackId: string,
   streamState: AnthropicStreamState
-) => string | (string | AnthropicChatCompleteStreamResponse)[] | undefined = (
-  responseChunk,
-  fallbackId,
-  streamState
-) => {
+) => string | undefined = (responseChunk, fallbackId, streamState) => {
   let chunk = responseChunk.trim();
   if (
     chunk.startsWith('event: ping') ||
@@ -517,7 +513,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
   const parsedChunk: AnthropicChatCompleteStreamResponse = JSON.parse(chunk);
 
   if (parsedChunk.type === 'error' && parsedChunk.error) {
-    return [
+    return (
       `data: ${JSON.stringify({
         id: fallbackId,
         object: 'chat.completion.chunk',
@@ -533,10 +529,9 @@ export const AnthropicChatCompleteStreamChunkTransform: (
           },
         ],
       })}` +
-        '\n\n' +
-        'data: [DONE]\n\n',
-      parsedChunk,
-    ];
+      '\n\n' +
+      'data: [DONE]\n\n'
+    );
   }
 
   if (
@@ -561,7 +556,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
           parsedChunk.message?.usage?.cache_creation_input_tokens,
       }),
     };
-    return [
+    return (
       `data: ${JSON.stringify({
         id: fallbackId,
         object: 'chat.completion.chunk',
@@ -578,9 +573,8 @@ export const AnthropicChatCompleteStreamChunkTransform: (
             finish_reason: null,
           },
         ],
-      })}` + '\n\n',
-      parsedChunk,
-    ];
+      })}` + '\n\n'
+    );
   }
 
   if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
@@ -589,7 +583,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
       (streamState?.usage?.cache_creation_input_tokens ?? 0) +
       (streamState?.usage?.cache_read_input_tokens ?? 0) +
       (parsedChunk.usage.output_tokens ?? 0);
-    return [
+    return (
       `data: ${JSON.stringify({
         id: fallbackId,
         object: 'chat.completion.chunk',
@@ -608,9 +602,8 @@ export const AnthropicChatCompleteStreamChunkTransform: (
           ...streamState.usage,
           total_tokens: totalTokens,
         },
-      })}` + '\n\n',
-      parsedChunk,
-    ];
+      })}` + '\n\n'
+    );
   }
 
   const toolCalls = [];
@@ -650,7 +643,7 @@ export const AnthropicChatCompleteStreamChunkTransform: (
     content = parsedChunk.delta.thinking;
   }
 
-  return [
+  return (
     `data: ${JSON.stringify({
       id: fallbackId,
       object: 'chat.completion.chunk',
@@ -668,7 +661,6 @@ export const AnthropicChatCompleteStreamChunkTransform: (
           finish_reason: parsedChunk.delta?.stop_reason ?? null,
         },
       ],
-    })}` + '\n\n',
-    parsedChunk,
-  ];
+    })}` + '\n\n'
+  );
 };

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -133,6 +133,8 @@ const getMessageContent = (message: Message) => {
             },
           });
         }
+      } else {
+        out.push(item);
       }
     });
   }

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -44,6 +44,10 @@ export interface BedrockConverseAnthropicChatCompletionsParams
   extends BedrockChatCompletionsParams {
   anthropic_version?: string;
   user?: string;
+  thinking?: {
+    type: string;
+    budget_tokens: number;
+  };
 }
 
 export interface BedrockConverseCohereChatCompletionsParams
@@ -515,6 +519,11 @@ export const BedrockConverseAnthropicChatCompleteConfig: ProviderConfig = {
       transformAnthropicAdditionalModelRequestFields(params),
   },
   user: {
+    param: 'additionalModelRequestFields',
+    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
+      transformAnthropicAdditionalModelRequestFields(params),
+  },
+  thinking: {
     param: 'additionalModelRequestFields',
     transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
       transformAnthropicAdditionalModelRequestFields(params),

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -116,6 +116,9 @@ export const transformAnthropicAdditionalModelRequestFields = (
       user_id: params['user'],
     };
   }
+  if (params['thinking']) {
+    additionalModelRequestFields['thinking'] = params['thinking'];
+  }
   return additionalModelRequestFields;
 };
 

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -1105,6 +1105,13 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
     });
   }
 
+  let content = null;
+  if (parsedChunk.delta?.text) {
+    content = parsedChunk.delta.text;
+  } else if (parsedChunk.delta?.thinking) {
+    content = parsedChunk.delta.thinking;
+  }
+
   return (
     `data: ${JSON.stringify({
       id: fallbackId,
@@ -1115,7 +1122,7 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
       choices: [
         {
           delta: {
-            content: parsedChunk.delta?.text,
+            content,
             tool_calls: toolCalls.length ? toolCalls : undefined,
           },
           index: 0,

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -600,6 +600,10 @@ export const VertexAnthropicChatCompleteConfig: ProviderConfig = {
     required: true,
     default: 'vertex-2023-10-16',
   },
+  thinking: {
+    param: 'thinking',
+    required: false,
+  },
 };
 
 export const GoogleChatCompleteResponseTransform: (


### PR DESCRIPTION
**Related Issues:**
- #964 

To receive `raw_response` along with the transformed response, please include the following header when making your requests: `x-portkey-include-raw-response: true` 

**Testing Done**
- [X] non-streaming anthropic calls with `x-portkey-include-raw-response` set to false and true
- [X] streaming anthropic calls with `x-portkey-include-raw-response` set to false and true
- [X] Test one other provider with streaming and non-streaming to make sure the streamHandler changes are working correctly

**Note**
this PR adds support for raw_response in non-streaming responses only