### PR TITLE
fix: logging error with more than 1k characters

### DIFF
--- a/src/middlewares/log/index.ts
+++ b/src/middlewares/log/index.ts
@@ -68,9 +68,14 @@ async function processLog(c: Context, start: number) {
       : await c.res.clone().json();
 
     const responseString = JSON.stringify(response);
-    requestOptionsArray[0].response = responseString.length > MAX_RESPONSE_LENGTH
-      ? JSON.parse(responseString.substring(0, MAX_RESPONSE_LENGTH) + '...')
-      : response;
+    if (responseString.length > MAX_RESPONSE_LENGTH) {
+      requestOptionsArray[0].response = {
+        ...response,
+        __truncated: `Response truncated (${responseString.length} chars exceeded limit of ${MAX_RESPONSE_LENGTH})`
+      };
+    } else {
+      requestOptionsArray[0].response = response;
+    }
   } catch (error) {
     console.error('Error processing log:', error);
   }

--- a/src/middlewares/log/index.ts
+++ b/src/middlewares/log/index.ts
@@ -69,7 +69,8 @@ async function processLog(c: Context, start: number) {
 
     const responseString = JSON.stringify(response);
     if (responseString.length > MAX_RESPONSE_LENGTH) {
-      requestOptionsArray[0].response = responseString.substring(0, MAX_RESPONSE_LENGTH) + '...';
+      requestOptionsArray[0].response =
+        responseString.substring(0, MAX_RESPONSE_LENGTH) + '...';
     } else {
       requestOptionsArray[0].response = response;
     }

--- a/src/middlewares/log/index.ts
+++ b/src/middlewares/log/index.ts
@@ -2,6 +2,7 @@ import { Context } from 'hono';
 import { getRuntimeKey } from 'hono/adapter';
 
 let logId = 0;
+const MAX_RESPONSE_LENGTH = 100000;
 
 // Map to store all connected log clients
 const logClients: Map<string | number, any> = new Map();
@@ -61,18 +62,17 @@ async function processLog(c: Context, start: number) {
     return;
   }
 
-  if (requestOptionsArray[0].requestParams.stream) {
-    requestOptionsArray[0].response = {
-      message: 'The response was a stream.',
-    };
-  } else {
-    const response = await c.res.clone().json();
-    const maxLength = 1000; // Set a reasonable limit for the response length
+  try {
+    const response = requestOptionsArray[0].requestParams.stream
+      ? { message: 'The response was a stream.' }
+      : await c.res.clone().json();
+
     const responseString = JSON.stringify(response);
-    requestOptionsArray[0].response =
-      responseString.length > maxLength
-        ? JSON.parse(responseString.substring(0, maxLength) + '...')
-        : response;
+    requestOptionsArray[0].response = responseString.length > MAX_RESPONSE_LENGTH
+      ? JSON.parse(responseString.substring(0, MAX_RESPONSE_LENGTH) + '...')
+      : response;
+  } catch (error) {
+    console.error('Error processing log:', error);
   }
 
   await broadcastLog(

--- a/src/middlewares/log/index.ts
+++ b/src/middlewares/log/index.ts
@@ -69,10 +69,7 @@ async function processLog(c: Context, start: number) {
 
     const responseString = JSON.stringify(response);
     if (responseString.length > MAX_RESPONSE_LENGTH) {
-      requestOptionsArray[0].response = {
-        ...response,
-        __truncated: `Response truncated (${responseString.length} chars exceeded limit of ${MAX_RESPONSE_LENGTH})`
-      };
+      requestOptionsArray[0].response = responseString.substring(0, MAX_RESPONSE_LENGTH) + '...';
     } else {
       requestOptionsArray[0].response = response;
     }


### PR DESCRIPTION
**Fix logging error with more than 1k characters:** 
- In this PR the 1000 characters limit from the 

**Description:**
- Extract the magic number to a constant
- Set the constant into 100k

**Motivation:** 
- Tons of SyntaxtError logs in the console

**Related Issues:**
- #893 


The simplest and most effective fix is to set MAX_RESPONSE_LENGTH to a higher, practical value that accommodates typical LLM outputs while keeping log messages manageable for broadcasting to clients via WebSockets. However, we must also modify the code to prevent parsing errors when truncation occurs. Here’s why and how:

- Why Not Remove the Check? While removing the length check would log full responses, it risks sending extremely large messages (e.g., megabytes) to clients, potentially causing performance issues in WebSocket communication or client handling. A reasonable limit provides balance.

- Why a Higher Limit? LLM outputs can easily exceed 1000 characters. For example, a 4096-token response (a common max for models like GPT-3) might translate to ~16,000 characters or more in JSON form, including metadata. A higher limit ensures most responses are logged fully.

- Why Fix Truncation? Even with a higher limit, responses exceeding it must be handled gracefully to avoid invalid JSON errors.


## Setting MAX_RESPONSE_LENGTH to 100,000 characters (~100KB):

- Covers Most Cases: This captures full responses for most LLM outputs, including lengthy ones up to tens of thousands of characters, while accounting for JSON overhead (e.g., keys, quotes).

- WebSocket Friendly: Modern WebSocket implementations, including in Cloudflare Workers (where your app runs with workerd), support messages up to 1MB. At ~100KB, this is well within limits and safe for broadcasting.

- Practical for Logging: It balances completeness with preventing excessively large log entries.
