### PR TITLE
Add labels parameter in Vertex AI

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -334,7 +334,6 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
   },
   labels: {
     param: 'labels',
-    default: '',
   },
 };
 

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -332,6 +332,10 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
       }
     },
   },
+  labels: {
+    param: 'labels',
+    default: '',
+  },
 };
 
 interface AnthropicTool {


### PR DESCRIPTION
**Title:** 
- Add labels parameter to the vertex provider config

**Description:** (optional)
- Added the labels parameter so custom metadata labels can be added to the call. Documentation about this feature: https://cloud.google.com/vertex-ai/generative-ai/docs/multimodal/add-labels-to-api-calls
