### PR TITLE
fix: remove conditional for bedrock list/get endpoints, date fixes

### DIFF
--- a/src/providers/bedrock/api.ts
+++ b/src/providers/bedrock/api.ts
@@ -1,7 +1,5 @@
-import { env } from 'hono/adapter';
 import { Context } from 'hono';
 import { Options } from '../../types/requestBody';
-import { GatewayError } from '../../errors/GatewayError';
 import { endpointStrings, ProviderAPIConfig } from '../types';
 import { bedrockInvokeModels } from './constants';
 import {
@@ -9,6 +7,7 @@ import {
   getAssumedRoleCredentials,
   providerAssumedRoleCredentials,
 } from './utils';
+import { GatewayError } from '../../errors/GatewayError';
 
 interface BedrockAPIConfigInterface extends Omit<ProviderAPIConfig, 'headers'> {
   headers: (args: {
@@ -44,13 +43,6 @@ const AWS_GET_METHODS: endpointStrings[] = [
   'retrieveFileContent',
   'listFinetunes',
   'retrieveFinetune',
-];
-
-// Endpoints that does not require model parameter
-const BEDROCK_FINETUNE_ENDPOINTS: endpointStrings[] = [
-  'listFinetunes',
-  'retrieveFinetune',
-  'cancelFinetune',
 ];
 
 const S3_ENDPOINTS: endpointStrings[] = [
@@ -169,7 +161,7 @@ const BedrockAPIConfig: BedrockAPIConfigInterface = {
       return `/model-invocation-job/${batchId}/stop`;
     }
     const { model, stream } = gatewayRequestBody;
-    if (!model && !BEDROCK_FINETUNE_ENDPOINTS.includes(fn as endpointStrings)) {
+    if (!model) {
       throw new GatewayError('Model is required');
     }
     let mappedFn: string = fn;

--- a/src/providers/bedrock/listBatches.ts
+++ b/src/providers/bedrock/listBatches.ts
@@ -28,8 +28,12 @@ export const BedrockListBatchesResponseTransform = (
       output_file_id: encodeURIComponent(
         batch.outputDataConfig.s3OutputDataConfig.s3Uri
       ),
-      finalizing_at: new Date(batch.endTime).getTime(),
-      expires_at: new Date(batch.jobExpirationTime).getTime(),
+      finalizing_at: batch.endTime
+        ? new Date(batch.endTime).getTime()
+        : undefined,
+      expires_at: batch.jobExpirationTime
+        ? new Date(batch.jobExpirationTime).getTime()
+        : undefined,
     }));
 
     return {


### PR DESCRIPTION
**Title:** 
- Bedrock list/get batch endpoints are not required `model`, we had a hard check which is not needed. Also some unwanted properties are handled with conditionals.
