### PR TITLE
fix: handle 246 status code for stream responses

### DIFF
--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -48,11 +48,10 @@ export async function responseHandler(
   originalResponseJson?: Record<string, any>;
 }> {
   let responseTransformerFunction: Function | undefined;
-  let providerOption: Options | undefined;
   const responseContentType = response.headers?.get('content-type');
+  const isSuccessStatusCode = [200, 246].includes(response.status);
 
   if (typeof provider == 'object') {
-    providerOption = { ...provider };
     provider = provider.provider || '';
   }
 
@@ -65,7 +64,7 @@ export async function responseHandler(
   }
 
   // Checking status 200 so that errors are not considered as stream mode.
-  if (responseTransformer && streamingMode && response.status === 200) {
+  if (responseTransformer && streamingMode && isSuccessStatusCode) {
     responseTransformerFunction =
       providerTransformers?.[`stream-${responseTransformer}`];
   } else if (responseTransformer) {
@@ -85,7 +84,7 @@ export async function responseHandler(
 
   if (
     streamingMode &&
-    response.status === 200 &&
+    isSuccessStatusCode &&
     isCacheHit &&
     responseTransformerFunction
   ) {
@@ -96,7 +95,7 @@ export async function responseHandler(
     );
     return { response: streamingResponse, responseJson: null };
   }
-  if (streamingMode && response.status === 200) {
+  if (streamingMode && isSuccessStatusCode) {
     return {
       response: handleStreamingMode(
         response,
@@ -228,12 +227,28 @@ export async function afterRequestHookHandler(
       }
     );
 
-    if (!responseJSON) {
-      return response;
-    }
-
     const span = hooksManager.getSpan(hookSpanId) as HookSpan;
     const hooksResult = span.getHooksResult();
+
+    const failedBeforeRequestHooks =
+      hooksResult.beforeRequestHooksResult.filter((h) => !h.verdict);
+    const failedAfterRequestHooks = hooksResult.afterRequestHooksResult.filter(
+      (h) => !h.verdict
+    );
+
+    if (!responseJSON) {
+      // For streaming responses, check if beforeRequestHooks failed without deny enabled.
+      if (failedBeforeRequestHooks.length || failedAfterRequestHooks.length) {
+        // This should not be a major performance bottleneck as it is just copying the headers and using the body as is.
+        return new Response(response.body, {
+          ...response,
+          status: 246,
+          statusText: 'Hooks failed',
+          headers: response.headers,
+        });
+      }
+      return response;
+    }
 
     if (shouldDeny) {
       return createHookResponse(response, {}, hooksResult, {
@@ -242,12 +257,6 @@ export async function afterRequestHookHandler(
         forceError: true,
       });
     }
-
-    const failedBeforeRequestHooks =
-      hooksResult.beforeRequestHooksResult.filter((h) => !h.verdict);
-    const failedAfterRequestHooks = hooksResult.afterRequestHooksResult.filter(
-      (h) => !h.verdict
-    );
 
     const responseData = span.getContext().response.isTransformed
       ? span.getContext().response.json

--- a/src/handlers/streamHandler.ts
+++ b/src/handlers/streamHandler.ts
@@ -359,5 +359,7 @@ export async function handleJSONToStreamResponse(
       ...Object.fromEntries(response.headers),
       'content-type': CONTENT_TYPES.EVENT_STREAM,
     }),
+    status: response.status,
+    statusText: response.statusText,
   });
 }


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![bug fix](https://img.shields.io/badge/bug_fix-818aff) 

**Title:** fix: handle 246 status code for stream responses

### 🔄 What Changed
- Added status code 246 to the list of success status codes for streaming responses
- Updated conditional checks throughout the code to use the new `isSuccessStatusCode` variable
- Enhanced the `afterRequestHookHandler` to return a 246 status code for streaming responses when hooks fail
- Modified `handleJSONToStreamResponse` to preserve status code and status text in streaming responses

### 🔍 Impact of the Change
- Improves handling of streaming responses when hooks fail without deny enabled
- Provides better signaling to clients about partial success with hook failures
- Maintains consistency in status code propagation throughout the response pipeline

### 📁 Total Files Changed
- 2 files modified: `src/handlers/responseHandlers.ts` and `src/handlers/streamHandler.ts`
- Total changes: 39 lines (25 additions, 14 deletions)

### 🧪 Test Added
N/A - No tests were added in this PR

### 🔒 Security Vulnerabilities
N/A - No security vulnerabilities were introduced or addressed

**Related Issues:** 
- Fixes #1013