### PR TITLE
chore: add default status codes only when retry attempts are configured

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -448,7 +448,9 @@ export async function tryPost(
 
   providerOption.retry = {
     attempts: providerOption.retry?.attempts ?? 0,
-    onStatusCodes: providerOption.retry?.onStatusCodes ?? RETRY_STATUS_CODES,
+    onStatusCodes: providerOption.retry?.attempts
+      ? providerOption.retry?.onStatusCodes ?? RETRY_STATUS_CODES
+      : [],
   };
 
   async function createResponse(


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-95%25-02b838) ![type: bug fix](https://img.shields.io/badge/type:_bug fix-818aff) 

**Title:** 
- [x] chore: add default status codes only when retry attempts are configured

**Description:** 
### 🔄 What Changed
Modified the retry logic in `handlerUtils.ts` to only set default status codes for retry when retry attempts are actually configured (greater than 0).

### 🔍 Impact of the Change
Improves the behavior of the retry mechanism by ensuring that retry status codes are only set when retry attempts are actually configured. This prevents unnecessary configuration when retries are not being used.

### 📁 Total Files Changed
1 file changed with 3 additions and 1 deletion in `src/handlers/handlerUtils.ts`.

### 🧪 Test Added
N/A - The change is a minor logic improvement that doesn't require specific test coverage.

### 🔒 Security Vulnerabilities
N/A - No security vulnerabilities were introduced or addressed in this PR.

**Motivation:** 
- [x] This change improves the retry logic by only setting default retry status codes when retry attempts are actually configured, making the code more logical and efficient.

**Related Issues:** 
- Fixes #1012 