### PR TITLE
fix: give preference to provider error code over hooks failure respon…

### DIFF
--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -265,7 +265,10 @@ export async function afterRequestHookHandler(
       ? span.getContext().response.json
       : responseJSON;
 
-    if (failedBeforeRequestHooks.length || failedAfterRequestHooks.length) {
+    if (
+      (failedBeforeRequestHooks.length || failedAfterRequestHooks.length) &&
+      response.status === 200
+    ) {
       return createHookResponse(response, responseData, hooksResult, {
         status: 246,
         statusText: 'Hooks failed',


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-95%25-02b838) ![bug fix](https://img.shields.io/badge/bug_fix-818aff) 

**Title:** 
- ✅ fix: give preference to provider error code over hooks failure response code

**Description:** 
### 🔄 What Changed
- Modified the conditional logic in `afterRequestHookHandler` to only override response status with hook failure code (246) when the original response status is 200
- Added additional condition to preserve provider error codes when hooks fail

### 🔍 Impact of the Change
- Preserves original error status codes from providers when hooks fail
- Improves error reporting by maintaining more specific error information
- Fixes issue #1017

### 📁 Total Files Changed
- 1 file: src/handlers/responseHandlers.ts (4 additions, 1 deletion)

### 🧪 Test Added
- N/A

### 🔒 Security Vulnerabilities
- N/A

**Motivation:** 
- Ensures that specific error codes from providers are not masked by generic hook failure codes
- Improves error handling and debugging by preserving more detailed error information

**Related Issues:** 
- Fixes #1017