### PR TITLE
feature: add openrouter tools support and handle error chunks

### DIFF
--- a/src/providers/openrouter/chatComplete.ts
+++ b/src/providers/openrouter/chatComplete.ts
@@ -48,6 +48,12 @@ export const OpenrouterChatCompleteConfig: ProviderConfig = {
     min: 0,
     max: 1,
   },
+  tools: {
+    param: 'tools',
+  },
+  tool_choice: {
+    param: 'tool_choice',
+  },
   stream: {
     param: 'stream',
     default: false,
@@ -170,9 +176,9 @@ export const OpenrouterChatCompleteStreamChunkTransform: (
       provider: OPENROUTER,
       choices: [
         {
-          index: parsedChunk.choices[0].index,
-          delta: parsedChunk.choices[0].delta,
-          finish_reason: parsedChunk.choices[0].finish_reason,
+          index: parsedChunk.choices?.[0]?.index,
+          delta: parsedChunk.choices?.[0]?.delta,
+          finish_reason: parsedChunk.choices?.[0]?.finish_reason,
         },
       ],
       ...(parsedChunk.usage && { usage: parsedChunk.usage }),


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![new feature](https://img.shields.io/badge/new_feature-818aff) 

## Author Description

- add openrouter tools support 

This is straightforward, the gateway is currently not passing the tools parameters to openrouter

- handle openrouter error chunks

i've had cases where openrouter returns an error chunk. in such cases, the chunk formatting fails and the gateway do not return anything (hanging promise)

The quick-win is to handle it with null-safe operators, since i'm not sure what is the policy regarding handling errored chunks.

**Title:** 
feature: add openrouter tools support and handle error chunks

**Description:**
### 🔄 What Changed
- Added OpenRouter tools support by configuring the `tools` and `tool_choice` parameters
- Implemented error handling for OpenRouter error chunks using null-safe operators

### 🔍 Impact of the Change
- Enables passing tools parameters to OpenRouter API calls
- Prevents hanging promises when OpenRouter returns error chunks
- Improves overall reliability of the gateway when interacting with OpenRouter

### 📁 Total Files Changed
- 1 file modified: `src/providers/openrouter/chatComplete.ts` (+9, -3)

### 🧪 Test Added
N/A - No tests were added in this PR

### 🔒 Security Vulnerabilities
No security vulnerabilities detected

**Motivation:**
- Tools parameters were not being passed to OpenRouter, limiting functionality
- Error chunks from OpenRouter were causing the gateway to hang due to improper handling

**Related Issues:**
N/A