### PR TITLE
fix: correctly handle other errors from handlers

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -737,7 +737,7 @@ export async function tryTargetsRecursively(
   ];
   // end: merge inherited config with current target config (preference given to current)
 
-  let response;
+  let response: Response | null = null;
 
   switch (strategyMode) {
     case StrategyModes.FALLBACK:
@@ -859,7 +859,7 @@ export async function tryTargetsRecursively(
           currentJsonPath,
           method
         );
-      } catch (error: any) {
+      } catch (error: unknown) {
         // tryPost always returns a Response.
         // TypeError will check for all unhandled exceptions.
         // GatewayError will check for all handled exceptions which cannot allow the request to proceed.
@@ -882,11 +882,20 @@ export async function tryTargetsRecursively(
               },
             }
           );
-        } else {
+        } else if (
+          typeof error === 'object' &&
+          error &&
+          'response' in error &&
+          error.response instanceof Response
+        ) {
           response = error.response;
         }
       }
       break;
+  }
+
+  if (!response) {
+    throw new Error('Could not create response');
   }
 
   return response;


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![bug fix](https://img.shields.io/badge/bug_fix-d47f00) 

## Author Description

**Title:** 
This fixes an issue where some unhandled errors thrown by `tryPost` cause big issues. Due to some loose typing, it was possible for the handlers to return `null` for a `response`. This causes *bad things* as eventually it makes its way to the top of the call chain, and if you return from your last handler in hono, the context itself is returned, which is difficult to understand what is going on.

**Title:** fix: correctly handle other errors from handlers

### 🔄 What Changed
- Added explicit typing for `response` variable as `Response | null`
- Changed `error: any` to `error: unknown` for better type safety
- Added proper type checking for error objects before accessing properties
- Added a safeguard that throws an error when no response is created

### 🔍 Impact of the Change
- Prevents unhandled errors from causing unexpected behavior
- Ensures that a proper response is always returned or an error is thrown
- Improves type safety throughout the error handling flow
- Provides clearer error messages when something goes wrong

### 📁 Total Files Changed
- 1 file modified: `src/handlers/handlerUtils.ts` (12 additions, 3 deletions)

### 🧪 Test Added
N/A

### 🔒 Security Vulnerabilities
N/A

## Quality Recommendations

1. Consider adding unit tests to verify the error handling behavior

2. Add more specific error messages that include details about what went wrong

3. Consider implementing a more robust error handling strategy with custom error types