### PR TITLE
Handle ping

### DIFF
--- a/src/providers/deepinfra/chatComplete.ts
+++ b/src/providers/deepinfra/chatComplete.ts
@@ -178,6 +178,10 @@ export const DeepInfraChatCompleteResponseTransform: (
 export const DeepInfraChatCompleteStreamChunkTransform: (
   response: string
 ) => string = (responseChunk) => {
+  if (responseChunk.startsWith(': ping - ')) {
+    return '';
+  }
+
   let chunk = responseChunk.trim();
   chunk = chunk.replace(/^data: /, '');
   chunk = chunk.trim();

--- a/src/providers/deepinfra/chatComplete.ts
+++ b/src/providers/deepinfra/chatComplete.ts
@@ -178,7 +178,12 @@ export const DeepInfraChatCompleteResponseTransform: (
 export const DeepInfraChatCompleteStreamChunkTransform: (
   response: string
 ) => string = (responseChunk) => {
-  if (responseChunk.startsWith(': ping - ')) {
+  // Matches a ping chunk `: ping - 2025-04-13 03:55:09.637341+00:00`
+  if (
+    responseChunk.match(
+      /^:\s*ping\s*-\s*\d{4}-\d{2}-\d{2}\s\d{2}:\d{2}:\d{2}\.\d{6}\+\d{2}:\d{2}$/
+    )
+  ) {
     return '';
   }
 


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![bug fix](https://img.shields.io/badge/bug_fix-d47f00) 

## Author Description

(optional)
Deepinfra streams back ping chunks on long requests. They're a weird format, here's what they look like before any processing: `: ping - 2025-04-13 03:55:09.637341+00:00`.

**Title:** Handle ping chunks from deep infra

### 🔄 What Changed
- Added regex pattern to identify DeepInfra ping messages
- Implemented filtering logic to remove ping messages from response stream
- Ping messages like `: ping - 2025-04-13 03:55:09.637341+00:00` are now properly handled

### 🔍 Impact of the Change
- Fixes bug where DeepInfra ping messages were being incorrectly processed as response data
- Improves reliability of DeepInfra integrations
- Ensures only relevant response data is processed

### 📁 Total Files Changed
- 1 file modified (src/providers/deepinfra/chatComplete.ts)
- 9 lines added, 0 lines removed

### 🧪 Test Added
N/A - No tests were added in this PR

### 🔒 Security Vulnerabilities
N/A - No security vulnerabilities were addressed

**Motivation:**
Fixes a bug where DeepInfra ping messages were being incorrectly processed as part of the response data.

**Related Issues:**
- #1035

## Quality Recommendations

1. Consider adding unit tests to verify the ping message filtering functionality

2. Add error handling in case the regex matching fails unexpectedly

3. Consider adding a comment explaining why these ping messages need to be filtered out