### PR TITLE
Add usage to final chunk for deepinfra

### DIFF
--- a/src/providers/deepinfra/chatComplete.ts
+++ b/src/providers/deepinfra/chatComplete.ts
@@ -113,6 +113,11 @@ interface DeepInfraStreamChunk {
     index: number;
     finish_reason: string | null;
   }[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
 }
 
 export const DeepInfraChatCompleteResponseTransform: (
@@ -199,6 +204,13 @@ export const DeepInfraChatCompleteStreamChunkTransform: (
           finish_reason: parsedChunk.choices[0].finish_reason,
         },
       ],
+      usage: parsedChunk.usage
+        ? {
+            prompt_tokens: parsedChunk.usage.prompt_tokens,
+            completion_tokens: parsedChunk.usage.completion_tokens,
+            total_tokens: parsedChunk.usage.total_tokens,
+          }
+        : undefined,
     })}` + '\n\n'
   );
 };


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![type: new feature](https://img.shields.io/badge/type-_new_feature-818aff) 

## Author Description

(optional)
- Detailed change 1
- Detailed change 2

**Title:** Add usage to final chunk for deepinfra

### 🔄 What Changed
- Added a `usage` field to the `DeepInfraStreamChunk` interface
- Modified the `DeepInfraChatCompleteStreamChunkTransform` function to include usage data in the transformed output when available

### 🔍 Impact of the Change
- Enables clients to receive token usage statistics in the final streaming chunk from DeepInfra API calls
- Provides valuable information for monitoring, billing, and optimizing token usage in applications

### 📁 Total Files Changed
- 1 file modified: `src/providers/deepinfra/chatComplete.ts` (+12 lines, -0 lines)

### 🧪 Test Added
- N/A

### 🔒 Security Vulnerabilities
- No security vulnerabilities identified in this change

**Related Issues:** N/A

## Quality Recommendations

1. Add unit tests to verify the correct handling of usage information in streaming responses

2. Consider adding documentation comments to explain the purpose of the usage field and how it's used

3. Add error handling for potential malformed usage data from the API