### PR TITLE
fix: replace chat_completion by chat.completion in providers responses

### DIFF
--- a/src/providers/ai21/chatComplete.ts
+++ b/src/providers/ai21/chatComplete.ts
@@ -147,7 +147,7 @@ export const AI21ChatCompleteResponseTransform: (
   if ('outputs' in response) {
     return {
       id: response.id,
-      object: 'chat_completion',
+      object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
       model: '',
       provider: AI21,

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -486,7 +486,7 @@ export const AnthropicChatCompleteResponseTransform: (
 
     return {
       id: response.id,
-      object: 'chat_completion',
+      object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
       model: response.model,
       provider: ANTHROPIC,

--- a/src/providers/cohere/chatComplete.ts
+++ b/src/providers/cohere/chatComplete.ts
@@ -162,7 +162,7 @@ export const CohereChatCompleteResponseTransform: (
 
   return {
     id: response.generation_id,
-    object: 'chat_completion',
+    object: 'chat.completion',
     created: Math.floor(Date.now() / 1000),
     model: 'Unknown',
     provider: COHERE,

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -434,7 +434,7 @@ export const GoogleChatCompleteResponseTransform: (
 
     return {
       id: 'portkey-' + crypto.randomUUID(),
-      object: 'chat_completion',
+      object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
       model: response.modelVersion,
       provider: GOOGLE_VERTEX_AI,
@@ -731,7 +731,7 @@ export const VertexAnthropicChatCompleteResponseTransform: (
 
     return {
       id: response.id,
-      object: 'chat_completion',
+      object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
       model: response.model,
       provider: GOOGLE_VERTEX_AI,

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -512,7 +512,7 @@ export const GoogleChatCompleteResponseTransform: (
   if ('candidates' in response) {
     return {
       id: 'portkey-' + crypto.randomUUID(),
-      object: 'chat_completion',
+      object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
       model: response.modelVersion,
       provider: 'google',

--- a/src/providers/palm/chatComplete.ts
+++ b/src/providers/palm/chatComplete.ts
@@ -91,7 +91,7 @@ export const PalmChatCompleteResponseTransform: (
   if ('candidates' in response) {
     return {
       id: Date.now().toString(),
-      object: 'chat_completion',
+      object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
       model: 'Unknown',
       provider: PALM,

--- a/src/providers/reka-ai/chatComplete.ts
+++ b/src/providers/reka-ai/chatComplete.ts
@@ -164,7 +164,7 @@ export const RekaAIChatCompleteResponseTransform: (
   if ('text' in response) {
     return {
       id: crypto.randomUUID(),
-      object: 'chat_completion',
+      object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
       model: 'Unknown',
       provider: REKA_AI,

--- a/src/providers/workers-ai/chatComplete.ts
+++ b/src/providers/workers-ai/chatComplete.ts
@@ -106,7 +106,7 @@ export const WorkersAiChatCompleteResponseTransform: (
   if ('result' in response) {
     return {
       id: Date.now().toString(),
-      object: 'chat_completion',
+      object: 'chat.completion',
       created: Math.floor(Date.now() / 1000),
       model: gatewayRequest.model || '',
       provider: WORKERS_AI,


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-95%25-02b838) ![bug fix](https://img.shields.io/badge/bug_fix-d47f00) 

## Author Description

**Title:** 
Some providers had the wrong value for the `object` field, not a major issue but this replacement makes their responses fully openai compatible.

**Title:** fix: replace chat_completion by chat.completion in providers responses

### 🔄 What Changed
- Updated the `object` field value from `chat_completion` to `chat.completion` in response transformation functions
- Affected 8 provider files with minimal changes

### 🔍 Impact of the Change
- Makes provider responses fully OpenAI compatible
- Ensures consistent response format across all providers
- Improves API compatibility for consumers of the gateway

### 📁 Total Files Changed
- 8 files modified with 9 additions and 9 deletions
- All changes are consistent string replacements

### 🧪 Test Added
- N/A

### 🔒 Security Vulnerabilities
- N/A

## Quality Recommendations

1. Consider adding a simple test case to verify the response format compatibility with OpenAI

2. Add a comment explaining why 'chat.completion' is the correct format for OpenAI compatibility