### PR TITLE
feat: supports specific openrouter request parameters

### DIFF
--- a/src/providers/openrouter/chatComplete.ts
+++ b/src/providers/openrouter/chatComplete.ts
@@ -42,6 +42,12 @@ export const OpenrouterChatCompleteConfig: ProviderConfig = {
     min: 0,
     max: 2,
   },
+  modalities: {
+    param: 'modalities',
+  },
+  reasoning: {
+    param: 'reasoning',
+  },
   top_p: {
     param: 'top_p',
     default: 1,
@@ -54,9 +60,21 @@ export const OpenrouterChatCompleteConfig: ProviderConfig = {
   tool_choice: {
     param: 'tool_choice',
   },
+  transforms: {
+    param: 'transforms',
+  },
+  provider: {
+    param: 'provider',
+  },
+  models: {
+    param: 'models',
+  },
   stream: {
     param: 'stream',
     default: false,
+  },
+  response_format: {
+    param: 'response_format',
   },
 };
 
@@ -143,8 +161,18 @@ export const OpenrouterChatCompleteResponseTransform: (
 };
 
 export const OpenrouterChatCompleteStreamChunkTransform: (
-  response: string
-) => string = (responseChunk) => {
+  response: string,
+  fallbackId: string,
+  _streamState: Record<string, boolean>,
+  _strictOpenAiCompliance: boolean,
+  gatewayRequest: Params
+) => string = (
+  responseChunk,
+  fallbackId,
+  _streamState,
+  _strictOpenAiCompliance,
+  gatewayRequest
+) => {
   let chunk = responseChunk.trim();
   chunk = chunk.replace(/^data: /, '');
   chunk = chunk.trim();
@@ -154,7 +182,7 @@ export const OpenrouterChatCompleteStreamChunkTransform: (
   if (chunk.includes('OPENROUTER PROCESSING')) {
     chunk = JSON.stringify({
       id: `${Date.now()}`,
-      model: '',
+      model: gatewayRequest.model || '',
       object: 'chat.completion.chunk',
       created: Date.now(),
       choices: [


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![new feature](https://img.shields.io/badge/new_feature-818aff) 

## Author Description

**Title:** 
This PR allows to send some openrouter specific fields to there api.

- `modalities`: https://openrouter.ai/docs/api-reference/overview#image-generation
- `reasoning`: https://openrouter.ai/docs/use-cases/reasoning-tokens#controlling-reasoning-tokens
- `transforms`: https://openrouter.ai/docs/features/message-transforms
- `provider`: https://openrouter.ai/docs/features/provider-routing
- `model`: https://openrouter.ai/docs/features/model-routing
- `response_format`: https://openrouter.ai/docs/features/structured-outputs

That brings the full power of portkey combined to the versatility of openrouter 🚀

**Title:** feat: supports specific openrouter request parameters

### 🔄 What Changed
- Added support for OpenRouter-specific parameters: modalities, reasoning, transforms, provider, models, and response_format
- Updated the stream chunk transform function to properly handle these parameters
- Enhanced model information in stream responses by using the model from the gateway request

### 🔍 Impact of the Change
- Enables full utilization of OpenRouter's API capabilities
- Allows users to leverage image generation, reasoning control, message transformations, and specific provider/model routing
- Combines Portkey's gateway capabilities with OpenRouter's versatility

### 📁 Total Files Changed
- 1 file modified (src/providers/openrouter/chatComplete.ts) with 31 additions and 3 deletions

### 🧪 Test Added
N/A - No tests were added in this PR

### 🔒 Security Vulnerabilities
N/A - No security vulnerabilities identified

## Quality Recommendations

1. Add input validation for the new parameters to ensure they conform to OpenRouter's expected formats

2. Consider adding type definitions for the new parameters to improve type safety

3. Add unit tests to verify the correct handling of the new parameters

4. Update documentation to explain how to use these new parameters in the gateway