### PR TITLE
feat: support openrouter usage in api

### DIFF
--- a/src/providers/openrouter/chatComplete.ts
+++ b/src/providers/openrouter/chatComplete.ts
@@ -69,6 +69,9 @@ export const OpenrouterChatCompleteConfig: ProviderConfig = {
   models: {
     param: 'models',
   },
+  usage: {
+    param: 'usage',
+  },
   stream: {
     param: 'stream',
     default: false,
@@ -78,16 +81,29 @@ export const OpenrouterChatCompleteConfig: ProviderConfig = {
   },
 };
 
+interface OpenrouterUsageDetails {
+  prompt_tokens: number;
+  completion_tokens: number;
+  total_tokens: number;
+  prompt_tokens_details?: {
+    cached_tokens: number;
+    audio_tokens: number;
+  };
+  completion_tokens_details?: {
+    reasoning_tokens: number;
+    audio_tokens: number;
+    accepted_prediction_tokens: number;
+    rejected_prediction_tokens: number;
+  };
+  cost?: number;
+}
+
 interface OpenrouterChatCompleteResponse extends ChatCompletionResponse {
   id: string;
   object: string;
   created: number;
   model: string;
-  usage: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
+  usage: OpenrouterUsageDetails;
 }
 
 export interface OpenrouterErrorResponse {
@@ -103,11 +119,7 @@ interface OpenrouterStreamChunk {
   object: string;
   created: number;
   model: string;
-  usage?: {
-    prompt_tokens: number;
-    completion_tokens: number;
-    total_tokens: number;
-  };
+  usage?: OpenrouterUsageDetails;
   choices: {
     delta: {
       role?: string | null;
@@ -149,11 +161,7 @@ export const OpenrouterChatCompleteResponseTransform: (
         },
         finish_reason: c.finish_reason,
       })),
-      usage: {
-        prompt_tokens: response.usage?.prompt_tokens,
-        completion_tokens: response.usage?.completion_tokens,
-        total_tokens: response.usage?.total_tokens,
-      },
+      usage: response.usage,
     };
   }
 


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![new feature](https://img.shields.io/badge/new_feature-818aff) 

## Author Description

OpenRouter recently added an api parameter to get the cost of the request in the responses:

https://openrouter.ai/docs/use-cases/usage-accounting

This PR introduces the following changes:
- Accept `usage` parameter in the request body (enable cost report)
- Add a new type for the OpenRouter `usage` format (described [here](https://openrouter.ai/docs/use-cases/usage-accounting#response-format))
- Return the full `usage` in the non-streaming response (we already do that in the streaming responses)

## Description

### 🔄 What Changed
This PR adds support for OpenRouter's usage accounting feature by implementing the following changes:
- Added the `usage` parameter to the request configuration
- Created a new interface `OpenrouterUsageDetails` to properly type the usage data format
- Updated the response handling to return the full usage information in non-streaming responses

### 🔍 Impact of the Change
This enhancement allows users to receive detailed cost and token usage information from OpenRouter API calls, including cost reporting and detailed token usage breakdowns.

### 📁 Total Files Changed
1 file modified: `src/providers/openrouter/chatComplete.ts` (+23, -15)

### 🧪 Test Added
N/A - No tests were added in this PR

### 🔒 Security Vulnerabilities
No security vulnerabilities identified

## Motivation
OpenRouter recently added an API parameter to get the cost of the request in the responses, as documented in their usage accounting documentation. This PR implements support for this feature to provide users with detailed usage information.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues
Related to OpenRouter's usage accounting feature: https://openrouter.ai/docs/use-cases/usage-accounting

## Quality Recommendations

1. Add unit tests to verify the new usage parameter functionality

2. Add validation for the usage parameter to ensure it's a boolean value

3. Add documentation comments for the new OpenrouterUsageDetails interface

4. Consider adding examples of how to use the new usage parameter in the code comments