### PR TITLE
chore: add anthropic_beta param

### DIFF
--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -650,6 +650,9 @@ export const BedrockConverseAnthropicChatCompleteConfig: ProviderConfig = {
     transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
       transformAnthropicAdditionalModelRequestFields(params),
   },
+  anthropic_beta: {
+    param: 'anthropic_beta',
+  },
 };
 
 export const BedrockConverseCohereChatCompleteConfig: ProviderConfig = {


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![type: new feature](https://img.shields.io/badge/type-_new_feature-818aff) 

## Author Description

<!-- Provide a brief description of the changes in this PR -->

## Description

### 🔄 What Changed
Added support for the `anthropic_beta` parameter in the Bedrock Converse Anthropic Chat Complete configuration. This parameter allows passing Anthropic beta features to the API.

### 🔍 Impact of the Change
Enables users to access experimental features in Anthropic models through the Bedrock integration by passing the anthropic_beta parameter.

### 📁 Total Files Changed
1 file modified: src/providers/bedrock/chatComplete.ts (+3 lines)

### 🧪 Test Added
N/A - No tests have been added for this change.

### 🔒 Security Vulnerabilities
N/A - This change doesn't introduce any security vulnerabilities.

## Motivation
To support the anthropic_beta parameter which is needed for accessing experimental features in Anthropic's models through Amazon Bedrock.

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
N/A

## Quality Recommendations

1. Add unit tests to verify the new parameter is correctly passed to the Anthropic API when used

2. Consider adding a comment explaining what the anthropic_beta parameter is used for and its expected values

3. Update documentation to reflect the new parameter availability