### PR TITLE
fix: return tool calls in non streaming openrouter responses

### DIFF
--- a/src/providers/openrouter/chatComplete.ts
+++ b/src/providers/openrouter/chatComplete.ts
@@ -146,12 +146,14 @@ export const OpenrouterChatCompleteResponseTransform: (
         message: {
           role: c.message.role,
           content: c.message.content,
-          content_blocks: [
-            {
-              type: 'thinking',
-              thinking: c.message.reasoning,
-            },
-          ],
+          ...(c.message.reasoning && {
+            content_blocks: [
+              {
+                type: 'thinking',
+                thinking: c.message.reasoning,
+              },
+            ],
+          }),
           ...(c.message.tool_calls && {
             tool_calls: c.message.tool_calls,
           }),

--- a/src/providers/openrouter/chatComplete.ts
+++ b/src/providers/openrouter/chatComplete.ts
@@ -146,9 +146,12 @@ export const OpenrouterChatCompleteResponseTransform: (
         message: {
           role: c.message.role,
           content: c.message.content,
-          ...(c.message.reasoning && {
-            reasoning: c.message.reasoning,
-          }),
+          content_blocks: [
+            {
+              type: 'thinking',
+              thinking: c.message.reasoning,
+            },
+          ],
           ...(c.message.tool_calls && {
             tool_calls: c.message.tool_calls,
           }),

--- a/src/providers/openrouter/chatComplete.ts
+++ b/src/providers/openrouter/chatComplete.ts
@@ -146,6 +146,12 @@ export const OpenrouterChatCompleteResponseTransform: (
         message: {
           role: c.message.role,
           content: c.message.content,
+          ...(c.message.reasoning && {
+            reasoning: c.message.reasoning,
+          }),
+          ...(c.message.tool_calls && {
+            tool_calls: c.message.tool_calls,
+          }),
         },
         finish_reason: c.finish_reason,
       })),


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![bug fix](https://img.shields.io/badge/bug_fix-d47f00) 

## Author Description

This PR fixes an issue that causes tool_calls not to be returned when not streaming the response.

This is due to the too strict mapping of messages.
Ideally, we could just pass the whole message content, like it is done with the streaming responses.

## Summary By MatterAI

### 🔄 What Changed
This PR fixes an issue where tool_calls were not being returned in non-streaming responses from OpenRouter. The implementation now properly includes tool_calls in the message object when transforming the response. Additionally, it adds support for content_blocks to handle reasoning tokens in a unified way across streaming and non-streaming responses.

### 🔍 Impact of the Change
This change ensures consistent behavior between streaming and non-streaming responses, allowing applications to properly receive and process tool_calls regardless of the streaming mode. It also improves the handling of reasoning content by using a standardized content_blocks approach.

### 📁 Total Files Changed
1 file changed with 73 additions and 13 deletions (86 total changes)

### 🧪 Test Added
N/A

### 🔒 Security Vulnerabilities
No security vulnerabilities detected

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
Issue with tool_calls not being returned in non-streaming OpenRouter responses

## Quality Recommendations

1. Add unit tests to verify the fix for tool_calls in non-streaming responses

2. Consider adding error handling for malformed responses from OpenRouter

3. Add comments explaining the purpose of content_blocks and their relationship to reasoning

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Client
    participant Gateway
    participant OpenRouter
    
    Client->>Gateway: Send chat completion request
    Gateway->>OpenRouter: Forward request to OpenRouter API
    OpenRouter-->>Gateway: Return response with tool_calls
    
    alt Streaming Mode
        Gateway->>Gateway: OpenrouterChatCompleteStreamChunkTransform()
        Note over Gateway: Already handles tool_calls correctly
    else Non-Streaming Mode
        Gateway->>Gateway: OpenrouterChatCompleteResponseTransform()
        Note over Gateway: Now properly includes tool_calls in message
        Note over Gateway: Adds content_blocks when not in strictOpenAiCompliance mode
    end
    
    Gateway-->>Client: Return transformed response with tool_calls
```
