### PR TITLE
Fix/support provider specific fields for bedrock in snake case

### DIFF
--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -32,8 +32,14 @@ import {
 
 export interface BedrockChatCompletionsParams extends Params {
   additionalModelRequestFields?: Record<string, any>;
+  additional_model_request_fields?: Record<string, any>;
   additionalModelResponseFieldPaths?: string[];
   guardrailConfig?: {
+    guardrailIdentifier: string;
+    guardrailVersion: string;
+    trace?: string;
+  };
+  guardrail_config?: {
     guardrailIdentifier: string;
     guardrailVersion: string;
     trace?: string;
@@ -312,7 +318,15 @@ export const BedrockConverseChatCompleteConfig: ProviderConfig = {
     param: 'guardrailConfig',
     required: false,
   },
+  guardrail_config: {
+    param: 'guardrailConfig',
+    required: false,
+  },
   additionalModelResponseFieldPaths: {
+    param: 'additionalModelResponseFieldPaths',
+    required: false,
+  },
+  additional_model_response_field_paths: {
     param: 'additionalModelResponseFieldPaths',
     required: false,
   },

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -346,6 +346,11 @@ export const BedrockConverseChatCompleteConfig: ProviderConfig = {
     transform: (params: BedrockChatCompletionsParams) =>
       transformAdditionalModelRequestFields(params),
   },
+  additional_model_request_fields: {
+    param: 'additionalModelRequestFields',
+    transform: (params: BedrockChatCompletionsParams) =>
+      transformAdditionalModelRequestFields(params),
+  },
   top_k: {
     param: 'additionalModelRequestFields',
     transform: (params: BedrockChatCompletionsParams) =>
@@ -696,6 +701,11 @@ export const BedrockConverseAnthropicChatCompleteConfig: ProviderConfig = {
     transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
       transformAnthropicAdditionalModelRequestFields(params),
   },
+  additional_model_request_fields: {
+    param: 'additionalModelRequestFields',
+    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
+      transformAnthropicAdditionalModelRequestFields(params),
+  },
   top_k: {
     param: 'additionalModelRequestFields',
     transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
@@ -724,6 +734,11 @@ export const BedrockConverseAnthropicChatCompleteConfig: ProviderConfig = {
 export const BedrockConverseCohereChatCompleteConfig: ProviderConfig = {
   ...BedrockConverseChatCompleteConfig,
   additionalModelRequestFields: {
+    param: 'additionalModelRequestFields',
+    transform: (params: BedrockConverseCohereChatCompletionsParams) =>
+      transformCohereAdditionalModelRequestFields(params),
+  },
+  additional_model_request_fields: {
     param: 'additionalModelRequestFields',
     transform: (params: BedrockConverseCohereChatCompletionsParams) =>
       transformCohereAdditionalModelRequestFields(params),
@@ -758,6 +773,11 @@ export const BedrockConverseCohereChatCompleteConfig: ProviderConfig = {
 export const BedrockConverseAI21ChatCompleteConfig: ProviderConfig = {
   ...BedrockConverseChatCompleteConfig,
   additionalModelRequestFields: {
+    param: 'additionalModelRequestFields',
+    transform: (params: BedrockConverseAI21ChatCompletionsParams) =>
+      transformAI21AdditionalModelRequestFields(params),
+  },
+  additional_model_request_fields: {
     param: 'additionalModelRequestFields',
     transform: (params: BedrockConverseAI21ChatCompletionsParams) =>
       transformAI21AdditionalModelRequestFields(params),

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -741,7 +741,9 @@ export const BedrockConverseAnthropicChatCompleteConfig: ProviderConfig = {
       transformAnthropicAdditionalModelRequestFields(params),
   },
   anthropic_beta: {
-    param: 'anthropic_beta',
+    param: 'additionalModelRequestFields',
+    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
+      transformAnthropicAdditionalModelRequestFields(params),
   },
 };
 

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -93,7 +93,9 @@ export const transformAdditionalModelRequestFields = (
   params: BedrockChatCompletionsParams
 ) => {
   const additionalModelRequestFields: Record<string, any> =
-    params.additionalModelRequestFields || {};
+    params.additionalModelRequestFields ||
+    params.additional_model_request_fields ||
+    {};
   if (params['top_k']) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }
@@ -104,7 +106,9 @@ export const transformAnthropicAdditionalModelRequestFields = (
   params: BedrockConverseAnthropicChatCompletionsParams
 ) => {
   const additionalModelRequestFields: Record<string, any> =
-    params.additionalModelRequestFields || {};
+    params.additionalModelRequestFields ||
+    params.additional_model_request_fields ||
+    {};
   if (params['top_k']) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }
@@ -127,7 +131,9 @@ export const transformCohereAdditionalModelRequestFields = (
   params: BedrockConverseCohereChatCompletionsParams
 ) => {
   const additionalModelRequestFields: Record<string, any> =
-    params.additionalModelRequestFields || {};
+    params.additionalModelRequestFields ||
+    params.additional_model_request_fields ||
+    {};
   if (params['top_k']) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }
@@ -152,7 +158,9 @@ export const transformAI21AdditionalModelRequestFields = (
   params: BedrockConverseAI21ChatCompletionsParams
 ) => {
   const additionalModelRequestFields: Record<string, any> =
-    params.additionalModelRequestFields || {};
+    params.additionalModelRequestFields ||
+    params.additional_model_request_fields ||
+    {};
   if (params['top_k']) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![bug fix](https://img.shields.io/badge/bug_fix-d47f00) 

## Author Description

So, portkey node SDK converts input parameters in chat.completions requests into snake_case, when I originally added transforms for `additionalModelRequestFields`, it was in camelCase, it was tested with the REST API and the python sdk, but not the node sdk

# Summary By MatterAI

### 🔄 What Changed
This PR adds support for snake_case versions of provider-specific fields for AWS Bedrock in addition to the existing camelCase versions. The change was necessary because the Portkey Node SDK converts all input parameters in chat.completions requests into snake_case format, which was causing issues with the additionalModelRequestFields and other parameters.

### 🔍 Impact of the Change
This change ensures compatibility with the Portkey Node SDK by supporting both camelCase and snake_case parameter formats. It maintains backward compatibility while fixing the issue with the Node SDK integration.

### 📁 Total Files Changed
2 files changed with 46 additions and 4 deletions:
- src/providers/bedrock/chatComplete.ts: +34, -0
- src/providers/bedrock/utils.ts: +12, -4

### 🧪 Test Added
N/A

### 🔒 Security Vulnerabilities
No security vulnerabilities introduced.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
Issue with Portkey Node SDK converting parameters to snake_case

## Quality Recommendations

1. Consider adding unit tests to verify the snake_case parameter handling works correctly

2. Add documentation comments to explain why both camelCase and snake_case versions are supported

3. Consider creating a utility function to handle the duplicate parameter checking pattern that appears in multiple transform functions

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Client
    participant PortkeyNodeSDK
    participant Gateway
    participant BedrockProvider
    participant AWSBedrock
    
    Client->>PortkeyNodeSDK: chat.completions request
    Note over PortkeyNodeSDK: Converts parameters to snake_case
    PortkeyNodeSDK->>Gateway: Forward request with snake_case params
    Gateway->>BedrockProvider: Process request
    Note over BedrockProvider: Now supports both camelCase and snake_case:
    Note over BedrockProvider: - additionalModelRequestFields
    Note over BedrockProvider: - additional_model_request_fields
    Note over BedrockProvider: - guardrailConfig
    Note over BedrockProvider: - guardrail_config
    BedrockProvider->>BedrockProvider: Transform parameters
    Note over BedrockProvider: transformAdditionalModelRequestFields()
    Note over BedrockProvider: transformAnthropicAdditionalModelRequestFields()
    Note over BedrockProvider: transformCohereAdditionalModelRequestFields()
    Note over BedrockProvider: transformAI21AdditionalModelRequestFields()
    BedrockProvider->>AWSBedrock: Send properly formatted request
    AWSBedrock->>BedrockProvider: Return response
    BedrockProvider->>Gateway: Process response
    Gateway->>PortkeyNodeSDK: Return formatted response
    PortkeyNodeSDK->>Client: Return final response
```
