### PR TITLE
anthropic pdf

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -64,26 +64,26 @@ interface AnthropicTextContentItem {
 }
 
 interface AnthropicUrlPdfContentItem {
-  type: 'document';
+  type: string;
   source: {
-    type: 'url';
+    type: string;
     url: string;
   };
 }
 
 interface AnthropicBase64PdfContentItem {
-  type: 'document';
+  type: string;
   source: {
-    type: 'base64';
+    type: string;
     data: string;
     media_type: string;
   };
 }
 
 interface AnthropicPlainTextContentItem {
-  type: 'document';
+  type: string;
   source: {
-    type: 'text';
+    type: string;
     data: string;
     media_type: string;
   };
@@ -213,25 +213,14 @@ const transformAndAppendFileContentItem = (
   } else if (item.file?.file_data) {
     const contentType =
       mimeType === fileExtensionMimeTypeMap.txt ? 'text' : 'base64';
-    if (contentType === 'text') {
-      transformedMessage.content.push({
-        type: 'document',
-        source: {
-          type: contentType,
-          data: item.file.file_data,
-          media_type: mimeType,
-        },
-      });
-    } else {
-      transformedMessage.content.push({
-        type: 'document',
-        source: {
-          type: contentType,
-          data: item.file.file_data,
-          media_type: mimeType,
-        },
-      });
-    }
+    transformedMessage.content.push({
+      type: 'document',
+      source: {
+        type: contentType,
+        data: item.file.file_data,
+        media_type: mimeType,
+      },
+    });
   }
 };
 

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -63,11 +63,40 @@ interface AnthropicTextContentItem {
   text: string;
 }
 
+interface AnthropicUrlPdfContentItem {
+  type: 'document';
+  source: {
+    type: 'url';
+    url: string;
+  };
+}
+
+interface AnthropicBase64PdfContentItem {
+  type: 'document';
+  source: {
+    type: 'base64';
+    data: string;
+    media_type: string;
+  };
+}
+
+interface AnthropicPlainTextContentItem {
+  type: 'document';
+  source: {
+    type: 'text';
+    data: string;
+    media_type: string;
+  };
+}
+
 type AnthropicMessageContentItem =
   | AnthropicToolResultContentItem
   | AnthropicBase64ImageContentItem
   | AnthropicUrlImageContentItem
-  | AnthropicTextContentItem;
+  | AnthropicTextContentItem
+  | AnthropicUrlPdfContentItem
+  | AnthropicBase64PdfContentItem
+  | AnthropicPlainTextContentItem;
 
 interface AnthropicMessage extends Message, PromptCache {
   content: AnthropicMessageContentItem[];
@@ -166,6 +195,46 @@ const transformAndAppendImageContentItem = (
   }
 };
 
+const transformAndAppendFileContentItem = (
+  item: ContentType,
+  transformedMessage: AnthropicMessage
+) => {
+  const mimeType =
+    (item.file?.mime_type as keyof typeof fileExtensionMimeTypeMap) ||
+    fileExtensionMimeTypeMap.pdf;
+  if (item.file?.file_url) {
+    transformedMessage.content.push({
+      type: 'document',
+      source: {
+        type: 'url',
+        url: item.file.file_url,
+      },
+    });
+  } else if (item.file?.file_data) {
+    const contentType =
+      mimeType === fileExtensionMimeTypeMap.txt ? 'text' : 'base64';
+    if (contentType === 'text') {
+      transformedMessage.content.push({
+        type: 'document',
+        source: {
+          type: contentType,
+          data: item.file.file_data,
+          media_type: mimeType,
+        },
+      });
+    } else {
+      transformedMessage.content.push({
+        type: 'document',
+        source: {
+          type: contentType,
+          data: item.file.file_data,
+          media_type: mimeType,
+        },
+      });
+    }
+  }
+};
+
 export const AnthropicChatCompleteConfig: ProviderConfig = {
   model: {
     param: 'model',
@@ -205,6 +274,8 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
                   });
                 } else if (item.type === 'image_url') {
                   transformAndAppendImageContentItem(item, transformedMessage);
+                } else if (item.type === 'file') {
+                  transformAndAppendFileContentItem(item, transformedMessage);
                 }
               });
               messages.push(transformedMessage as AnthropicMessage);

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -188,7 +188,7 @@ const getMessageContent = (message: Message) => {
           out.push({
             document: {
               format: fileFormat,
-              name: crypto.randomUUID(),
+              name: item.file.file_name || crypto.randomUUID(),
               source: {
                 s3Location: {
                   uri: item.file.file_url,
@@ -200,7 +200,7 @@ const getMessageContent = (message: Message) => {
           out.push({
             document: {
               format: fileFormat,
-              name: crypto.randomUUID(),
+              name: item.file.file_name || crypto.randomUUID(),
               source: {
                 bytes: item.file.file_data,
               },

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -1,4 +1,9 @@
-import { BEDROCK, documentMimeTypes, imagesMimeTypes } from '../../globals';
+import {
+  BEDROCK,
+  documentMimeTypes,
+  fileExtensionMimeTypeMap,
+  imagesMimeTypes,
+} from '../../globals';
 import {
   Message,
   Params,
@@ -172,6 +177,32 @@ const getMessageContent = (message: Message) => {
               name: crypto.randomUUID(),
               source: {
                 bytes,
+              },
+            },
+          });
+        }
+      } else if (item.type === 'file') {
+        const mimeType = item.file?.mime_type || fileExtensionMimeTypeMap.pdf;
+        const fileFormat = mimeType.split('/')[1];
+        if (item.file?.file_url) {
+          out.push({
+            document: {
+              format: fileFormat,
+              name: crypto.randomUUID(),
+              source: {
+                s3Location: {
+                  uri: item.file.file_url,
+                },
+              },
+            },
+          });
+        } else if (item.file?.file_data) {
+          out.push({
+            document: {
+              format: fileFormat,
+              name: crypto.randomUUID(),
+              source: {
+                bytes: item.file.file_data,
               },
             },
           });
@@ -377,7 +408,10 @@ type BedrockContentItem = {
     format: string;
     name: string;
     source: {
-      bytes: string;
+      bytes?: string;
+      s3Location?: {
+        uri: string;
+      };
     };
   };
   cachePoint?: {

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -216,6 +216,7 @@ export interface Config {
 }
 
 /**
+ * TODO: make this a union type
  * A message content type.
  * @interface
  */
@@ -230,6 +231,17 @@ export interface ContentType extends PromptCache {
     mime_type?: string;
   };
   data?: string;
+  file?: {
+    file_data?: string;
+    file_id?: string;
+    file_name?: string;
+    file_url?: string;
+    mime_type?: string;
+  };
+  input_audio?: {
+    data: string;
+    format: string; //defaults to auto
+  };
 }
 
 export interface ToolCall {


### PR DESCRIPTION
![Code Quality](https://img.shields.io/badge/Code_Quality-85%25-d47f00) ![new feature](https://img.shields.io/badge/new_feature-818aff) 

## Author Description

so couple of things in this PR,
I've added two new parameters in the chat completions request body file content part

```js
// file content part
{
  type: 'file';
  file?: {
    file_data?: string;
    file_id?: string;
    file_name?: string;
    file_url?: string; // new field
    mime_type?: string; // new field
  };
}
```
I've tested with anthropic, vertex anthropic and bedrock anthropic
note: vertex anthropic does not support plain text and pdf urls, bedrock does not support plain text, and only supports s3urls

here are request bodies to test
*pdf url*
```json
{
    "model": "claude-3-5-sonnet-20240620",
    "max_tokens": 200,
    "stream": false,
    "messages": 
        }
    ]
}
```

*pdf base64*
```json
{
    "model": "claude-3-5-sonnet-20240620",
    "max_tokens": 200,
    "stream": false,
    "messages": 
        }
    ]
}
```

*plain text document*
```json
{
    "model": "claude-3-5-sonnet-20240620",
    "max_tokens": 200,
    "stream": false,
    "messages": 
        }
    ]
}
```

# Summary By MatterAI

### 🔄 What Changed
This PR adds support for PDF files in Anthropic and Bedrock providers by introducing two new parameters in the chat completions request body file content part: `file_url` and `mime_type`. The implementation supports both PDF URLs and base64-encoded PDFs, as well as plain text documents.

### 🔍 Impact of the Change
This enhancement allows users to send PDF documents to Anthropic and Bedrock models for analysis. Different providers have varying support: Vertex Anthropic doesn't support plain text and PDF URLs, while Bedrock only supports S3 URLs for PDFs.

### 📁 Total Files Changed
3 files changed with 120 additions and 3 deletions:
- `src/providers/anthropic/chatComplete.ts`: Added PDF handling for Anthropic
- `src/providers/bedrock/chatComplete.ts`: Added PDF handling for Bedrock
- `src/types/requestBody.ts`: Updated content type interfaces

### 🧪 Test Added
Manual testing was performed with Anthropic, Vertex Anthropic, and Bedrock Anthropic providers using various request bodies (PDF URL, PDF base64, plain text).

### 🔒 Security Vulnerabilities
N/A

## Type of Change
- [x] New feature (non-breaking change which adds functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
N/A

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
N/A

## Quality Recommendations

1. Add error handling for unsupported file types or formats

2. Add validation for file_url and file_data to ensure they are properly formatted

3. Consider adding unit tests to verify the PDF handling functionality

4. Add documentation comments for the new interfaces and functions

## Sequence Diagram

```mermaid
sequenceDiagram
    participant Client
    participant Gateway
    participant AnthropicProvider
    participant BedrockProvider
    
    Client->>Gateway: POST /chat/completions
    Note over Client,Gateway: Request with file_url or file_data
    
    alt Anthropic Provider
        Gateway->>AnthropicProvider: transformAndAppendFileContentItem()
        Note over AnthropicProvider: Process file content based on type
        
        alt PDF URL
            AnthropicProvider-->>AnthropicProvider: Create AnthropicUrlPdfContentItem
            Note over AnthropicProvider: { type: 'document', source: { type: 'url', url: file_url } }
        else PDF Base64
            AnthropicProvider-->>AnthropicProvider: Create AnthropicBase64PdfContentItem
            Note over AnthropicProvider: { type: 'document', source: { type: 'base64', data: file_data, media_type: mime_type } }
        else Plain Text
            AnthropicProvider-->>AnthropicProvider: Create AnthropicPlainTextContentItem
            Note over AnthropicProvider: { type: 'document', source: { type: 'text', data: file_data, media_type: mime_type } }
        end
    else Bedrock Provider
        Gateway->>BedrockProvider: getMessageContent()
        Note over BedrockProvider: Process file content based on type
        
        alt File URL (S3)
            BedrockProvider-->>BedrockProvider: Create document with s3Location
            Note over BedrockProvider: { document: { format: fileFormat, name: UUID, source: { s3Location: { uri: file_url } } } }
        else File Data
            BedrockProvider-->>BedrockProvider: Create document with bytes
            Note over BedrockProvider: { document: { format: fileFormat, name: UUID, source: { bytes: file_data } } }
        end
    end
    
    Gateway-->>Client: Return completion response
```
https://github.com/Portkey-AI/gateway/issues/1075