### PR TITLE
do not invoke getEndpoint() when proxy route

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -322,14 +322,17 @@ export async function tryPost(
       c,
       gatewayRequestURL: c.req.url,
     }));
-  const endpoint = apiConfig.getEndpoint({
-    c,
-    providerOptions: providerOption,
-    fn,
-    gatewayRequestBodyJSON: params,
-    gatewayRequestBody: requestBody,
-    gatewayRequestURL: c.req.url,
-  });
+  const endpoint =
+    fn === 'proxy'
+      ? ''
+      : apiConfig.getEndpoint({
+          c,
+          providerOptions: providerOption,
+          fn,
+          gatewayRequestBodyJSON: params,
+          gatewayRequestBody: {}, // not using anywhere.
+          gatewayRequestURL: c.req.url,
+        });
 
   url =
     fn === 'proxy'


### PR DESCRIPTION
The return value from this is not used anyways, and it's throwing 500 error in cases like request body is used inside the getEndpoint() function etc