### PR TITLE
feat: add support for mistral function calling

### DIFF
--- a/src/providers/mistral-ai/chatComplete.ts
+++ b/src/providers/mistral-ai/chatComplete.ts
@@ -75,7 +75,39 @@ export const MistralAIChatCompleteConfig: ProviderConfig = {
     required: false,
     default: '',
   },
+  tools: {
+    param: 'tools',
+    default: null,
+  },
+  tool_choice: {
+    param: 'tool_choice',
+    default: null,
+    transform: (params: Params) => {
+      if (
+        typeof params.tool_choice === 'string' &&
+        params.tool_choice === 'required'
+      ) {
+        return 'any';
+      }
+      return params.tool_choice;
+    },
+  },
+  parallel_tool_calls: {
+    param: 'parallel_tool_calls',
+    default: null,
+  },
 };
+
+interface MistralToolCallFunction {
+  name: string;
+  arguments: string;
+}
+
+interface MistralToolCall {
+  id: string;
+  type: string;
+  function: MistralToolCallFunction;
+}
 
 interface MistralAIChatCompleteResponse extends ChatCompletionResponse {
   id: string;
@@ -106,6 +138,7 @@ interface MistralAIStreamChunk {
     delta: {
       role?: string | null;
       content?: string;
+      tool_calls?: MistralToolCall[];
     };
     index: number;
     finish_reason: string | null;
@@ -140,6 +173,7 @@ export const MistralAIChatCompleteResponseTransform: (
         message: {
           role: c.message.role,
           content: c.message.content,
+          tool_calls: c.message.tool_calls,
         },
         finish_reason: c.finish_reason,
       })),


### PR DESCRIPTION
## Description
This implements [function calling](https://docs.mistral.ai/capabilities/function_calling/) support for mistral and closes #1002

Note that the `tool_choice` param for "requiring a tool call" is `any` instead of `required` for mistral.

## Motivation
Feature parity ;) 

## Type of Change
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing (connected with our own SaaS)

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
#1002 
