### PR TITLE
Vertex thinking changes to disable thinking mode for 2.5 models

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -434,6 +434,7 @@ export const GoogleChatCompleteResponseTransform: (
       promptTokenCount = 0,
       candidatesTokenCount = 0,
       totalTokenCount = 0,
+      thoughtsTokenCount = 0,
     } = response.usageMetadata;
 
     return {
@@ -499,6 +500,9 @@ export const GoogleChatCompleteResponseTransform: (
         prompt_tokens: promptTokenCount,
         completion_tokens: candidatesTokenCount,
         total_tokens: totalTokenCount,
+        completion_token_details: {
+          reasoning_tokens: thoughtsTokenCount,
+        },
       },
     };
   }
@@ -589,6 +593,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
       prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
       completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
       total_tokens: parsedChunk.usageMetadata.totalTokenCount,
+      completion_tokens_details: {
+        reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,
+      },
     };
   }
 

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -500,7 +500,7 @@ export const GoogleChatCompleteResponseTransform: (
         prompt_tokens: promptTokenCount,
         completion_tokens: candidatesTokenCount,
         total_tokens: totalTokenCount,
-        completion_token_details: {
+        completion_tokens_details: {
           reasoning_tokens: thoughtsTokenCount,
         },
       },

--- a/src/providers/google-vertex-ai/transformGenerationConfig.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.ts
@@ -52,7 +52,8 @@ export function transformGenerationConfig(params: Params) {
 
   if (params?.thinking) {
     const thinkingConfig: Record<string, any> = {};
-    thinkingConfig['include_thoughts'] = true;
+    thinkingConfig['include_thoughts'] =
+      params.thinking.type && params.thinking.type === 'enabled' ? true : false;
     thinkingConfig['thinking_budget'] = params.thinking.budget_tokens;
     generationConfig['thinking_config'] = thinkingConfig;
   }

--- a/src/providers/google-vertex-ai/types.ts
+++ b/src/providers/google-vertex-ai/types.ts
@@ -65,6 +65,7 @@ export interface GoogleGenerateContentResponse {
     promptTokenCount: number;
     candidatesTokenCount: number;
     totalTokenCount: number;
+    thoughtsTokenCount?: number;
   };
 }
 

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -480,6 +480,7 @@ interface GoogleGenerateContentResponse {
     promptTokenCount: number;
     candidatesTokenCount: number;
     totalTokenCount: number;
+    thoughtsTokenCount: number;
   };
 }
 
@@ -580,6 +581,9 @@ export const GoogleChatCompleteResponseTransform: (
         prompt_tokens: response.usageMetadata.promptTokenCount,
         completion_tokens: response.usageMetadata.candidatesTokenCount,
         total_tokens: response.usageMetadata.totalTokenCount,
+        completions_tokens_details: {
+          reasoning_tokens: response.usageMetadata.thoughtsTokenCount ?? 0,
+        },
       },
     };
   }
@@ -625,6 +629,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
       prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
       completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
       total_tokens: parsedChunk.usageMetadata.totalTokenCount,
+      completion_tokens_details: {
+        reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,
+      },
     };
   }
 

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -581,7 +581,7 @@ export const GoogleChatCompleteResponseTransform: (
         prompt_tokens: response.usageMetadata.promptTokenCount,
         completion_tokens: response.usageMetadata.candidatesTokenCount,
         total_tokens: response.usageMetadata.totalTokenCount,
-        completions_tokens_details: {
+        completion_tokens_details: {
           reasoning_tokens: response.usageMetadata.thoughtsTokenCount ?? 0,
         },
       },

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -73,7 +73,8 @@ const transformGenerationConfig = (params: Params) => {
   }
   if (params?.thinking) {
     const thinkingConfig: Record<string, any> = {};
-    thinkingConfig['include_thoughts'] = true;
+    thinkingConfig['include_thoughts'] =
+      params.thinking.type && params.thinking.type === 'enabled' ? true : false;
     thinkingConfig['thinking_budget'] = params.thinking.budget_tokens;
     generationConfig['thinking_config'] = thinkingConfig;
   }


### PR DESCRIPTION
make changes to disable thinking mode in 2.5 models
also return thinking tokens in the response as per open ai format

example request body to disable thinking
```json
{
    "model": "gemini-2.5-flash-preview-04-17",
    "max_tokens": 2000,
    "stream": true,
    "messages": [
        {
            "role": "user",
            "content": "What is the meanin of life, universe and everything"
        }
    ],
    "thinking": {
        "type": "disabled",
        "budget_tokens": 0
    }
}
```

NOTE: users are required to send `type disabled` and `budget_tokens: 0` explicitly