### PR TITLE
fix vertex video embeddings mode/config

### DIFF
--- a/src/providers/google-vertex-ai/transformGenerationConfig.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.ts
@@ -101,9 +101,11 @@ export function transformEmbeddingInputs(params: GoogleEmbedParams) {
             video: {
               gcsUri: input.video.url,
               bytesBase64Encoded: input.video.base64,
-              startOffsetSec: input.video.start_offset,
-              endOffsetSec: input.video.end_offset,
-              intervalSec: input.video.interval,
+              videoSegmentConfig: {
+                startOffsetSec: input.video.start_offset,
+                endOffsetSec: input.video.end_offset,
+                intervalSec: input.video.interval,
+              },
             },
           }),
         });

--- a/src/providers/google-vertex-ai/types.ts
+++ b/src/providers/google-vertex-ai/types.ts
@@ -107,9 +107,11 @@ export interface MultimodalEmbedInstance {
   video?: {
     gcsUri?: string;
     bytesBase64Encoded?: string;
-    startOffsetSec?: number;
-    endOffsetSec?: number;
-    intervalSec?: number;
+    videoSegmentConfig?: {
+      startOffsetSec?: number;
+      endOffsetSec?: number;
+      intervalSec?: number;
+    };
   };
 }
 


### PR DESCRIPTION
tested with
- no config
- config

Here's a 35 second base64 encoded video file,
[temp.txt](https://github.com/user-attachments/files/20219522/temp.txt)
