### PR TITLE
fix multi turn tool calling for anthropic when arguments to the tool call is an empty object

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -130,7 +130,9 @@ const transformAssistantMessage = (msg: Message): AnthropicMessage => {
         type: 'tool_use',
         name: toolCall.function.name,
         id: toolCall.id,
-        input: JSON.parse(toolCall.function.arguments),
+        input: toolCall.function.arguments?.length
+          ? JSON.parse(toolCall.function.arguments)
+          : {},
       });
     });
   }

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -32,6 +32,7 @@ interface AnthropicTool extends PromptCache {
       }
     >;
     required: string[];
+    $defs: Record<string, any>;
   };
 }
 
@@ -338,6 +339,7 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
                 type: tool.function.parameters?.type || 'object',
                 properties: tool.function.parameters?.properties || {},
                 required: tool.function.parameters?.required || [],
+                $defs: tool.function.parameters?.['$defs'] || {},
               },
               ...(tool.cache_control && {
                 cache_control: { type: 'ephemeral' },


### PR DESCRIPTION
This PR fixes
- multi turn tool calling when arguments are an empty object
- expanded support for input_schema for sending `$defs` alongwith your schema

https://github.com/Portkey-AI/gateway/issues/1103

*Testing done*
Did multi turn tool calling with empty string arguments in assistant tool call message

payload for testing
```json
{
    "model": "claude-3-5-sonnet-20240620",
    "max_tokens": 200,
    "stream": false,
    "messages": [
        {
            "role": "user",
            "content": "Based on the temperature and time in California what do you suggest I wear?"
        },
        {
            "role": "assistant",
            "content": "Certainly! I'd be happy to provide you with the current temperature and time in San Francisco. To get this information, I'll need to use two separate tools. Let me fetch that data for you.",
            "tool_calls": [
                {
                    "id": "toolu_01BspjPLY4dtHkKGurn8q9A6",
                    "type": "function",
                    "function": {
                        "name": "get_current_temperature",
                        "arguments": ""
                    }
                },
                {
                    "id": "toolu_014jEfKqGbfFvRaKfiauxgPv",
                    "type": "function",
                    "function": {
                        "name": "get_current_time",
                        "arguments": "{\"location\":\"San Francisco, CA\"}"
                    }
                }
            ]
        },
        {
            "role": "tool",
            "content": "15 degrees",
            "tool_call_id": "toolu_01BspjPLY4dtHkKGurn8q9A6"
        },
        {
            "role": "tool",
            "content": "10 PM",
            "tool_call_id": "toolu_014jEfKqGbfFvRaKfiauxgPv"
        }
    ],
    "tools": [
        {
            "type": "function",
            "function": {
                "name": "get_current_temperature",
                "description": "Get the current temperature for a specific location",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "location": {
                            "type": "string",
                            "description": "The city and state, e.g., San Francisco, CA"
                        },
                        "unit": {
                            "type": "string",
                            "enum": [
                                "Celsius",
                                "Fahrenheit"
                            ],
                            "description": "The temperature unit to use. Infer this from the user's location."
                        }
                    },
                    "required": [
                        "location",
                        "unit"
                    ]
                }
            }
        },
        {
            "type": "function",
            "function": {
                "name": "get_current_time",
                "description": "Get the current time for a specific location",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "location": {
                            "type": "string",
                            "description": "The city and state, e.g., San Francisco, CA"
                        }
                    },
                    "required": [
                        "location"
                    ]
                }
            }
        }
    ]
}
```