### PR TITLE
working implementation to enable guardrails for realtime api

### DIFF
--- a/src/handlers/realtimeHandler.ts
+++ b/src/handlers/realtimeHandler.ts
@@ -30,6 +30,7 @@ const getOutgoingWebSocket = async (url: string, options: RequestInit) => {
 export async function realTimeHandler(c: Context): Promise<Response> {
   try {
     const requestHeaders = Object.fromEntries(c.req.raw.headers);
+    const hooksManager = c.get('hooksManager');
 
     const providerOptions = constructConfigFromRequestHeaders(
       requestHeaders
@@ -68,7 +69,14 @@ export async function realTimeHandler(c: Context): Promise<Response> {
 
     let outgoingWebSocket: WebSocket = await getOutgoingWebSocket(url, options);
     const eventParser = new RealtimeLlmEventParser();
-    addListeners(outgoingWebSocket, eventParser, server, c, sessionOptions);
+    addListeners(
+      outgoingWebSocket,
+      eventParser,
+      server,
+      c,
+      sessionOptions,
+      providerOptions
+    );
 
     return new Response(null, {
       status: 101,

--- a/src/middlewares/hooks/index.ts
+++ b/src/middlewares/hooks/index.ts
@@ -418,7 +418,9 @@ export class HooksManager {
   private shouldSkipHook(span: HookSpan, hook: HookObject): boolean {
     const context = span.getContext();
     return (
-      !['chatComplete', 'complete', 'embed'].includes(context.requestType) ||
+      !['chatComplete', 'complete', 'embed', 'realtime'].includes(
+        context.requestType
+      ) ||
       (context.requestType === 'embed' &&
         hook.eventType !== 'beforeRequestHook') ||
       (context.requestType === 'embed' && hook.type === HookType.MUTATOR) ||


### PR DESCRIPTION
Keeping in draft, did this as an experiment to see if we could guardrail realtime audio responses.

This works, to take this to completion
- we'll need to make the checks async
- standardize events to emit for failed guardrail checks that the clients can handle on their end