### PR TITLE
feature: inference profiles for bedrock

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -323,6 +323,7 @@ export async function tryPost(
       fn,
       c,
       gatewayRequestURL: c.req.url,
+      params: params,
     }));
   const endpoint =
     fn === 'proxy'

--- a/src/providers/bedrock/getBatchOutput.ts
+++ b/src/providers/bedrock/getBatchOutput.ts
@@ -53,7 +53,7 @@ export const BedrockGetBatchOutputRequestHandler = async ({
     // get s3 file id from batch details
     // get file from s3
     // return file
-    const baseUrl = BedrockAPIConfig.getBaseURL({
+    const baseUrl = await BedrockAPIConfig.getBaseURL({
       providerOptions,
       fn: 'retrieveBatch',
       c,

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -89,7 +89,8 @@ const BedrockConfig: ProviderConfigs = {
     let config: ProviderConfigs = {};
 
     if (params.model) {
-      const providerModel = params?.model?.replace(/^(us\.|eu\.)/, '');
+      let providerModel = params.foundationModel || params.model;
+      providerModel = providerModel.replace(/^(us\.|eu\.)/, '');
       const providerModelArray = providerModel?.split('.');
       const provider = providerModelArray?.[0];
       const model = providerModelArray?.slice(1).join('.');

--- a/src/providers/bedrock/retrieveFileContent.ts
+++ b/src/providers/bedrock/retrieveFileContent.ts
@@ -19,7 +19,7 @@ export const BedrockRetrieveFileContentRequestHandler = async ({
 }) => {
   try {
     // construct the base url and endpoint
-    const baseURL = BedrockAPIConfig.getBaseURL({
+    const baseURL = await BedrockAPIConfig.getBaseURL({
       providerOptions,
       fn: 'retrieveFileContent',
       c,

--- a/src/providers/bedrock/types.ts
+++ b/src/providers/bedrock/types.ts
@@ -64,3 +64,17 @@ export interface BedrockFinetuneRecord {
   outputModelName?: string;
   outputModelArn?: string;
 }
+
+export interface BedrockInferenceProfile {
+  inferenceProfileName: string;
+  description: string;
+  createdAt: string;
+  updatedAt: string;
+  inferenceProfileArn: string;
+  models: {
+    modelArn: string;
+  }[];
+  inferenceProfileId: string;
+  status: string;
+  type: string;
+}

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -458,8 +458,6 @@ export const getFoundationModelFromInferenceProfile = async (
       ? await getFromCacheByKey(env(c), cacheKey)
       : null;
     if (cachedFoundationModel) {
-      //update ttl, dont't await the result
-      putInCacheWithValue(env(c), cacheKey, cachedFoundationModel, 56400);
       return cachedFoundationModel;
     }
 
@@ -475,7 +473,9 @@ export const getFoundationModelFromInferenceProfile = async (
     const foundationModel = inferenceProfile?.models?.[0]?.modelArn
       ?.split('/')
       ?.pop();
-    putInCacheWithValue(env(c), cacheKey, foundationModel, 56400);
+    if (putInCacheWithValue) {
+      putInCacheWithValue(env(c), cacheKey, foundationModel, 56400);
+    }
     return foundationModel;
   } catch (error) {
     return null;

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -10,7 +10,7 @@ import {
 } from './chatComplete';
 import { Options } from '../../types/requestBody';
 import { GatewayError } from '../../errors/GatewayError';
-import { BedrockFinetuneRecord } from './types';
+import { BedrockFinetuneRecord, BedrockInferenceProfile } from './types';
 import { FinetuneRequest } from '../types';
 
 export const generateAWSHeaders = async (
@@ -403,4 +403,81 @@ export const populateHyperParameters = (value: FinetuneRequest) => {
   }
 
   return hyperParameters;
+};
+
+export const getInferenceProfile = async (
+  inferenceProfileIdentifier: string,
+  awsRegion: string,
+  awsAccessKeyId: string,
+  awsSecretAccessKey: string,
+  awsSessionToken?: string
+) => {
+  const url = `https://bedrock.${awsRegion}.amazonaws.com/inference-profiles/${encodeURIComponent(decodeURIComponent(inferenceProfileIdentifier))}`;
+
+  const headers = await generateAWSHeaders(
+    undefined,
+    { 'content-type': 'application/json' },
+    url,
+    'GET',
+    'bedrock',
+    awsRegion,
+    awsAccessKeyId,
+    awsSecretAccessKey,
+    awsSessionToken
+  );
+
+  try {
+    const response = await fetch(url, {
+      method: 'GET',
+      headers,
+    });
+
+    if (!response.ok) {
+      throw new Error(
+        `Failed to get inference profile: ${response.status} ${response.statusText}`
+      );
+    }
+
+    return (await response.json()) as BedrockInferenceProfile;
+  } catch (error) {
+    console.error('Error getting inference profile:', error);
+    throw error;
+  }
+};
+
+export const getFoundationModelFromInferenceProfile = async (
+  c: Context,
+  inferenceProfileIdentifier: string,
+  providerOptions: Options
+) => {
+  try {
+    const getFromCacheByKey = c.get('getFromCacheByKey');
+    const putInCacheWithValue = c.get('putInCacheWithValue');
+    const cacheKey = `bedrock-inference-profile-${inferenceProfileIdentifier}`;
+    const cachedFoundationModel = getFromCacheByKey
+      ? await getFromCacheByKey(env(c), cacheKey)
+      : null;
+    if (cachedFoundationModel) {
+      //update ttl, dont't await the result
+      putInCacheWithValue(env(c), cacheKey, cachedFoundationModel, 56400);
+      return cachedFoundationModel;
+    }
+
+    const inferenceProfile = await getInferenceProfile(
+      inferenceProfileIdentifier || '',
+      providerOptions.awsRegion || '',
+      providerOptions.awsAccessKeyId || '',
+      providerOptions.awsSecretAccessKey || '',
+      providerOptions.awsSessionToken || ''
+    );
+
+    // modelArn is always like arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2:1
+    const foundationModel = inferenceProfile?.models?.[0]?.modelArn
+      ?.split('/')
+      ?.pop();
+    putInCacheWithValue(env(c), cacheKey, foundationModel, 56400);
+    return foundationModel;
+  } catch (error) {
+    return null;
+  }
 };

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -474,7 +474,7 @@ export const getFoundationModelFromInferenceProfile = async (
       ?.split('/')
       ?.pop();
     if (putInCacheWithValue) {
-      putInCacheWithValue(env(c), cacheKey, foundationModel, 56400);
+      putInCacheWithValue(env(c), cacheKey, foundationModel, 86400);
     }
     return foundationModel;
   } catch (error) {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -50,6 +50,7 @@ export interface ProviderAPIConfig {
     requestHeaders?: Record<string, string>;
     c: Context;
     gatewayRequestURL: string;
+    params?: Params;
   }) => Promise<string> | string;
   /** A function to generate the endpoint based on parameters */
   getEndpoint: (args: {

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -423,6 +423,7 @@ export interface Params {
   // Embeddings specific
   dimensions?: number;
   parameters?: any;
+  [key: string]: any;
 }
 
 interface Examples {


### PR DESCRIPTION
more on bedrock inference profiles:
https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles.html

## Testing done:
- Tested with application inference profiles ex: `arn:aws:bedrock:us-east-1:517194595696:application-inference-profile/s529qz7ddy06` (both URI encoded and as a regular string), verified that cost calculation is working as intended
- Tested with regular models like `anthropic.claude-3-haiku-20240307-v1:0`
- verified with cache

## Guide
1. Create an inference profile:
- your IAM role should have the requisite permissions: https://docs.aws.amazon.com/bedrock/latest/userguide/inference-profiles-prereq.html
- Fetch the ARN of the foundation model (or cross region inference profile) that you want to use 
```sh
aws bedrock get-foundation-model --model-identifier anthropic.claude-v2:1
```
- use the following command from the CLI to create an application inference profile 
```sh
 aws bedrock create-inference-profile \
                             --inference-profile-name inference-profile-test \
                             --model-source copyFrom=arn:aws:bedrock:us-east-1::foundation-model/anthropic.claude-v2:1
```

> [!NOTE]
>  inference profiles are immutable

2. Using the inference profile
- send the generated inference profile id in your model parameter like (`arn:aws:bedrock:us-east-1:517194595696:application-inference-profile/s529qz7ddy06`)
- this is cached for upto a day

snippets for testing 
```sh
curl --location 'http://localhost:8787/v1/chat/completions' \
--header 'Content-Type: application/json' \
--header 'x-portkey-virtual-key: ' \
--header 'x-portkey-api-key: ' \
--data '{
    "messages": [
        {
            "role": "user",
            "content": "How are you doing sir?"
        },
        {
            "role": "assistant",
            "content": [
                    {
                        "type": "text",
                        "text": "\n\nThank you forsking! I'\''m just a program, so I don'\''t have feelings, but I'\''m here and ready to help with whatever you need. How can I assist you today? 😊"
                    }
                ]
        },
        {
            "role": "user",
            "content": "good good, you seem cherry"
        }
    ],
    "model": "arn:aws:bedrock:us-east-1:517194595696:application-inference-profile/s529qz7ddy06",
    "max_tokens": 3000,
    "stream": false
}'
```