### PR TITLE
support anthropic computer use

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -21,8 +21,8 @@ import { AnthropicStreamState } from './types';
 
 interface AnthropicTool extends PromptCache {
   name: string;
-  description: string;
-  input_schema: {
+  description?: string;
+  input_schema?: {
     type: string;
     properties: Record<
       string,
@@ -33,6 +33,10 @@ interface AnthropicTool extends PromptCache {
     >;
     required: string[];
   };
+  type?: string;
+  display_width_px?: number;
+  display_height_px?: number;
+  display_number?: number;
 }
 
 interface AnthropicToolResultContentItem {
@@ -340,6 +344,12 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
               ...(tool.cache_control && {
                 cache_control: { type: 'ephemeral' },
               }),
+            });
+          } else if (tool.computer) {
+            tools.push({
+              ...tool.computer,
+              name: 'computer',
+              type: tool.computer.name,
             });
           }
         });

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -357,6 +357,12 @@ export interface Tool extends PromptCache {
   type: string;
   /** A description of the function. */
   function: Function;
+  computer?: {
+    name: string;
+    display_width_px: number;
+    display_height_px: number;
+    display_number: number;
+  };
 }
 
 /**


### PR DESCRIPTION
Add support for anthropic computer use

example playload:
```json
{
    "model": "claude-4-opus-20250514",
    "max_tokens": 2000,
    "anthropic_beta": "computer-use-2025-01-24",
    "tools": [
        {
            "type": "computer",
            "computer": {
                "name": "computer_20250124",
                "display_width_px": 1024,
                "display_height_px": 768,
                "display_number": 1
            }
        },
        {
            "type": "text_editor_20250429",
            "name": "str_replace_based_edit_tool"
        },
        {
            "type": "bash_20250124",
            "name": "bash"
        }
    ],
    "messages": [
        {
            "role": "user",
            "content": "Save a picture of a cat to my desktop."
        }
    ]
    // "thinking": {
    //     "type": "enabled",
    //     "budget_tokens": 1024
    // }
}
```