### PR TITLE
feat: multimodal embeddings for bedrock titan and cohere

### DIFF
--- a/src/providers/bedrock/embed.ts
+++ b/src/providers/bedrock/embed.ts
@@ -1,5 +1,5 @@
 import { BEDROCK } from '../../globals';
-import { EmbedResponse } from '../../types/embedRequestBody';
+import { EmbedParams, EmbedResponse } from '../../types/embedRequestBody';
 import { Params } from '../../types/requestBody';
 import { ErrorResponse, ProviderConfig } from '../types';
 import { generateInvalidProviderResponseError } from '../utils';
@@ -27,9 +27,69 @@ export const BedrockCohereEmbedConfig: ProviderConfig = {
 };
 
 export const BedrockTitanEmbedConfig: ProviderConfig = {
-  input: {
-    param: 'inputText',
-    required: true,
+  input: [
+    {
+      param: 'inputText',
+      required: false,
+      transform: (params: EmbedParams): string | undefined => {
+        if (
+          Array.isArray(params.input) &&
+          typeof params.input[0] === 'object' &&
+          params.input[0].text
+        ) {
+          return params.input[0].text;
+        }
+        if (typeof params.input === 'string') return params.input;
+      },
+    },
+    {
+      param: 'inputImage',
+      required: false,
+      transform: (params: EmbedParams) => {
+        if (
+          Array.isArray(params.input) &&
+          typeof params.input[0] === 'object' &&
+          params.input[0].image?.base64
+        ) {
+          return params.input[0].image.base64;
+        }
+      },
+    },
+  ],
+  dimensions: [
+    {
+      param: 'dimensions',
+      required: false,
+      transform: (params: EmbedParams): number | undefined => {
+        if (typeof params.input === 'string') return params.dimensions;
+      },
+    },
+    {
+      param: 'embeddingConfig',
+      required: false,
+      transform: (
+        params: EmbedParams
+      ): { outputEmbeddingLength: number } | undefined => {
+        if (Array.isArray(params.input) && params.dimensions) {
+          return {
+            outputEmbeddingLength: params.dimensions,
+          };
+        }
+      },
+    },
+  ],
+  encoding_format: {
+    param: 'embeddingTypes',
+    required: false,
+    transform: (params: any): string[] => {
+      if (Array.isArray(params.encoding_format)) return params.encoding_format;
+      return [params.encoding_format];
+    },
+  },
+  // Titan specific parameters
+  normalize: {
+    param: 'normalize',
+    required: false,
   },
 };
 

--- a/src/providers/bedrock/embed.ts
+++ b/src/providers/bedrock/embed.ts
@@ -79,6 +79,7 @@ export const BedrockTitanEmbedConfig: ProviderConfig = {
       param: 'inputImage',
       required: false,
       transform: (params: EmbedParams) => {
+        // Titan models only support one image per request
         if (
           Array.isArray(params.input) &&
           typeof params.input[0] === 'object' &&

--- a/src/providers/bedrock/embed.ts
+++ b/src/providers/bedrock/embed.ts
@@ -6,23 +6,56 @@ import { generateInvalidProviderResponseError } from '../utils';
 import { BedrockErrorResponseTransform } from './chatComplete';
 
 export const BedrockCohereEmbedConfig: ProviderConfig = {
-  input: {
-    param: 'texts',
-    required: true,
-    transform: (params: any): string[] => {
-      if (Array.isArray(params.input)) {
-        return params.input;
-      } else {
-        return [params.input];
-      }
+  input: [
+    {
+      param: 'texts',
+      required: false,
+      transform: (params: EmbedParams): string[] | undefined => {
+        if (typeof params.input === 'string') return [params.input];
+        else if (Array.isArray(params.input) && params.input.length > 0) {
+          const texts: string[] = [];
+          params.input.forEach((item) => {
+            if (typeof item === 'string') {
+              texts.push(item);
+            } else if (item.text) {
+              texts.push(item.text);
+            }
+          });
+          return texts.length > 0 ? texts : undefined;
+        }
+      },
     },
-  },
+    {
+      param: 'images',
+      required: false,
+      transform: (params: EmbedParams): string[] | undefined => {
+        if (Array.isArray(params.input) && params.input.length > 0) {
+          const images: string[] = [];
+          params.input.forEach((item) => {
+            if (typeof item === 'object' && item.image?.base64) {
+              images.push(item.image.base64);
+            }
+          });
+          return images.length > 0 ? images : undefined;
+        }
+      },
+    },
+  ],
   input_type: {
     param: 'input_type',
     required: true,
   },
   truncate: {
     param: 'truncate',
+    required: false,
+  },
+  encoding_format: {
+    param: 'embedding_types',
+    required: false,
+    transform: (params: any): string[] => {
+      if (Array.isArray(params.encoding_format)) return params.encoding_format;
+      return [params.encoding_format];
+    },
   },
 };
 

--- a/src/providers/cohere/embed.ts
+++ b/src/providers/cohere/embed.ts
@@ -4,32 +4,56 @@ import { generateErrorResponse } from '../utils';
 import { COHERE } from '../../globals';
 
 export const CohereEmbedConfig: ProviderConfig = {
-  input: {
-    param: 'texts',
-    required: true,
-    transform: (params: EmbedParams): string[] => {
-      if (Array.isArray(params.input)) {
-        return params.input as string[];
-      } else {
-        return [params.input];
-      }
+  input: [
+    {
+      param: 'texts',
+      required: false,
+      transform: (params: EmbedParams): string[] | undefined => {
+        if (typeof params.input === 'string') return [params.input];
+        else if (Array.isArray(params.input) && params.input.length > 0) {
+          const texts: string[] = [];
+          params.input.forEach((item) => {
+            if (typeof item === 'string') {
+              texts.push(item);
+            } else if (item.text) {
+              texts.push(item.text);
+            }
+          });
+          return texts.length > 0 ? texts : undefined;
+        }
+      },
     },
-  },
-  model: {
-    param: 'model',
-    default: 'embed-english-light-v2.0',
-  },
+    {
+      param: 'images',
+      required: false,
+      transform: (params: EmbedParams): string[] | undefined => {
+        if (Array.isArray(params.input) && params.input.length > 0) {
+          const images: string[] = [];
+          params.input.forEach((item) => {
+            if (typeof item === 'object' && item.image?.base64) {
+              images.push(item.image.base64);
+            }
+          });
+          return images.length > 0 ? images : undefined;
+        }
+      },
+    },
+  ],
   input_type: {
     param: 'input_type',
-    required: false,
-  },
-  embedding_types: {
-    param: 'embedding_types',
-    required: false,
+    required: true,
   },
   truncate: {
     param: 'truncate',
     required: false,
+  },
+  encoding_format: {
+    param: 'embedding_types',
+    required: false,
+    transform: (params: any): string[] => {
+      if (Array.isArray(params.encoding_format)) return params.encoding_format;
+      return [params.encoding_format];
+    },
   },
 };
 

--- a/src/providers/cohere/embed.ts
+++ b/src/providers/cohere/embed.ts
@@ -55,6 +55,11 @@ export const CohereEmbedConfig: ProviderConfig = {
       return [params.encoding_format];
     },
   },
+  //backwards compatibility
+  embedding_types: {
+    param: 'embedding_types',
+    required: false,
+  },
 };
 
 /**


### PR DESCRIPTION
This PR adds support for multimodal embeddings in compliance with the portkey signature:

example requests:
1. Titan text embedding:
```sh
curl --location 'http://localhost:8787/v1/embeddings' \
--header 'x-portkey-provider: bedrock' \
--header 'Content-Type: application/json' \
--header 'x-portkey-aws-access-key-id: ID' \
--header 'x-portkey-aws-secret-access-key: KEY' \
--header 'x-portkey-aws-region: us-east-1' \
--data '{
    "model": "amazon.titan-embed-text-v2:0",
    "input": "Hello this is a test",
    "normalize": false
}'
```

2. Titan image embedding:
```sh
curl --location 'http://localhost:8787/v1/embeddings' \
--header 'x-portkey-provider: bedrock' \
--header 'Content-Type: application/json' \
--header 'x-portkey-aws-access-key-id: ID' \
--header 'x-portkey-aws-secret-access-key: KEY' \
--header 'x-portkey-aws-region: us-east-1' \
--data '{
    "model": "amazon.titan-embed-image-v1",
    "dimensions": 256,
    "input": [
        {
            "text": "this is the caption of the image",
            "image": {
                "base64": "UklGRkac....."
            }
        }
    ]
}'
```

3. Cohere text embedding:
```sh
curl --location 'http://localhost:8787/v1/embeddings' \
--header 'x-portkey-provider: bedrock' \
--header 'Content-Type: application/json' \
--header 'x-portkey-aws-access-key-id: ID' \
--header 'x-portkey-aws-secret-access-key: KEY' \
--header 'x-portkey-aws-region: us-east-1' \
--data '{
    "model": "cohere.embed-english-v3",
    "input": ["Hello this is a test", "skibidi"],
    "input_type": "classification"
}'
```

4. Cohere Multimodal embedding:
```sh
curl --location 'http://localhost:8787/v1/embeddings' \
--header 'x-portkey-provider: bedrock' \
--header 'Content-Type: application/json' \
--header 'x-portkey-aws-access-key-id: ID' \
--header 'x-portkey-aws-secret-access-key: KEY' \
--header 'x-portkey-aws-region: us-east-1' \
--data '{
    "model": "cohere.embed-english-v3",
    "input_type": "image",
    "dimensions": 256,
    "input": [
        {
            
            "image": {
                "base64": "UklGRkac....."
            }
        }
    ]
}'
```