### PR TITLE
anthropic prompt caching for tool result and tool use

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -147,6 +147,9 @@ const transformAssistantMessage = (msg: Message): AnthropicMessage => {
         input: toolCall.function.arguments?.length
           ? JSON.parse(toolCall.function.arguments)
           : {},
+        ...(toolCall.cache_control && {
+          cache_control: toolCall.cache_control,
+        }),
       });
     });
   }

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -43,7 +43,16 @@ interface AnthropicTool extends PromptCache {
 interface AnthropicToolResultContentItem {
   type: 'tool_result';
   tool_use_id: string;
-  content?: string;
+  content?:
+    | {
+        type: string;
+        text?: string;
+        cache_control?: {
+          type: string;
+          ttl?: number;
+        };
+      }[]
+    | string;
 }
 
 interface AnthropicBase64ImageContentItem {
@@ -155,7 +164,7 @@ const transformToolMessage = (msg: Message): AnthropicMessage => {
       {
         type: 'tool_result',
         tool_use_id,
-        content: msg.content as string,
+        content: msg.content,
       },
     ],
   };
@@ -250,6 +259,9 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
 
             if (msg.role === 'assistant') {
               messages.push(transformAssistantMessage(msg));
+            } else if (msg.role === 'tool') {
+              // even though anthropic supports images in tool results, openai doesn't support it yet
+              messages.push(transformToolMessage(msg));
             } else if (
               msg.content &&
               typeof msg.content === 'object' &&
@@ -275,9 +287,6 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
                 }
               });
               messages.push(transformedMessage as AnthropicMessage);
-            } else if (msg.role === 'tool') {
-              // even though anthropic supports images in tool results, openai doesn't support it yet
-              messages.push(transformToolMessage(msg));
             } else {
               messages.push({
                 role: msg.role,


### PR DESCRIPTION
#1140 

documentation for prompt caching from anthropic: https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching
https://docs.anthropic.com/en/api/messages#body-messages-content-cache-control

example payload
```json
{
    "model": "claude-3-5-sonnet-20240620",
    "max_tokens": 200,
    "stream": false,
    "messages": [
        {
            "role": "user",
            "content": "Based on the temperature and time in California what do you suggest I wear?"
        },
        {
            "role": "assistant",
            "content": "Certainly! I'd be happy to provide you with the current temperature and time in San Francisco. To get this information, I'll need to use two separate tools. Let me fetch that data for you.",
            "tool_calls": [
                {
                    "id": "toolu_01BspjPLY4dtHkKGurn8q9A6",
                    "type": "function",
                    "function": {
                        "name": "get_current_temperature",
                        "arguments": ""
                    },
                    "cache_control": {
                        "type": "ephemeral"
                    }
                },
                {
                    "id": "toolu_014jEfKqGbfFvRaKfiauxgPv",
                    "type": "function",
                    "function": {
                        "name": "get_current_time",
                        "arguments": "{\"location\":\"San Francisco, CA\"}"
                    }
                }
            ]
        },
        {
            "role": "tool",
            "content": [
                {
                    "type": "text",
                    "text": "15 degrees",
                    "cache_control": {
                        "type": "ephemeral"
                    }
                }
            ],
            "tool_call_id": "toolu_01BspjPLY4dtHkKGurn8q9A6"
        },
        {
            "role": "tool",
            "content": "10 PM",
            "tool_call_id": "toolu_014jEfKqGbfFvRaKfiauxgPv"
        }
    ],
    "tools": [
        {
            "type": "function",
            "function": {
                "name": "get_current_temperature",
                "description": "Get the current temperature for a specific location",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "location": {
                            "type": "string",
                            "description": "The city and state, e.g., San Francisco, CA"
                        },
                        "unit": {
                            "type": "string",
                            "enum": [
                                "Celsius",
                                "Fahrenheit"
                            ],
                            "description": "The temperature unit to use. Infer this from the user's location."
                        }
                    },
                    "required": [
                        "location",
                        "unit"
                    ]
                }
            }
        },
        {
            "type": "function",
            "function": {
                "name": "get_current_time",
                "description": "Get the current time for a specific location",
                "parameters": {
                    "type": "object",
                    "properties": {
                        "location": {
                            "type": "string",
                            "description": "The city and state, e.g., San Francisco, CA"
                        }
                    },
                    "required": [
                        "location"
                    ]
                }
            }
        }
    ]
}
```