### PR TITLE
return finish reason in bedrock error chunk

### DIFF
--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -643,7 +643,6 @@ export const BedrockChatCompleteStreamChunkTransform: (
   gatewayRequest
 ) => {
   const parsedChunk: BedrockChatCompleteStreamChunk = JSON.parse(responseChunk);
-  console.log(JSON.stringify(parsedChunk, null, 2));
   if (parsedChunk.message) {
     return getBedrockErrorChunk(fallbackId, gatewayRequest.model || '');
   }

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -746,6 +746,7 @@ export const BedrockChatCompleteStreamChunkTransform: (
             }),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         },
+        finish_reason: streamState.stopReason ?? null,
       },
     ],
   })}\n\n`;

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -28,6 +28,7 @@ import {
 } from './complete';
 import { BedrockErrorResponse } from './embed';
 import {
+  getBedrockErrorChunk,
   transformAdditionalModelRequestFields,
   transformAI21AdditionalModelRequestFields,
   transformAnthropicAdditionalModelRequestFields,
@@ -584,6 +585,8 @@ export const BedrockChatCompleteResponseTransform: (
 };
 
 export interface BedrockChatCompleteStreamChunk {
+  // this is error message from bedrock
+  message?: string;
   contentBlockIndex?: number;
   delta?: {
     text: string;
@@ -640,6 +643,10 @@ export const BedrockChatCompleteStreamChunkTransform: (
   gatewayRequest
 ) => {
   const parsedChunk: BedrockChatCompleteStreamChunk = JSON.parse(responseChunk);
+  console.log(JSON.stringify(parsedChunk, null, 2));
+  if (parsedChunk.message) {
+    return getBedrockErrorChunk(fallbackId, gatewayRequest.model || '');
+  }
   if (parsedChunk.stopReason) {
     streamState.stopReason = parsedChunk.stopReason;
   }

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -746,7 +746,7 @@ export const BedrockChatCompleteStreamChunkTransform: (
             }),
           tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
         },
-        finish_reason: streamState.stopReason ?? null,
+        finish_reason: null,
       },
     ],
   })}\n\n`;

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -12,6 +12,7 @@ import { Options } from '../../types/requestBody';
 import { GatewayError } from '../../errors/GatewayError';
 import { BedrockFinetuneRecord, BedrockInferenceProfile } from './types';
 import { FinetuneRequest } from '../types';
+import { BEDROCK } from '../../globals';
 
 export const generateAWSHeaders = async (
   body: Record<string, any> | string | undefined,
@@ -480,4 +481,26 @@ export const getFoundationModelFromInferenceProfile = async (
   } catch (error) {
     return null;
   }
+};
+
+export const getBedrockErrorChunk = (id: string, model: string) => {
+  return [
+    `data: ${JSON.stringify({
+      id,
+      object: 'chat.completion.chunk',
+      created: Math.floor(Date.now() / 1000),
+      model: model,
+      provider: BEDROCK,
+      choices: [
+        {
+          index: 0,
+          delta: {
+            role: 'assistant',
+            finish_reason: 'stop',
+          },
+        },
+      ],
+    })}\n\n`,
+    `data: [DONE]\n\n`,
+  ];
 };


### PR DESCRIPTION
This is not a fix for #1142 , the stream error is still consumed silently, but this change returns finish reason which is required for the last streaming chunk