### PR TITLE
prompt_tokens support in message [anthropic vertex ai]

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -832,6 +832,10 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
 
   if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
     streamState.model = parsedChunk?.message?.model ?? '';
+
+    streamState.usage = {
+      prompt_tokens: parsedChunk.message.usage?.input_tokens,
+    };
     return (
       `data: ${JSON.stringify({
         id: fallbackId,
@@ -850,7 +854,7 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
           },
         ],
         usage: {
-          prompt_tokens: parsedChunk.message?.usage?.input_tokens,
+          prompt_tokens: streamState.usage.prompt_tokens,
         },
       })}` + '\n\n'
     );
@@ -873,6 +877,10 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
         ],
         usage: {
           completion_tokens: parsedChunk.usage?.output_tokens,
+          prompt_tokens: streamState.usage?.prompt_tokens,
+          total_tokens:
+            (streamState.usage?.prompt_tokens || 0) +
+            (parsedChunk.usage?.output_tokens || 0),
         },
       })}` + '\n\n'
     );


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->
This PR improves token usage tracking in Google Vertex AI streaming responses by storing prompt token information in the stream state and including token usage metrics in response chunks
## Motivation
<!-- Provide a brief motivation of why the changes in this PR are needed -->
The current implementation doesn't properly maintain token usage information across streaming chunks, which leads  missing token metrics in the chunk response. This change ensures that prompt tokens are properly stored in the stream state and that total token counts are accurately calculated and included in the response
## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->

Before vs after

```
{
  id: 'vertex-ai-1751013934585',
  object: 'chat.completion.chunk',
  created: 1751013934,
  model: 'claude-3-7-sonnet-20250219',
  provider: 'vertex-ai',
  choices: [ { index: 0, delta: {}, finish_reason: 'end_turn' } ],
  usage: { completion_tokens: 29 }
}
```

```
{
  id: 'vertex-ai-1751013762551',
  object: 'chat.completion.chunk',
  created: 1751013762,
  model: 'claude-3-7-sonnet-20250219',
  provider: 'vertex-ai',
  choices: [ { index: 0, delta: {}, finish_reason: 'end_turn' } ],
  usage: { completion_tokens: 39, prompt_tokens: 9, total_tokens: 48 }
}
```