### PR TITLE
Fix: Redis Service Allows Unauthorized Privilege Escalation in docker-compose.yaml

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,6 +1,8 @@
 version: '3'
 services:
   web:
+    security_opt:
+      - "no-new-privileges:true"
     ports:
       - "8787:8787"
     image: "portkeyai/gateway:latest"


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** Service 'web' allows for privilege escalation via setuid or setgid binaries. Add 'no-new-privileges:true' in 'security_opt' to prevent this.
- **Rule ID:** yaml.docker-compose.security.no-new-privileges.no-new-privileges
- **Severity:** HIGH
- **File:** docker-compose.yaml
- **Lines Affected:** 3 - 3

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `docker-compose.yaml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.