### PR TITLE
Fix: Container Missing Security Settings Allowing Privilege Escalation in deployment.yaml

### DIFF
--- a/deployment.yaml
+++ b/deployment.yaml
@@ -28,6 +28,8 @@ spec:
     spec:
       containers:
       - image: portkeyai/gateway
+        securityContext:
+          allowPrivilegeEscalation: false
         imagePullPolicy: IfNotPresent
         name: portkeyai
         ports:


### PR DESCRIPTION
**Context and Purpose:**

This PR automatically remediates a security vulnerability:
- **Description:** In Kubernetes, each pod runs in its own isolated environment with its own set of security policies. However, certain container images may contain `setuid` or `setgid` binaries that could allow an attacker to perform privilege escalation and gain access to sensitive resources. To mitigate this risk, it's recommended to add a `securityContext` to the container in the pod, with the parameter `allowPrivilegeEscalation` set to `false`. This will prevent the container from running any privileged processes and limit the impact of any potential attacks. By adding a `securityContext` to your Kubernetes pod, you can help to ensure that your containerized applications are more secure and less vulnerable to privilege escalation attacks.
- **Rule ID:** yaml.kubernetes.security.allow-privilege-escalation-no-securitycontext.allow-privilege-escalation-no-securitycontext
- **Severity:** MEDIUM
- **File:** deployment.yaml
- **Lines Affected:** 32 - 32

This change is necessary to protect the application from potential security risks associated with this vulnerability.

**Solution Implemented:**

The automated remediation process has applied the necessary changes to the affected code in `deployment.yaml` to resolve the identified issue.

Please review the changes to ensure they are correct and integrate as expected.