### PR TITLE
fix: correct plugin id capitalization in manifest.json

### DIFF
--- a/plugins/default/manifest.json
+++ b/plugins/default/manifest.json
@@ -596,7 +596,7 @@
     },
     {
       "name": "Allowed Models",
-      "id": "modelwhitelist",
+      "id": "modelWhitelist",
       "type": "guardrail",
       "supportedHooks": ["beforeRequestHook"],
       "description": [


### PR DESCRIPTION
## Description
<!-- Provide a brief description of the changes in this PR -->

## Motivation
<!-- Provide a brief motivation of why the changes in this PR are needed -->

Resolve `modelWhitelist` module not found in case-sensitive environments.

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
