### PR TITLE
[bug] clean up resources during unhandled rejections from inside stream transforms

### DIFF
--- a/src/handlers/streamHandler.ts
+++ b/src/handlers/streamHandler.ts
@@ -310,31 +310,41 @@ export function handleStreamingMode(
 
   if (proxyProvider === BEDROCK) {
     (async () => {
-      for await (const chunk of readAWSStream(
-        reader,
-        responseTransformer,
-        fallbackChunkId,
-        strictOpenAiCompliance,
-        gatewayRequest
-      )) {
-        await writer.write(encoder.encode(chunk));
+      try {
+        for await (const chunk of readAWSStream(
+          reader,
+          responseTransformer,
+          fallbackChunkId,
+          strictOpenAiCompliance,
+          gatewayRequest
+        )) {
+          await writer.write(encoder.encode(chunk));
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        writer.close();
       }
-      writer.close();
     })();
   } else {
     (async () => {
-      for await (const chunk of readStream(
-        reader,
-        splitPattern,
-        responseTransformer,
-        isSleepTimeRequired,
-        fallbackChunkId,
-        strictOpenAiCompliance,
-        gatewayRequest
-      )) {
-        await writer.write(encoder.encode(chunk));
+      try {
+        for await (const chunk of readStream(
+          reader,
+          splitPattern,
+          responseTransformer,
+          isSleepTimeRequired,
+          fallbackChunkId,
+          strictOpenAiCompliance,
+          gatewayRequest
+        )) {
+          await writer.write(encoder.encode(chunk));
+        }
+      } catch (error) {
+        console.error(error);
+      } finally {
+        writer.close();
       }
-      writer.close();
     })();
   }
 


### PR DESCRIPTION
this fixes #1206 

to test, I simply modified the code inside a stream transform to throw an error
```js
export const AnthropicChatCompleteStreamChunkTransform: (
  response: string,
  fallbackId: string,
  streamState: AnthropicStreamState,
  _strictOpenAiCompliance: boolean
) => string | undefined = (
  responseChunk,
  fallbackId,
  streamState,
  strictOpenAiCompliance
) => {
  throw new Error("unhandled error");
  let chunk = responseChunk.trim();
  if (
    chunk.startsWith('event: ping') ||
    chunk.startsWith('event: content_block_stop')
  ) {
    return;
```