### PR TITLE
fix tokens calculation for bedrock models when cache tokens are present

### DIFF
--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -669,9 +669,9 @@ export const BedrockChatCompleteStreamChunkTransform: (
 
   // final chunk
   if (parsedChunk.usage) {
-    const shouldSendCacheUsage =
-      parsedChunk.usage.cacheWriteInputTokens ||
-      parsedChunk.usage.cacheReadInputTokens;
+    const cacheReadInputTokens = parsedChunk.usage?.cacheReadInputTokens || 0;
+    const cacheWriteInputTokens = parsedChunk.usage?.cacheWriteInputTokens || 0;
+
     return [
       `data: ${JSON.stringify({
         id: fallbackId,
@@ -690,10 +690,13 @@ export const BedrockChatCompleteStreamChunkTransform: (
           },
         ],
         usage: {
-          prompt_tokens: parsedChunk.usage.inputTokens,
+          prompt_tokens:
+            parsedChunk.usage.inputTokens +
+            cacheReadInputTokens +
+            cacheWriteInputTokens,
           completion_tokens: parsedChunk.usage.outputTokens,
           total_tokens: parsedChunk.usage.totalTokens,
-          ...(shouldSendCacheUsage && {
+          ...((cacheReadInputTokens > 0 || cacheWriteInputTokens > 0) && {
             cache_read_input_tokens: parsedChunk.usage.cacheReadInputTokens,
             cache_creation_input_tokens:
               parsedChunk.usage.cacheWriteInputTokens,

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -696,6 +696,10 @@ export const BedrockChatCompleteStreamChunkTransform: (
             cacheWriteInputTokens,
           completion_tokens: parsedChunk.usage.outputTokens,
           total_tokens: parsedChunk.usage.totalTokens,
+          prompt_tokens_details: {
+            cached_tokens: cacheReadInputTokens,
+          },
+          // we only want to be sending this for anthropic models and this is not openai compliant
           ...((cacheReadInputTokens > 0 || cacheWriteInputTokens > 0) && {
             cache_read_input_tokens: parsedChunk.usage.cacheReadInputTokens,
             cache_creation_input_tokens:

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -529,8 +529,8 @@ export const BedrockChatCompleteResponseTransform: (
   }
 
   if ('output' in response) {
-    const cacheReadInputTokens = response.usage.cacheReadInputTokens || 0;
-    const cacheWriteInputTokens = response.usage.cacheWriteInputTokens || 0;
+    const cacheReadInputTokens = response.usage?.cacheReadInputTokens || 0;
+    const cacheWriteInputTokens = response.usage?.cacheWriteInputTokens || 0;
 
     let content: string = '';
     content = response.output.message.content
@@ -574,7 +574,7 @@ export const BedrockChatCompleteResponseTransform: (
           cached_tokens: cacheReadInputTokens,
         },
         // we only want to be sending this for anthropic models and this is not openai compliant
-        ...((cacheReadInputTokens || cacheWriteInputTokens) && {
+        ...((cacheReadInputTokens > 0 || cacheWriteInputTokens > 0) && {
           cache_read_input_tokens: cacheReadInputTokens,
           cache_creation_input_tokens: cacheWriteInputTokens,
         }),

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -154,6 +154,16 @@ export interface CResponse extends BaseResponse {
     prompt_tokens: number;
     completion_tokens: number;
     total_tokens: number;
+    completion_tokens_details?: {
+      accepted_prediction_tokens?: number;
+      audio_tokens?: number;
+      reasoning_tokens?: number;
+      rejected_prediction_tokens?: number;
+    };
+    prompt_tokens_details?: {
+      audio_tokens?: number;
+      cached_tokens?: number;
+    };
     /*
      * Anthropic Prompt cache token usage
      */


### PR DESCRIPTION
#1210 

Here is an example usage object from bedrock (anthropic model) when cache control is used
```json
"usage": {
  "prompt_tokens": 368,
  "completion_tokens": 19,
  "total_tokens": 10923,
  "cache_read_input_tokens": 10536,
  "cache_creation_input_tokens": 0
}
```

untransformed
```json
            "usage": {
                "cacheReadInputTokenCount": 10536,
                "cacheReadInputTokens": 10536,
                "cacheWriteInputTokenCount": 0,
                "cacheWriteInputTokens": 0,
                "inputTokens": 368,
                "outputTokens": 19,
                "totalTokens": 10923
            }
```

openai sends all the input tokens together in `prompt_tokens`, so the current implementation is not compliant and could cause problems with cost calculation

reference:
https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_TokenUsage.html
https://platform.openai.com/docs/api-reference/chat/object