### PR TITLE
Fix/cohere embed handle null encoding format

### DIFF
--- a/src/providers/bedrock/embed.ts
+++ b/src/providers/bedrock/embed.ts
@@ -115,9 +115,10 @@ export const BedrockTitanEmbedConfig: ProviderConfig = {
   encoding_format: {
     param: 'embeddingTypes',
     required: false,
-    transform: (params: any): string[] => {
+    transform: (params: any): string[] | undefined => {
       if (Array.isArray(params.encoding_format)) return params.encoding_format;
-      return [params.encoding_format];
+      else if (typeof params.encoding_format === 'string')
+        return [params.encoding_format];
     },
   },
   // Titan specific parameters

--- a/src/providers/bedrock/embed.ts
+++ b/src/providers/bedrock/embed.ts
@@ -52,9 +52,10 @@ export const BedrockCohereEmbedConfig: ProviderConfig = {
   encoding_format: {
     param: 'embedding_types',
     required: false,
-    transform: (params: any): string[] => {
+    transform: (params: any): string[] | undefined => {
       if (Array.isArray(params.encoding_format)) return params.encoding_format;
-      return [params.encoding_format];
+      else if (typeof params.encoding_format === 'string')
+        return [params.encoding_format];
     },
   },
 };

--- a/src/providers/cohere/embed.ts
+++ b/src/providers/cohere/embed.ts
@@ -50,9 +50,10 @@ export const CohereEmbedConfig: ProviderConfig = {
   encoding_format: {
     param: 'embedding_types',
     required: false,
-    transform: (params: any): string[] => {
+    transform: (params: any): string[] | undefined => {
       if (Array.isArray(params.encoding_format)) return params.encoding_format;
-      return [params.encoding_format];
+      else if (typeof params.encoding_format === 'string')
+        return [params.encoding_format];
     },
   },
   //backwards compatibility


### PR DESCRIPTION
#1212 

Testing done:
- [x] made requests to cohere embeddings with the following values for encoding_format
  - [x] null
  - [x] no param
  - [x] "float" 