### PR TITLE
Feat/prompt guardrail

### DIFF
--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -17,6 +17,7 @@ import { handler as portkeymoderateContent } from './portkey/moderateContent';
 import { handler as portkeylanguage } from './portkey/language';
 import { handler as portkeypii } from './portkey/pii';
 import { handler as portkeygibberish } from './portkey/gibberish';
+import { handler as portkeyprompt } from './portkey/prompt';
 import { handler as aporiavalidateProject } from './aporia/validateProject';
 import { handler as sydelabssydeguard } from './sydelabs/sydeguard';
 import { handler as pillarscanPrompt } from './pillar/scanPrompt';
@@ -75,6 +76,7 @@ export const plugins = {
     language: portkeylanguage,
     pii: portkeypii,
     gibberish: portkeygibberish,
+    prompt: portkeyprompt,
   },
   aporia: {
     validateProject: aporiavalidateProject,

--- a/plugins/portkey/manifest.json
+++ b/plugins/portkey/manifest.json
@@ -323,6 +323,71 @@
           }
         }
       }
+    },
+    {
+      "name": "Prompt Guardrail",
+      "id": "prompt",
+      "type": "guardrail",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Runs a prompt and returns the verdict based on the response."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "promptId": {
+            "type": "string",
+            "label": "Prompt ID",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "The ID of the prompt to run."
+              }
+            ],
+            "required": true
+          },
+          "verdictType": {
+            "type": "string",
+            "label": "Verdict Type",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "The type of verdict to return."
+              }
+            ],
+            "enum": ["boolean", "choice", "jsonMatch", "score", "regex"],
+            "enumNames": ["Boolean", "Choice", "JSON Match", "Score", "Regex"],
+            "default": "boolean"
+          },
+          "expectedResult": {
+            "type": "string",
+            "label": "Verdict",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "The verdict to return."
+              }
+            ],
+            "enum": ["true", "false"],
+            "enumNames": ["True", "False"],
+            "default": "true"
+          },
+          "not": {
+            "type": "boolean",
+            "label": "Invert Result",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "If true, the verdict will be inverted"
+              }
+            ],
+            "default": false
+          }
+        }
+      }
     }
   ]
 }

--- a/plugins/portkey/manifest.json
+++ b/plugins/portkey/manifest.json
@@ -370,10 +370,7 @@
                 "type": "subHeading",
                 "text": "The verdict to return."
               }
-            ],
-            "enum": ["true", "false"],
-            "enumNames": ["True", "False"],
-            "default": "true"
+            ]
           },
           "not": {
             "type": "boolean",
@@ -386,7 +383,8 @@
             ],
             "default": false
           }
-        }
+        },
+        "required": ["promptId", "verdictType", "expectedResult"]
       }
     }
   ]

--- a/plugins/portkey/prompt.ts
+++ b/plugins/portkey/prompt.ts
@@ -1,0 +1,238 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { getText } from '../utils';
+import { PORTKEY_ENDPOINTS, fetchPortkey } from './globals';
+
+interface BooleanExpectedResult {
+  type: 'boolean';
+  booleanResult: boolean;
+}
+
+interface ChoiceExpectedResult {
+  type: 'choice';
+  choices: string[] | string;
+  caseSensitive?: boolean; // Default: false
+}
+
+interface JsonMatchExpectedResult {
+  type: 'jsonMatch';
+  jsonMatch: Record<string, string | string[]>; // dot notation keys and expected string values or array of choices
+  // Customizations for string matching within each key
+  caseSensitive?: boolean; // Whether to match case exactly for all keys
+  // JSON structure options
+  maxDepth?: number; // How deep to traverse JSON structure
+  requiredKeys?: string[]; // Keys that must be present
+  optionalKeys?: string[]; // Keys that are optional
+  allowExtraKeys?: boolean; // Whether to allow extra keys, default: true
+}
+
+interface ScoreExpectedResult {
+  type: 'score';
+  score: number;
+  // Customizations
+  minScore?: number; // Minimum acceptable score
+  maxScore?: number; // Maximum acceptable score
+  precision?: number; // Number of decimal places to consider
+  comparison?:
+    | 'equals'
+    | 'greaterThan'
+    | 'lessThan'
+    | 'greaterThanOrEqual'
+    | 'lessThanOrEqual';
+  normalized?: boolean; // Whether score is normalized to 0-1 range
+  tolerance?: number; // Acceptable deviation from target score
+}
+
+interface RegexExpectedResult {
+  type: 'regex';
+  regex: string | string[];
+  // Customizations
+  flags?: string; // Regex flags (i, m, g, etc.)
+  matchStrategy?: 'any' | 'all'; // Whether ANY or ALL patterns must match
+  caseInsensitive?: boolean; // Case insensitive matching (alternative to flags)
+}
+
+type ExpectedResult =
+  | BooleanExpectedResult
+  | ChoiceExpectedResult
+  | JsonMatchExpectedResult
+  | ScoreExpectedResult
+  | RegexExpectedResult;
+
+type VerdictCheckResult = {
+  verdict: boolean;
+  data?: any;
+  error?: Error;
+};
+
+class VerdictChecker {
+  private completionText: string;
+  private expectedResult: ExpectedResult;
+  private type: string;
+
+  constructor(
+    completionText: string,
+    expectedResult: ExpectedResult,
+    type: string
+  ) {
+    this.completionText = completionText;
+    this.expectedResult = expectedResult;
+    this.type = type;
+  }
+
+  check(): VerdictCheckResult {
+    switch (this.type) {
+      case 'boolean':
+        const booleanResult = this.boolean();
+        return {
+          verdict: booleanResult,
+          data: {
+            explanation: booleanResult
+              ? 'The completion text matches the expected result.'
+              : 'The completion text does not match the expected result.',
+            expectedResult: this.expectedResult,
+          },
+        };
+      case 'choice':
+        return this.choices();
+      case 'jsonMatch':
+        return this.jsonMatch();
+      case 'score':
+        return this.score();
+      case 'regex':
+        return this.regex();
+    }
+  }
+
+  boolean() {
+    this.expectedResult = this.expectedResult as BooleanExpectedResult;
+    return this.completionText === this.expectedResult.booleanResult.toString();
+  }
+
+  choices() {
+    this.expectedResult = this.expectedResult as ChoiceExpectedResult;
+    let choices = Array.isArray(this.expectedResult.choices)
+      ? this.expectedResult.choices
+      : [this.expectedResult.choices];
+    if (!this.expectedResult.caseSensitive) {
+      choices = choices.map((choice) => choice.toLowerCase());
+      this.completionText = this.completionText.toLowerCase();
+    }
+    return choices.includes(this.completionText);
+  }
+
+  jsonMatch() {
+    this.expectedResult = this.expectedResult as JsonMatchExpectedResult;
+    const jsonMatch = JSON.parse(this.completionText);
+    const keys = Object.keys(this.expectedResult.jsonMatch);
+    for (const key of keys) {
+      const expectedValue = this.expectedResult.jsonMatch[key];
+    }
+  }
+}
+
+const getPromptCompletion = async (
+  promptId: string,
+  variables: Record<string, string>
+) => {
+  const response = await fetch(
+    `${process.env.PORTKEY_API_URL}/prompts/${promptId}/complete`,
+    {
+      method: 'POST',
+      body: JSON.stringify({ variables }),
+    }
+  );
+  return response.json();
+};
+
+const checkJsonMatchVerdict = (
+  completionText: string,
+  expectedResult: JsonMatchExpectedResult
+) => {};
+
+const findVerdict = async (
+  completion: any,
+  verdictKind: string,
+  expectedResult: any
+) => {
+  const completionText = completion.choices[0].message.content;
+  switch (verdictKind) {
+    case 'boolean':
+      return completionText === expectedResult.booleanResult.toString();
+    case 'choice':
+      return completionText === expectedResult.choice;
+    case 'jsonMatch':
+  }
+};
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType,
+  options
+) => {
+  let error = null;
+  let verdict = false;
+  let data: any = null;
+
+  try {
+    const text = getText(context, eventType);
+    const categories = parameters.categories;
+    const not = parameters.not || false;
+
+    const result: any = await fetchPortkey(
+      options?.env || {},
+      PORTKEY_ENDPOINTS.MODERATIONS,
+      parameters.credentials,
+      { input: text },
+      parameters.timeout
+    );
+
+    const categoriesFlagged = Object.keys(result.results[0].categories).filter(
+      (category) => result.results[0].categories[category]
+    );
+
+    const intersection = categoriesFlagged.filter((category) =>
+      categories.includes(category)
+    );
+
+    const hasRestrictedContent = intersection.length > 0;
+    verdict = not ? hasRestrictedContent : !hasRestrictedContent;
+
+    data = {
+      verdict,
+      not,
+      explanation: verdict
+        ? not
+          ? 'Found restricted content categories as expected.'
+          : 'No restricted content categories were found.'
+        : not
+          ? 'No restricted content categories were found when they should have been.'
+          : `Found restricted content categories: ${intersection.join(', ')}`,
+      flaggedCategories: intersection,
+      restrictedCategories: categories,
+      allFlaggedCategories: categoriesFlagged,
+      moderationResults: result.results[0],
+      textExcerpt: text.length > 100 ? text.slice(0, 100) + '...' : text,
+    };
+  } catch (e) {
+    error = e as Error;
+    const text = getText(context, eventType);
+    data = {
+      explanation: `An error occurred during content moderation: ${error.message}`,
+      not: parameters.not || false,
+      restrictedCategories: parameters.categories || [],
+      textExcerpt: text
+        ? text.length > 100
+          ? text.slice(0, 100) + '...'
+          : text
+        : 'No text available',
+    };
+  }
+
+  return { error, verdict, data };
+};


### PR DESCRIPTION
## Description
Enhanced the Portkey prompt plugin with comprehensive type definitions for expected results and implemented a robust verdict checking system. Currently support boolean prompts only with support for choices, json matching and more coming soon.

## Motivation
This plugin provides a structured approach to handle different types of expected results from prompt completions, making it easier to validate AI responses against predefined criteria. The comprehensive type system and verdict checking capabilities make the plugin flexible and maintainable for various use cases.

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
N/A
