### PR TITLE
fix: handle provider error logs addition

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -790,53 +790,35 @@ export async function tryTargetsRecursively(
         // tryPost always returns a Response.
         // TypeError will check for all unhandled exceptions.
         // GatewayError will check for all handled exceptions which cannot allow the request to proceed.
-        if (
-          error instanceof TypeError ||
-          error instanceof GatewayError ||
-          !error.response ||
-          (error.response && !(error.response instanceof Response))
-        ) {
-          console.error(
-            'tryTargetsRecursively error: ',
-            error.message,
-            error.cause,
-            error.stack
-          );
-          const errorMessage =
-            error instanceof GatewayError
-              ? error.message
-              : 'Something went wrong';
-          response = new Response(
-            JSON.stringify({
-              status: 'failure',
-              message: errorMessage,
-            }),
-            {
-              status: 500,
-              headers: {
-                'content-type': 'application/json',
-                // Add this header so that the fallback loop can be interrupted if its an exception.
-                'x-portkey-gateway-exception': 'true',
-              },
-            }
-          );
-        } else {
-          response = error.response;
-          if (isHandlingCircuitBreaker) {
-            await c.get('recordCircuitBreakerFailure')?.(
-              env(c),
-              currentInheritedConfig.id,
-              currentTarget.cbConfig,
-              currentJsonPath,
-              response.status
-            );
+        console.error(
+          'tryTargetsRecursively error: ',
+          error.message,
+          error.cause,
+          error.stack
+        );
+        const errorMessage =
+          error instanceof GatewayError
+            ? error.message
+            : 'Something went wrong';
+        response = new Response(
+          JSON.stringify({
+            status: 'failure',
+            message: errorMessage,
+          }),
+          {
+            status: 500,
+            headers: {
+              'content-type': 'application/json',
+              // Add this header so that the fallback loop can be interrupted if its an exception.
+              'x-portkey-gateway-exception': 'true',
+            },
           }
-        }
+        );
       }
       break;
   }
 
-  return response;
+  return response!;
 }
 
 export function constructConfigFromRequestHeaders(

--- a/src/handlers/services/responseService.ts
+++ b/src/handlers/services/responseService.ts
@@ -62,13 +62,6 @@ export class ResponseService {
 
     this.updateHeaders(finalMappedResponse, cache.cacheStatus, retryAttempt);
 
-    if (!finalMappedResponse.ok) {
-      const errorObj: any = new Error(await finalMappedResponse.clone().text());
-      errorObj.status = finalMappedResponse.status;
-      errorObj.response = finalMappedResponse;
-      throw errorObj;
-    }
-
     return {
       response: finalMappedResponse,
       responseJson,


### PR DESCRIPTION
## Description
logObject.log() method is not getting called for error responses because responseService.create() throws an error with response details for all non-2xx LLM error responses. This causes issues with keeping track of logObjects of failed requests. 

It is redundant to throw the error from responseService, because it is simply getting caught and then the same value is used in the final response object of tryTargetsRecursively function. 

With this change, tryTargetsRecursively catch block should only be used when there is an actual gateway exception. For all provider non-2xx responses, they will be treated as a valid response. 


## Motivation
Fix on top of #1121

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
