### PR TITLE
fix: apply override_params to FormData request bodies

### DIFF
--- a/src/services/transformToProviderRequest.ts
+++ b/src/services/transformToProviderRequest.ts
@@ -232,7 +232,25 @@ export const transformToProviderRequest = (
       fn
     );
   }
-  if (requestBody instanceof FormData || requestBody instanceof ArrayBuffer)
+
+  if (requestBody instanceof FormData) {
+    if (typeof providerOptions.overrideParams === 'undefined') {
+      return requestBody;
+    }
+
+    for (const [k, v] of Object.entries(providerOptions.overrideParams)) {
+      requestBody.delete(k); // If the key already exists, delete it first so we always overwrite.
+
+      // Value can be string, Blob, File, or an array of those.
+      const values = Array.isArray(v) ? v : [v];
+      for (const val of values) {
+        requestBody.append(k, val);
+      }
+    }
+
+    return requestBody;
+
+  } else if (requestBody instanceof ArrayBuffer)
     return requestBody;
 
   if (fn === 'proxy') {


### PR DESCRIPTION
## Description
Transform the javascript FormData object based on the supplied override_params. Modified transformToProviderRequest.ts on line 235:
```
  if (requestBody instanceof FormData) {
    if (typeof providerOptions.overrideParams === 'undefined') {
      return requestBody;
    }

    for (const [k, v] of Object.entries(providerOptions.overrideParams)) {
      requestBody.delete(k); // If the key already exists, delete it first so we always overwrite.

      // Value can be string, Blob, File, or an array of those.
      const values = Array.isArray(v) ? v : [v];
      for (const val of values) {
        requestBody.append(k, val);
      }
    }

    return requestBody;

  }
```



## Motivation
Currently `portkey.audio.transcriptions.create` does not respect the `override_params` of the gateway config object. For example, if we change the model name in `override_params`, we would expect it to use the model name as specified in the config object. However, this values in the config object are ignored.

If override_params cannot modify the model name on the gateway, then the gateway features are essentially useless. You won't be able to do any sort of meaningful fallback nor loadbalancing, because each provider has their own model name. 

The source of the problem lies in transformToProviderRequest.ts on line 235. If body is FormData, then override parameters are not applied and instead the function returns early with the requestBody unmodified:
```
if (requestBody instanceof FormData || requestBody instanceof ArrayBuffer)
    return requestBody;
```

At first glance this makes sense because you cannot apply a simple spread operator to FormData nor ArrayBuffer, so we just ignore the override_params and return early.


However, the more elegant solution is to transform the javascript FormData object based on the override_params. Since requestBody is **already** a JavaScript FormData object, the computational cost of overriding the keys is **negligible**. This is in keeping with the spirit of the gateway's lightweight nature:

```
  for (const [k, v] of Object.entries(providerOptions.overrideParams)) {
      requestBody.delete(k); // If the key already exists, delete it first so we always overwrite.

      // Value can be string, Blob, File, or an array of those.
      const values = Array.isArray(v) ? v : [v];
      for (const val of values) {
        requestBody.append(k, val);
      }
    }
```

This pull request is to fix the issue as outlined in [https://github.com/Portkey-AI/gateway/issues/1217](https://github.com/Portkey-AI/gateway/issues/1217)




## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
