### PR TITLE
chore: remove response text check from hooks middleware for output ho…

### DIFF
--- a/src/middlewares/hooks/index.ts
+++ b/src/middlewares/hooks/index.ts
@@ -429,9 +429,6 @@ export class HooksManager {
       (context.requestType === 'embed' && hook.type === HookType.MUTATOR) ||
       (hook.eventType === 'afterRequestHook' &&
         context.response.statusCode !== 200) ||
-      (hook.eventType === 'afterRequestHook' &&
-        context.request.isStreamingRequest &&
-        !context.response.text) ||
       (hook.eventType === 'beforeRequestHook' &&
         span.getParentHookSpanId() !== null) ||
       (hook.type === HookType.MUTATOR && !!hook.async)


### PR DESCRIPTION
…oks and let individual plugin handle it

## Description
All the individual plugin should make the content checks based on their requirements. All the existing plugins already check if the text exists or not. 

Having this check causes issues where user might want to have a webhook plugin executed at the end but the response content is empty. Example: Anthropic returns empty content ("") for some responses with tool calls assistant message.

Example:
```json
{
    "id": "<>",
    "object": "chat.completion.chunk",
    "created": <>,
    "choices": [
      {
        "index": 0,
        "finish_reason": "tool_use",
        "message": {
          "role": "assistant",
          "content": "",
          "tool_calls": [
            {
              "id": "<>",
              "type": "function",
              "function": {
                "name": "sample_name",
                "arguments": "sample_arguments"
              }
            }
          ]
        }
      }
    ],
    "model": "claude-sonnet-4-20250514",
    "usage": {
      "completion_tokens": 1,
      "cache_read_input_tokens": 0,
      "cache_creation_input_tokens": 1,
      "prompt_tokens": 1
      "total_tokens": 12
    }
  }
```

## Motivation
<!-- Provide a brief motivation of why the changes in this PR are needed -->

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
