### PR TITLE
fix: remove headers from webhook plugin response object

### DIFF
--- a/plugins/default/webhook.ts
+++ b/plugins/default/webhook.ts
@@ -106,7 +106,6 @@ export const handler: PluginHandler = async (
       webhookUrl: url,
       responseData: response.data,
       requestContext: {
-        headers,
         timeout: parameters.timeout || 3000,
       },
     };
@@ -123,7 +122,6 @@ export const handler: PluginHandler = async (
       explanation: `Webhook error: ${e.message}`,
       webhookUrl: parameters.webhookURL || 'No URL provided',
       requestContext: {
-        headers: parameters.headers || {},
         timeout: parameters.timeout || 3000,
       },
       // return response body if it's not a ok response and not a timeout error


### PR DESCRIPTION
## Description
Headers might contain sensitive data so it should not be returned in the response object. And its also redundant to return them in guardrails response. 

## Motivation
<!-- Provide a brief motivation of why the changes in this PR are needed -->

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
