### PR TITLE
fix: assumed role flow for bedrock inference profile base model fetch

### DIFF
--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -433,16 +433,11 @@ export const getInferenceProfile = async (
   c: Context
 ) => {
   if (providerOptions.awsAuthType === 'assumedRole') {
-    const { accessKeyId, secretAccessKey, sessionToken } =
-      (await getAssumedRoleCredentials(
-        c,
-        providerOptions.awsRoleArn || '',
-        providerOptions.awsExternalId || '',
-        providerOptions.awsRegion || ''
-      )) || {};
-    providerOptions.awsAccessKeyId = accessKeyId;
-    providerOptions.awsSecretAccessKey = secretAccessKey;
-    providerOptions.awsSessionToken = sessionToken;
+    try {
+      await providerAssumedRoleCredentials(c, providerOptions);
+    } catch (e) {
+      console.error('getInferenceProfile Error while assuming bedrock role', e);
+    }
   }
 
   const awsRegion = providerOptions.awsRegion || 'us-east-1';


### PR DESCRIPTION
## Description
Gateway uses 2-step assume role flow for bedrock inference calls. The source credentials are first used to assume the source role which is then used to assume the final bedrock role.
But the getInferenceProfile profile does not follow this and directly tries to assume the final role which would result in failure.

Correct flow
https://github.com/Portkey-AI/gateway/blob/8051db4e7ab075e7920e34cd8b7ba770375c3c3f/src/providers/bedrock/api.ts#L159-L161

getInferenceProfile flow (Failing)
https://github.com/Portkey-AI/gateway/blob/8051db4e7ab075e7920e34cd8b7ba770375c3c3f/src/providers/bedrock/utils.ts#L435-L446

## Motivation
<!-- Provide a brief motivation of why the changes in this PR are needed -->

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
