### PR TITLE
fix: mistral-ai /chat/completitions missing "usage" in stream response

### DIFF
--- a/src/providers/mistral-ai/chatComplete.ts
+++ b/src/providers/mistral-ai/chatComplete.ts
@@ -143,6 +143,11 @@ interface MistralAIStreamChunk {
     index: number;
     finish_reason: string | null;
   }[];
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
 }
 
 export const MistralAIChatCompleteResponseTransform: (
@@ -212,6 +217,7 @@ export const MistralAIChatCompleteStreamChunkTransform: (
           finish_reason: parsedChunk.choices[0].finish_reason,
         },
       ],
+      ...(parsedChunk.usage ? { usage: parsedChunk.usage } : {}),
     })}` + '\n\n'
   );
 };


### PR DESCRIPTION
## Description
This PR fixes the https://github.com/Portkey-AI/gateway/issues/1259 and enable the gateway to return "usage" object in chunks while stream is enabled for mistral-ai.

## Motivation


## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

Response before change:

```
data: {"id":"7e37a1f7be8448feb47f896daacac26a","object":"chat.completion.chunk","created":1754040410,"model":"mistral-medium","provider":"mistral-ai","choices":[{"index":0,"delta":{"content":"3."},"finish_reason":null}]}

data: {"id":"7e37a1f7be8448feb47f896daacac26a","object":"chat.completion.chunk","created":1754040410,"model":"mistral-medium","provider":"mistral-ai","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}]}

data: [DONE]
```

Response after change:

```
data: {"id":"22060c7debab4abfa85d8acfd8ae15b5","object":"chat.completion.chunk","created":1754040277,"model":"mistral-medium","provider":"mistral-ai","choices":[{"index":0,"delta":{"content":"3."},"finish_reason":null}]}

data: {"id":"22060c7debab4abfa85d8acfd8ae15b5","object":"chat.completion.chunk","created":1754040277,"model":"mistral-medium","provider":"mistral-ai","choices":[{"index":0,"delta":{"content":""},"finish_reason":"stop"}],"usage":{"prompt_tokens":7,"total_tokens":22,"completion_tokens":15}}

data: [DONE]
```

## Screenshots (if applicable)

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues
Fixes https://github.com/Portkey-AI/gateway/issues/1259 
