### PR TITLE
support api key for bedrock

### DIFF
--- a/src/providers/bedrock/api.ts
+++ b/src/providers/bedrock/api.ts
@@ -80,7 +80,7 @@ const getService = (fn: endpointStrings) => {
     : 'bedrock';
 };
 
-const isBedrockApiKeyBasedAuth = (providerOptions: Options) => {
+const isBearerTokenBasedAuth = (providerOptions: Options) => {
   if (
     !providerOptions.awsAccessKeyId &&
     !(providerOptions.awsAuthType === 'assumedRole') &&
@@ -164,7 +164,7 @@ const BedrockAPIConfig: BedrockAPIConfigInterface = {
       delete headers['content-type'];
     }
 
-    if (isBedrockApiKeyBasedAuth(providerOptions)) {
+    if (isBearerTokenBasedAuth(providerOptions)) {
       headers['Authorization'] = `Bearer ${providerOptions.apiKey}`;
       return headers;
     }

--- a/src/providers/bedrock/api.ts
+++ b/src/providers/bedrock/api.ts
@@ -161,8 +161,9 @@ const BedrockAPIConfig: BedrockAPIConfigInterface = {
       await providerAssumedRoleCredentials(c, providerOptions);
     }
 
-    if (awsAuthType === 'assumedRole') {
-      await providerAssumedRoleCredentials(c, providerOptions);
+    if (awsAuthType === 'apiKey') {
+      headers['Authorization'] = `Bearer ${providerOptions.apiKey}`;
+      return headers;
     }
 
     let finalRequestBody = transformedRequestBody;

--- a/src/providers/bedrock/api.ts
+++ b/src/providers/bedrock/api.ts
@@ -80,6 +80,16 @@ const getService = (fn: endpointStrings) => {
     : 'bedrock';
 };
 
+const isBedrockApiKeyBasedAuth = (providerOptions: Options) => {
+  if (
+    !providerOptions.awsAccessKeyId &&
+    !(providerOptions.awsAuthType === 'assumedRole') &&
+    !providerOptions.awsSessionToken
+  )
+    return true;
+  return false;
+};
+
 const setRouteSpecificHeaders = (
   fn: string,
   headers: Record<string, string>,
@@ -152,6 +162,11 @@ const BedrockAPIConfig: BedrockAPIConfigInterface = {
 
     if (method === 'PUT' || method === 'GET') {
       delete headers['content-type'];
+    }
+
+    if (isBedrockApiKeyBasedAuth(providerOptions)) {
+      headers['Authorization'] = `Bearer ${providerOptions.apiKey}`;
+      return headers;
     }
 
     setRouteSpecificHeaders(fn, headers, providerOptions);

--- a/src/providers/bedrock/api.ts
+++ b/src/providers/bedrock/api.ts
@@ -84,7 +84,8 @@ const isBearerTokenBasedAuth = (providerOptions: Options) => {
   if (
     !providerOptions.awsAccessKeyId &&
     !(providerOptions.awsAuthType === 'assumedRole') &&
-    !providerOptions.awsSessionToken
+    !providerOptions.awsSessionToken &&
+    providerOptions.apiKey
   )
     return true;
   return false;


### PR DESCRIPTION
closes #1294 

Currently there are two types of supported authentication for bedrock in portkey
1. assumed role
2. api secret and key id

This PR adds support for Bearer token based auth

Testing done:
Tested with combinations of assumed role, api secret and Bearer
precedence is for assumed role and api secret as we dont want to disturb existing deployments