### PR TITLE
fix: portkey plugin response handling

### DIFF
--- a/plugins/portkey/gibberish.ts
+++ b/plugins/portkey/gibberish.ts
@@ -29,7 +29,7 @@ export const handler: PluginHandler = async (
     text = textArray.filter((text) => text).join('\n');
     const not = parameters.not || false;
 
-    const response: any = await fetchPortkey(
+    const { response }: any = await fetchPortkey(
       options?.env || {},
       PORTKEY_ENDPOINTS.GIBBERISH,
       parameters.credentials,

--- a/plugins/portkey/language.ts
+++ b/plugins/portkey/language.ts
@@ -30,7 +30,7 @@ export const handler: PluginHandler = async (
     const languages = parameters.language;
     const not = parameters.not || false;
 
-    const result: any = await fetchPortkey(
+    const { response: result }: any = await fetchPortkey(
       options?.env || {},
       PORTKEY_ENDPOINTS.LANGUAGE,
       parameters.credentials,

--- a/plugins/portkey/moderateContent.ts
+++ b/plugins/portkey/moderateContent.ts
@@ -30,7 +30,7 @@ export const handler: PluginHandler = async (
     const categories = parameters.categories;
     const not = parameters.not || false;
 
-    const result: any = await fetchPortkey(
+    const { response: result }: any = await fetchPortkey(
       options?.env || {},
       PORTKEY_ENDPOINTS.MODERATIONS,
       parameters.credentials,


### PR DESCRIPTION
## Description
fetchPortkey plugin function returns response and log. But the plugin code is assuming that only the response is been returned.

## Motivation
<!-- Provide a brief motivation of why the changes in this PR are needed -->

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
