### PR TITLE
fix: handle stream close failures

### DIFF
--- a/src/handlers/streamHandler.ts
+++ b/src/handlers/streamHandler.ts
@@ -321,9 +321,13 @@ export function handleStreamingMode(
           await writer.write(encoder.encode(chunk));
         }
       } catch (error) {
-        console.error(error);
+        console.error('Error during stream processing:', error);
       } finally {
-        writer.close();
+        try {
+          await writer.close();
+        } catch (closeError) {
+          console.error('Failed to close the writer:', closeError);
+        }
       }
     })();
   } else {
@@ -341,9 +345,13 @@ export function handleStreamingMode(
           await writer.write(encoder.encode(chunk));
         }
       } catch (error) {
-        console.error(error);
+        console.error('Error during stream processing:', error);
       } finally {
-        writer.close();
+        try {
+          await writer.close();
+        } catch (closeError) {
+          console.error('Failed to close the writer:', closeError);
+        }
       }
     })();
   }


### PR DESCRIPTION
## Description
Add a `try...catch` block around `writer.close()` within `handleStreamingMode` to prevent failures.

## Motivation
In streaming scenarios, if the user aborts the request, the process enters the first `catch` block due to a streaming write failure (`Response object has been garbage collected`). The `finally` block is then executed, which attempts to call `writer.close()`. This leads to a second error (`WritableStream is closed`) that is currently unhandled. On Node.js versions 15 and above, this `unhandled rejection` will cause the process to exit unexpectedly.

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
