### PR TITLE
feat/regex-replace-guardrail

### DIFF
--- a/plugins/default/regexReplace.ts
+++ b/plugins/default/regexReplace.ts
@@ -1,0 +1,92 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { getCurrentContentPart, setCurrentContentPart } from '../utils';
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let error = null;
+  let verdict = true;
+  let data: any = null;
+  const transformedData: Record<string, any> = {
+    request: {
+      json: null,
+    },
+    response: {
+      json: null,
+    },
+  };
+  let transformed = false;
+
+  try {
+    const regexPattern = parameters.rule;
+    const redactText = parameters.redactText || '[REDACTED]';
+    const failOnDetection = parameters.failOnDetection || false;
+
+    const { content, textArray } = getCurrentContentPart(context, eventType);
+
+    if (!regexPattern) {
+      throw new Error('Missing regex pattern');
+    }
+    if (!content) {
+      throw new Error('Missing text to match');
+    }
+
+    const regex = new RegExp(regexPattern, 'g');
+
+    // Process all text items in the array
+    let hasMatches = false;
+    const mappedTextArray: Array<string | null> = [];
+    textArray.forEach((text) => {
+      if (!text) {
+        mappedTextArray.push(null);
+        return;
+      }
+
+      // Reset regex for each text when using global flag
+      regex.lastIndex = 0;
+
+      const matches = text.match(regex);
+      if (matches && matches.length > 0) {
+        hasMatches = true;
+      }
+      const replacedText = text.replace(regex, redactText);
+      mappedTextArray.push(replacedText);
+    });
+
+    // Handle transformation
+    if (hasMatches) {
+      setCurrentContentPart(
+        context,
+        eventType,
+        transformedData,
+        mappedTextArray
+      );
+      transformed = true;
+    }
+    if (failOnDetection && hasMatches) {
+      verdict = false;
+    }
+    data = {
+      regexPattern,
+      verdict,
+      explanation: transformed
+        ? `Pattern '${regexPattern}' matched and was replaced with '${redactText}'`
+        : `The regex pattern '${regexPattern}' did not match any text.`,
+    };
+  } catch (e: any) {
+    error = e;
+    data = {
+      explanation: `An error occurred while processing the regex: ${e.message}`,
+      regexPattern: parameters.rule,
+    };
+  }
+
+  return { error, verdict, data, transformedData, transformed };
+};

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -50,6 +50,7 @@ import { handler as panwPrismaAirsintercept } from './panw-prisma-airs/intercept
 import { handler as defaultjwt } from './default/jwt';
 import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
 import { handler as walledaiguardrails } from './walledai/guardrails';
+import { handler as defaultregexReplace } from './default/regexReplace';
 
 export const plugins = {
   default: {
@@ -70,6 +71,7 @@ export const plugins = {
     modelWhitelist: defaultmodelWhitelist,
     jwt: defaultjwt,
     requiredMetadataKeys: defaultrequiredMetadataKeys,
+    regexReplace: defaultregexReplace,
   },
   portkey: {
     moderateContent: portkeymoderateContent,


### PR DESCRIPTION
## Description
This PR adds a new guardrail regex replace to portkey's default gurardrail

## Motivation
the ability to replace text while running a regex guardrail on both input and output

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [x] Unit Tests
- [x] Integration Tests
- [x] Manual Testing

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues
Fixes and Cloaes #1291