### PR TITLE
fix: remove the regex replace plugin with the correct regex function parsing

### DIFF
--- a/plugins/default/regexReplace.ts
+++ b/plugins/default/regexReplace.ts
@@ -6,6 +6,24 @@ import {
 } from '../types';
 import { getCurrentContentPart, setCurrentContentPart } from '../utils';
 
+function parseRegex(input: string): RegExp {
+  // Valid JavaScript regex flags
+  const validFlags = /^[gimsuyd]*$/;
+
+  const match = input.match(/^\/(.+?)\/([gimsuyd]*)$/);
+  if (match) {
+    const [, pattern, flags] = match;
+
+    if (flags && !validFlags.test(flags)) {
+      throw new Error(`Invalid regex flags: ${flags}`);
+    }
+
+    return new RegExp(pattern, flags);
+  }
+
+  return new RegExp(input);
+}
+
 export const handler: PluginHandler = async (
   context: PluginContext,
   parameters: PluginParameters,
@@ -38,7 +56,7 @@ export const handler: PluginHandler = async (
       throw new Error('Missing text to match');
     }
 
-    const regex = new RegExp(regexPattern);
+    const regex = parseRegex(regexPattern);
 
     // Process all text items in the array
     let hasMatches = false;

--- a/plugins/default/regexReplace.ts
+++ b/plugins/default/regexReplace.ts
@@ -38,7 +38,7 @@ export const handler: PluginHandler = async (
       throw new Error('Missing text to match');
     }
 
-    const regex = new RegExp(regexPattern, 'g');
+    const regex = new RegExp(regexPattern);
 
     // Process all text items in the array
     let hasMatches = false;


### PR DESCRIPTION
## Description
This PR fixed the regex replcae guardrail


## Motivation
the regex replace guardrail was adding a 'g' flag by itself that was causing the regex to fail OR not work in the desired way

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues

#1328 