### PR TITLE
unified route handler for image edits

### DIFF
--- a/src/handlers/imageEditsHandler.ts
+++ b/src/handlers/imageEditsHandler.ts
@@ -15,7 +15,7 @@ import { Context } from 'hono';
  */
 export async function imageEditsHandler(c: Context): Promise<Response> {
   try {
-    let request = await c.req.json();
+    let request = await c.req.raw.formData();
     let requestHeaders = Object.fromEntries(c.req.raw.headers);
     const camelCaseConfig = constructConfigFromRequestHeaders(requestHeaders);
 

--- a/src/handlers/imageEditsHandler.ts
+++ b/src/handlers/imageEditsHandler.ts
@@ -1,0 +1,55 @@
+import { RouterError } from '../errors/RouterError';
+import {
+  constructConfigFromRequestHeaders,
+  tryTargetsRecursively,
+} from './handlerUtils';
+import { Context } from 'hono';
+
+/**
+ * Handles the '/images/edits' API request by selecting the appropriate provider(s) and making the request to them.
+ *
+ * @param {Context} c - The Cloudflare Worker context.
+ * @returns {Promise<Response>} - The response from the provider.
+ * @throws Will throw an error if no provider options can be determined or if the request to the provider(s) fails.
+ * @throws Will throw an 500 error if the handler fails due to some reasons
+ */
+export async function imageEditsHandler(c: Context): Promise<Response> {
+  try {
+    let request = await c.req.json();
+    let requestHeaders = Object.fromEntries(c.req.raw.headers);
+    const camelCaseConfig = constructConfigFromRequestHeaders(requestHeaders);
+
+    const tryTargetsResponse = await tryTargetsRecursively(
+      c,
+      camelCaseConfig,
+      request,
+      requestHeaders,
+      'imageEdit',
+      'POST',
+      'config'
+    );
+
+    return tryTargetsResponse;
+  } catch (err: any) {
+    console.error('imageEdit error: ', err);
+    let statusCode = 500;
+    let errorMessage = 'Something went wrong';
+
+    if (err instanceof RouterError) {
+      statusCode = 400;
+      errorMessage = err.message;
+    }
+    return new Response(
+      JSON.stringify({
+        status: 'failure',
+        message: 'Something went wrong',
+      }),
+      {
+        status: 500,
+        headers: {
+          'content-type': 'application/json',
+        },
+      }
+    );
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -32,6 +32,7 @@ import filesHandler from './handlers/filesHandler';
 import batchesHandler from './handlers/batchesHandler';
 import finetuneHandler from './handlers/finetuneHandler';
 import { messagesHandler } from './handlers/messagesHandler';
+import { imageEditsHandler } from './handlers/imageEditsHandler';
 
 // Config
 import conf from '../conf.json';
@@ -149,6 +150,12 @@ app.post('/v1/embeddings', requestValidator, embeddingsHandler);
  * Handles requests by passing them to the imageGenerations handler.
  */
 app.post('/v1/images/generations', requestValidator, imageGenerationsHandler);
+
+/**
+ * POST route for '/v1/images/edits'.
+ * Handles requests by passing them to the imageGenerations handler.
+ */
+app.post('/v1/images/edits', requestValidator, imageEditsHandler);
 
 /**
  * POST route for '/v1/audio/speech'.

--- a/src/providers/azure-openai/api.ts
+++ b/src/providers/azure-openai/api.ts
@@ -96,6 +96,9 @@ const AzureOpenAIAPIConfig: ProviderAPIConfig = {
       case 'imageGenerate': {
         return `/deployments/${deploymentId}/images/generations?api-version=${apiVersion}`;
       }
+      case 'imageEdit': {
+        return `/deployments/${deploymentId}/images/edits?api-version=${apiVersion}`;
+      }
       case 'createSpeech': {
         return `/deployments/${deploymentId}/audio/speech?api-version=${apiVersion}`;
       }

--- a/src/providers/azure-openai/imageEdits.ts
+++ b/src/providers/azure-openai/imageEdits.ts
@@ -1,0 +1,81 @@
+import { AZURE_OPEN_AI } from '../../globals';
+import { OpenAIErrorResponseTransform } from '../openai/utils';
+import { ErrorResponse, ImageGenerateResponse, ProviderConfig } from '../types';
+
+export const AzureOpenAIImageEditConfig: ProviderConfig = {
+  image: {
+    param: 'image',
+    required: true,
+  },
+  prompt: {
+    param: 'prompt',
+    required: true,
+  },
+  background: {
+    param: 'background',
+  },
+  input_fidelity: {
+    param: 'input_fidelity',
+  },
+  mask: {
+    param: 'mask',
+  },
+  model: {
+    param: 'model',
+    default: 'dall-e-2',
+  },
+  n: {
+    param: 'n',
+    min: 1,
+    max: 10,
+  },
+  output_compression: {
+    param: 'output_compression',
+    min: 0,
+    max: 100,
+  },
+  output_format: {
+    param: 'output_format',
+  },
+  partial_images: {
+    param: 'partial_images',
+    min: 0,
+    max: 3,
+  },
+  quality: {
+    param: 'quality',
+  },
+  response_format: {
+    param: 'response_format',
+  },
+  size: {
+    param: 'size',
+  },
+  stream: {
+    param: 'stream',
+  },
+  user: {
+    param: 'user',
+  },
+};
+
+interface AzureOpenAIImageObject {
+  b64_json?: string; // The base64-encoded JSON of the generated image, if response_format is b64_json.
+  url?: string; // The URL of the generated image, if response_format is url (default).
+  revised_prompt?: string; // The prompt that was used to generate the image, if there was any revision to the prompt.
+}
+
+interface AzureOpenAIImageGenerateResponse extends ImageGenerateResponse {
+  data: AzureOpenAIImageObject[];
+}
+
+export const AzureOpenAIImageEditResponseTransform: (
+  response: AzureOpenAIImageGenerateResponse | ErrorResponse,
+  responseStatus: number
+) => ImageGenerateResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, AZURE_OPEN_AI);
+  }
+
+  return response;
+};

--- a/src/providers/azure-openai/index.ts
+++ b/src/providers/azure-openai/index.ts
@@ -36,12 +36,17 @@ import {
   OpenAIListInputItemsResponseTransformer,
 } from '../open-ai-base';
 import { AZURE_OPEN_AI } from '../../globals';
+import {
+  AzureOpenAIImageEditConfig,
+  AzureOpenAIImageEditResponseTransform,
+} from './imageEdits';
 
 const AzureOpenAIConfig: ProviderConfigs = {
   complete: AzureOpenAICompleteConfig,
   embed: AzureOpenAIEmbedConfig,
   api: AzureOpenAIAPIConfig,
   imageGenerate: AzureOpenAIImageGenerateConfig,
+  imageEdit: AzureOpenAIImageEditConfig,
   chatComplete: AzureOpenAIChatCompleteConfig,
   createSpeech: AzureOpenAICreateSpeechConfig,
   createFinetune: OpenAICreateFinetuneConfig,
@@ -63,6 +68,7 @@ const AzureOpenAIConfig: ProviderConfigs = {
     chatComplete: AzureOpenAIResponseTransform,
     embed: AzureOpenAIEmbedResponseTransform,
     imageGenerate: AzureOpenAIImageGenerateResponseTransform,
+    imageEdit: AzureOpenAIImageEditResponseTransform,
     createSpeech: AzureOpenAICreateSpeechResponseTransform,
     createTranscription: AzureOpenAICreateTranscriptionResponseTransform,
     createTranslation: AzureOpenAICreateTranslationResponseTransform,

--- a/src/providers/openai/api.ts
+++ b/src/providers/openai/api.ts
@@ -38,6 +38,8 @@ const OpenAIAPIConfig: ProviderAPIConfig = {
         return '/embeddings';
       case 'imageGenerate':
         return '/images/generations';
+      case 'imageEdit':
+        return '/images/edits';
       case 'createSpeech':
         return '/audio/speech';
       case 'createTranscription':

--- a/src/providers/openai/imageEdits.ts
+++ b/src/providers/openai/imageEdits.ts
@@ -1,0 +1,81 @@
+import { OPEN_AI } from '../../globals';
+import { ErrorResponse, ImageGenerateResponse, ProviderConfig } from '../types';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAIImageEditConfig: ProviderConfig = {
+  image: {
+    param: 'image',
+    required: true,
+  },
+  prompt: {
+    param: 'prompt',
+    required: true,
+  },
+  background: {
+    param: 'background',
+  },
+  input_fidelity: {
+    param: 'input_fidelity',
+  },
+  mask: {
+    param: 'mask',
+  },
+  model: {
+    param: 'model',
+    default: 'dall-e-2',
+  },
+  n: {
+    param: 'n',
+    min: 1,
+    max: 10,
+  },
+  output_compression: {
+    param: 'output_compression',
+    min: 0,
+    max: 100,
+  },
+  output_format: {
+    param: 'output_format',
+  },
+  partial_images: {
+    param: 'partial_images',
+    min: 0,
+    max: 3,
+  },
+  quality: {
+    param: 'quality',
+  },
+  response_format: {
+    param: 'response_format',
+  },
+  size: {
+    param: 'size',
+  },
+  stream: {
+    param: 'stream',
+  },
+  user: {
+    param: 'user',
+  },
+};
+
+interface OpenAIImageObject {
+  b64_json?: string; // The base64-encoded JSON of the generated image, if response_format is b64_json.
+  url?: string; // The URL of the generated image, if response_format is url (default).
+  revised_prompt?: string; // The prompt that was used to generate the image, if there was any revision to the prompt.
+}
+
+interface OpenAIImageGenerateResponse extends ImageGenerateResponse {
+  data: OpenAIImageObject[];
+}
+
+export const OpenAIImageEditResponseTransform: (
+  response: OpenAIImageGenerateResponse | ErrorResponse,
+  responseStatus: number
+) => ImageGenerateResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};

--- a/src/providers/openai/index.ts
+++ b/src/providers/openai/index.ts
@@ -46,6 +46,10 @@ import {
   OpenAIListInputItemsResponseTransformer,
 } from '../open-ai-base';
 import { OPEN_AI } from '../../globals';
+import {
+  OpenAIImageEditConfig,
+  OpenAIImageEditResponseTransform,
+} from './imageEdits';
 
 const OpenAIConfig: ProviderConfigs = {
   complete: OpenAICompleteConfig,
@@ -53,6 +57,7 @@ const OpenAIConfig: ProviderConfigs = {
   api: OpenAIAPIConfig,
   chatComplete: OpenAIChatCompleteConfig,
   imageGenerate: OpenAIImageGenerateConfig,
+  imageEdit: OpenAIImageEditConfig,
   createSpeech: OpenAICreateSpeechConfig,
   createTranscription: {},
   createTranslation: {},
@@ -77,6 +82,7 @@ const OpenAIConfig: ProviderConfigs = {
     chatComplete: OpenAIChatCompleteResponseTransform,
     // 'stream-chatComplete': OpenAIChatCompleteResponseTransform,
     imageGenerate: OpenAIImageGenerateResponseTransform,
+    imageEdit: OpenAIImageEditResponseTransform,
     createSpeech: OpenAICreateSpeechResponseTransform,
     createTranscription: OpenAICreateTranscriptionResponseTransform,
     createTranslation: OpenAICreateTranslationResponseTransform,

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -91,6 +91,7 @@ export type endpointStrings =
   | 'stream-messages'
   | 'proxy'
   | 'imageGenerate'
+  | 'imageEdit'
   | 'createSpeech'
   | 'createTranscription'
   | 'createTranslation'


### PR DESCRIPTION
example payload

```sh
curl --location 'http://localhost:8787/v1/images/edits' \
--header 'Content-Type: multipart/form-data' \
--header 'Authorization: Bearer sk-' \
--header 'x-portkey-provider: openai' \
--header 'x-portkey-api-key: ' \
--form 'model="dall-e-2"' \
--form 'image=@"/Users/naren/Desktop/Screenshot 2025-09-12 at 4.08.29 PM.png"' \
--form 'prompt="add a comic character to the image"'
```