### PR TITLE
feat: add Allowed Request Types plugin to control request processing

### DIFF
--- a/plugins/default/allowedRequestTypes.ts
+++ b/plugins/default/allowedRequestTypes.ts
@@ -1,0 +1,178 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let error = null;
+  let verdict = false;
+  let data: any = null;
+
+  try {
+    // Get allowed and blocked request types from parameters or metadata
+    let allowedTypes: string[] = [];
+    let blockedTypes: string[] = [];
+
+    // First check if allowedTypes is provided in parameters
+    if (parameters.allowedTypes) {
+      if (Array.isArray(parameters.allowedTypes)) {
+        allowedTypes = parameters.allowedTypes;
+      } else if (typeof parameters.allowedTypes === 'string') {
+        // Support comma-separated string
+        allowedTypes = parameters.allowedTypes
+          .split(',')
+          .map((t: string) => t.trim());
+      }
+    }
+
+    // Check if blockedTypes is provided in parameters
+    if (parameters.blockedTypes) {
+      if (Array.isArray(parameters.blockedTypes)) {
+        blockedTypes = parameters.blockedTypes;
+      } else if (typeof parameters.blockedTypes === 'string') {
+        // Support comma-separated string
+        blockedTypes = parameters.blockedTypes
+          .split(',')
+          .map((t: string) => t.trim());
+      }
+    }
+
+    // If not in parameters, check metadata for supported_endpoints
+    if (allowedTypes.length === 0 && context.metadata?.supported_endpoints) {
+      if (Array.isArray(context.metadata.supported_endpoints)) {
+        allowedTypes = context.metadata.supported_endpoints;
+      } else if (typeof context.metadata.supported_endpoints === 'string') {
+        // Support comma-separated string in metadata
+        allowedTypes = context.metadata.supported_endpoints
+          .split(',')
+          .map((t: string) => t.trim());
+      }
+    }
+
+    // Check metadata for blocked_endpoints
+    if (blockedTypes.length === 0 && context.metadata?.blocked_endpoints) {
+      if (Array.isArray(context.metadata.blocked_endpoints)) {
+        blockedTypes = context.metadata.blocked_endpoints;
+      } else if (typeof context.metadata.blocked_endpoints === 'string') {
+        // Support comma-separated string in metadata
+        blockedTypes = context.metadata.blocked_endpoints
+          .split(',')
+          .map((t: string) => t.trim());
+      }
+    }
+
+    // Get the current request type from context
+    const currentRequestType = context.requestType;
+
+    if (!currentRequestType) {
+      throw new Error('Request type not found in context');
+    }
+
+    // Check for conflicts when both lists are specified
+    if (allowedTypes.length > 0 && blockedTypes.length > 0) {
+      const conflicts = allowedTypes.filter((type) =>
+        blockedTypes.includes(type)
+      );
+      if (conflicts.length > 0) {
+        throw new Error(
+          `Conflict detected: The following types appear in both allowedTypes and blockedTypes: ${conflicts.join(', ')}. Please remove them from one list.`
+        );
+      }
+    }
+
+    // Determine verdict based on the lists provided
+    let mode = 'unrestricted';
+
+    // If neither list is specified, allow all
+    if (allowedTypes.length === 0 && blockedTypes.length === 0) {
+      verdict = true;
+      mode = 'unrestricted';
+    }
+    // If only blocklist is specified
+    else if (allowedTypes.length === 0 && blockedTypes.length > 0) {
+      verdict = !blockedTypes.includes(currentRequestType);
+      mode = 'blocklist';
+    }
+    // If only allowlist is specified
+    else if (allowedTypes.length > 0 && blockedTypes.length === 0) {
+      verdict = allowedTypes.includes(currentRequestType);
+      mode = 'allowlist';
+    }
+    // If both are specified (combined mode)
+    else {
+      const isBlocked = blockedTypes.includes(currentRequestType);
+      const isInAllowList = allowedTypes.includes(currentRequestType);
+
+      // Blocked takes precedence, then check allowlist
+      if (isBlocked) {
+        verdict = false;
+      } else {
+        verdict = isInAllowList;
+      }
+      mode = 'combined';
+    }
+
+    // Build appropriate explanation based on mode
+    let explanation = '';
+    if (mode === 'combined') {
+      const isBlocked = blockedTypes.includes(currentRequestType);
+      if (!verdict) {
+        if (isBlocked) {
+          explanation = `Request type "${currentRequestType}" is explicitly blocked.`;
+        } else {
+          explanation = `Request type "${currentRequestType}" is not in the allowed list. Allowed types (excluding blocked): ${allowedTypes.filter((t) => !blockedTypes.includes(t)).join(', ')}`;
+        }
+      } else {
+        explanation = `Request type "${currentRequestType}" is allowed (in allowlist and not blocked).`;
+      }
+    } else if (mode === 'blocklist') {
+      explanation = verdict
+        ? `Request type "${currentRequestType}" is allowed (not in blocklist).`
+        : `Request type "${currentRequestType}" is blocked.`;
+    } else if (mode === 'allowlist') {
+      explanation = verdict
+        ? `Request type "${currentRequestType}" is allowed.`
+        : `Request type "${currentRequestType}" is not allowed. Allowed types are: ${allowedTypes.join(', ')}`;
+    } else {
+      explanation = `Request type "${currentRequestType}" is allowed (no restrictions configured).`;
+    }
+
+    data = {
+      currentRequestType,
+      ...(allowedTypes.length > 0
+        ? { allowedTypes }
+        : mode === 'unrestricted'
+          ? { allowedTypes: ['all'] }
+          : {}),
+      ...(blockedTypes.length > 0 && { blockedTypes }),
+      verdict,
+      explanation,
+      source:
+        parameters.allowedTypes || parameters.blockedTypes
+          ? 'parameters'
+          : context.metadata?.supported_endpoints ||
+              context.metadata?.blocked_endpoints
+            ? 'metadata'
+            : 'default',
+      mode,
+    };
+  } catch (e: any) {
+    error = e;
+    data = {
+      explanation: `An error occurred while checking allowed request types: ${e.message}`,
+      currentRequestType: context.requestType || 'unknown',
+      allowedTypes:
+        parameters.allowedTypes || context.metadata?.supported_endpoints || [],
+      blockedTypes:
+        parameters.blockedTypes || context.metadata?.blocked_endpoints || [],
+    };
+  }
+
+  return { error, verdict, data };
+};

--- a/plugins/default/default.test.ts
+++ b/plugins/default/default.test.ts
@@ -11,9 +11,10 @@ import { handler as logHandler } from './log';
 import { handler as allUppercaseHandler } from './alluppercase';
 import { handler as endsWithHandler } from './endsWith';
 import { handler as allLowerCaseHandler } from './alllowercase';
-import { handler as modelWhitelistHandler } from './modelWhitelist';
+import { handler as modelWhitelistHandler } from './modelwhitelist';
 import { handler as characterCountHandler } from './characterCount';
 import { handler as jwtHandler } from './jwt';
+import { handler as allowedRequestTypesHandler } from './allowedRequestTypes';
 import { PluginContext, PluginParameters } from '../types';
 
 describe('Regex Matcher Plugin', () => {
@@ -2464,6 +2465,506 @@ describe('jwt handler', () => {
     expect(result.data).toMatchObject({
       verdict: false,
       explanation: expect.stringContaining('JWT validation error'),
+    });
+  });
+});
+
+describe('Allowed Request Types Plugin', () => {
+  const mockEventType = 'beforeRequestHook';
+
+  describe('Using parameters', () => {
+    it('should allow request when type is in allowed list', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'chatComplete',
+      };
+      const parameters: PluginParameters = {
+        allowedTypes: ['chatComplete', 'complete', 'embed'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.error).toBeNull();
+      expect(result.data.explanation).toContain(
+        'Request type "chatComplete" is allowed'
+      );
+      expect(result.data.source).toBe('parameters');
+    });
+
+    it('should reject request when type is not in allowed list', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'complete',
+        // Using a context property to test with imageGenerate
+        actualRequestType: 'imageGenerate',
+      };
+      const parameters: PluginParameters = {
+        allowedTypes: ['chatComplete', 'complete', 'embed'],
+      };
+
+      // Override the requestType in context for testing
+      mockContext.requestType = mockContext.actualRequestType as any;
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(false);
+      expect(result.error).toBeNull();
+      expect(result.data.explanation).toContain(
+        'Request type "imageGenerate" is not allowed'
+      );
+      expect(result.data.explanation).toContain(
+        'chatComplete, complete, embed'
+      );
+    });
+
+    it('should handle comma-separated string for allowedTypes', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'embed',
+      };
+      const parameters: PluginParameters = {
+        allowedTypes: 'chatComplete, complete, embed',
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.data.allowedTypes).toEqual([
+        'chatComplete',
+        'complete',
+        'embed',
+      ]);
+    });
+
+    it('should handle streaming request types', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'complete',
+      };
+      // Override with stream type for testing
+      (mockContext as any).requestType = 'stream-chatComplete';
+
+      const parameters: PluginParameters = {
+        allowedTypes: ['stream-chatComplete', 'stream-complete'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.data.currentRequestType).toBe('stream-chatComplete');
+    });
+  });
+
+  describe('Using metadata', () => {
+    it('should use metadata when parameters are not provided', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'complete',
+        metadata: {
+          supported_endpoints: ['complete', 'chatComplete'],
+        },
+      };
+      const parameters: PluginParameters = {};
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.data.source).toBe('metadata');
+      expect(result.data.allowedTypes).toEqual(['complete', 'chatComplete']);
+    });
+
+    it('should handle comma-separated string in metadata', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'embed',
+        metadata: {
+          supported_endpoints: 'embed, rerank, moderate',
+        },
+      };
+      const parameters: PluginParameters = {};
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.data.allowedTypes).toEqual(['embed', 'rerank', 'moderate']);
+    });
+
+    it('should prioritize parameters over metadata', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'embed',
+        metadata: {
+          supported_endpoints: ['complete', 'chatComplete'],
+        },
+      };
+      const parameters: PluginParameters = {
+        allowedTypes: ['embed', 'rerank'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.data.source).toBe('parameters');
+      expect(result.data.allowedTypes).toEqual(['embed', 'rerank']);
+    });
+  });
+
+  describe('Default behavior', () => {
+    it('should allow all request types when no allowed types are specified', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'chatComplete',
+      };
+      const parameters: PluginParameters = {};
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.error).toBeNull();
+      expect(result.data.allowedTypes).toEqual(['all']);
+      expect(result.data.explanation).toContain('no restrictions configured');
+      expect(result.data.source).toBe('default');
+    });
+
+    it('should allow any request type when no restrictions are configured', async () => {
+      // Test various request types to ensure all are allowed
+      const requestTypes = ['complete', 'chatComplete', 'embed', 'messages'];
+
+      for (const requestType of requestTypes) {
+        const mockContext: PluginContext = {
+          requestType: requestType as any,
+        };
+        const parameters: PluginParameters = {};
+
+        const result = await allowedRequestTypesHandler(
+          mockContext,
+          parameters,
+          mockEventType
+        );
+
+        expect(result.verdict).toBe(true);
+        expect(result.data.currentRequestType).toBe(requestType);
+        expect(result.data.allowedTypes).toEqual(['all']);
+      }
+    });
+  });
+
+  describe('Error handling', () => {
+    it('should handle missing requestType in context', async () => {
+      const mockContext: PluginContext = {};
+      const parameters: PluginParameters = {
+        allowedTypes: ['chatComplete'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(false);
+      expect(result.error).not.toBeNull();
+      expect(result.error.message).toContain(
+        'Request type not found in context'
+      );
+    });
+  });
+
+  describe('Complex scenarios', () => {
+    it('should handle multiple allowed types with rejection', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'complete',
+      };
+      // Override for testing other endpoint types
+      (mockContext as any).requestType = 'deleteFile';
+
+      const parameters: PluginParameters = {
+        allowedTypes: [
+          'uploadFile',
+          'listFiles',
+          'retrieveFile',
+          'retrieveFileContent',
+        ],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(false);
+      expect(result.data.explanation).toContain('deleteFile');
+      expect(result.data.explanation).toContain('not allowed');
+    });
+
+    it('should handle various endpoint types', async () => {
+      // Test with the allowed types from the PluginContext interface
+      const allowedEndpoints = [
+        'complete',
+        'chatComplete',
+        'embed',
+        'messages',
+      ];
+
+      for (const endpoint of allowedEndpoints) {
+        const mockContext: PluginContext = {
+          requestType: endpoint as any,
+        };
+        const parameters: PluginParameters = {
+          allowedTypes: [endpoint],
+        };
+
+        const result = await allowedRequestTypesHandler(
+          mockContext,
+          parameters,
+          mockEventType
+        );
+
+        expect(result.verdict).toBe(true);
+        expect(result.data.currentRequestType).toBe(endpoint);
+      }
+    });
+  });
+
+  describe('Blocklist functionality', () => {
+    it('should block request types in blocklist', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'complete',
+      };
+      // Override to test blocked type
+      (mockContext as any).requestType = 'imageGenerate';
+
+      const parameters: PluginParameters = {
+        blockedTypes: ['imageGenerate', 'createSpeech', 'deleteFile'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(false);
+      expect(result.error).toBeNull();
+      expect(result.data.explanation).toContain(
+        'Request type "imageGenerate" is blocked'
+      );
+      expect(result.data.mode).toBe('blocklist');
+      expect(result.data.blockedTypes).toEqual([
+        'imageGenerate',
+        'createSpeech',
+        'deleteFile',
+      ]);
+    });
+
+    it('should allow request types not in blocklist', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'chatComplete',
+      };
+
+      const parameters: PluginParameters = {
+        blockedTypes: ['imageGenerate', 'createSpeech', 'deleteFile'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.data.explanation).toContain(
+        'Request type "chatComplete" is allowed (not in blocklist)'
+      );
+      expect(result.data.mode).toBe('blocklist');
+    });
+
+    it('should handle comma-separated string for blockedTypes', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'embed',
+      };
+
+      const parameters: PluginParameters = {
+        blockedTypes: 'imageGenerate, createSpeech, deleteFile',
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.data.blockedTypes).toEqual([
+        'imageGenerate',
+        'createSpeech',
+        'deleteFile',
+      ]);
+    });
+
+    it('should use blocked_endpoints from metadata', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'complete',
+        metadata: {
+          blocked_endpoints: ['complete', 'embed'],
+        },
+      };
+
+      const parameters: PluginParameters = {};
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(false);
+      expect(result.data.source).toBe('metadata');
+      expect(result.data.mode).toBe('blocklist');
+      expect(result.data.blockedTypes).toEqual(['complete', 'embed']);
+    });
+
+    it('should prioritize parameter blockedTypes over metadata', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'chatComplete',
+        metadata: {
+          blocked_endpoints: ['chatComplete', 'complete'],
+        },
+      };
+
+      const parameters: PluginParameters = {
+        blockedTypes: ['embed', 'messages'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.data.source).toBe('parameters');
+      expect(result.data.blockedTypes).toEqual(['embed', 'messages']);
+    });
+
+    it('should allow combining allowedTypes and blockedTypes when no conflicts', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'chatComplete',
+      };
+
+      const parameters: PluginParameters = {
+        allowedTypes: ['chatComplete', 'complete', 'embed'],
+        blockedTypes: ['imageGenerate', 'createSpeech'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(true);
+      expect(result.error).toBeNull();
+      expect(result.data.mode).toBe('combined');
+      expect(result.data.explanation).toContain('in allowlist and not blocked');
+    });
+
+    it('should block types in blocklist even if in allowlist mode', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'complete',
+      };
+      // Override to test blocked type
+      (mockContext as any).requestType = 'imageGenerate';
+
+      const parameters: PluginParameters = {
+        allowedTypes: ['chatComplete', 'complete', 'embed'],
+        blockedTypes: ['imageGenerate', 'createSpeech'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(false);
+      expect(result.data.explanation).toContain('explicitly blocked');
+      expect(result.data.mode).toBe('combined');
+    });
+
+    it('should error when there are conflicts between allowedTypes and blockedTypes', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'chatComplete',
+      };
+
+      const parameters: PluginParameters = {
+        allowedTypes: ['chatComplete', 'complete', 'embed'],
+        blockedTypes: ['complete', 'embed', 'imageGenerate'],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(false);
+      expect(result.error).not.toBeNull();
+      expect(result.error.message).toContain('Conflict detected');
+      expect(result.error.message).toContain('complete');
+      expect(result.error.message).toContain('embed');
+    });
+
+    it('should handle blocklist with streaming endpoints', async () => {
+      const mockContext: PluginContext = {
+        requestType: 'complete',
+      };
+      // Override with stream type
+      (mockContext as any).requestType = 'stream-chatComplete';
+
+      const parameters: PluginParameters = {
+        blockedTypes: [
+          'stream-chatComplete',
+          'stream-complete',
+          'stream-messages',
+        ],
+      };
+
+      const result = await allowedRequestTypesHandler(
+        mockContext,
+        parameters,
+        mockEventType
+      );
+
+      expect(result.verdict).toBe(false);
+      expect(result.data.explanation).toContain('stream-chatComplete');
+      expect(result.data.explanation).toContain('blocked');
     });
   });
 });

--- a/plugins/default/manifest.json
+++ b/plugins/default/manifest.json
@@ -44,6 +44,120 @@
       }
     },
     {
+      "name": "Allowed Request Types",
+      "id": "allowedRequestTypes",
+      "type": "guardrail",
+      "supportedHooks": ["beforeRequestHook"],
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Control which request types (endpoints) can be processed. Use either an allowlist or blocklist approach. If no types are specified, all request types are allowed."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "allowedTypes": {
+            "type": "array",
+            "label": "Allowed Request Types (Multi-select)",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Select request types to allow. Can be combined with blockedTypes for refined control. Can also be specified in metadata as 'supported_endpoints'."
+              }
+            ],
+            "items": {
+              "type": "string",
+              "enum": [
+                "complete",
+                "chatComplete",
+                "embed",
+                "rerank",
+                "moderate",
+                "stream-complete",
+                "stream-chatComplete",
+                "stream-messages",
+                "proxy",
+                "imageGenerate",
+                "createSpeech",
+                "createTranscription",
+                "createTranslation",
+                "realtime",
+                "uploadFile",
+                "listFiles",
+                "retrieveFile",
+                "deleteFile",
+                "retrieveFileContent",
+                "createBatch",
+                "retrieveBatch",
+                "cancelBatch",
+                "listBatches",
+                "getBatchOutput",
+                "listFinetunes",
+                "createFinetune",
+                "retrieveFinetune",
+                "cancelFinetune",
+                "createModelResponse",
+                "getModelResponse",
+                "deleteModelResponse",
+                "listResponseInputItems",
+                "messages"
+              ]
+            }
+          },
+          "blockedTypes": {
+            "type": "array",
+            "label": "Blocked Request Types (Multi-select)",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Select request types to block. When combined with allowedTypes, blocked types take precedence. Can also be specified in metadata as 'blocked_endpoints'."
+              }
+            ],
+            "items": {
+              "type": "string",
+              "enum": [
+                "complete",
+                "chatComplete",
+                "embed",
+                "rerank",
+                "moderate",
+                "stream-complete",
+                "stream-chatComplete",
+                "stream-messages",
+                "proxy",
+                "imageGenerate",
+                "createSpeech",
+                "createTranscription",
+                "createTranslation",
+                "realtime",
+                "uploadFile",
+                "listFiles",
+                "retrieveFile",
+                "deleteFile",
+                "retrieveFileContent",
+                "createBatch",
+                "retrieveBatch",
+                "cancelBatch",
+                "listBatches",
+                "getBatchOutput",
+                "listFinetunes",
+                "createFinetune",
+                "retrieveFinetune",
+                "cancelFinetune",
+                "createModelResponse",
+                "getModelResponse",
+                "deleteModelResponse",
+                "listResponseInputItems",
+                "messages"
+              ]
+            }
+          }
+        },
+        "required": []
+      }
+    },
+    {
       "name": "Sentence Count",
       "id": "sentenceCount",
       "type": "guardrail",

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -52,6 +52,7 @@ import { handler as defaultjwt } from './default/jwt';
 import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
 import { handler as walledaiguardrails } from './walledai/guardrails';
 import { handler as defaultregexReplace } from './default/regexReplace';
+import { handler as defaultallowedRequestTypes } from './default/allowedRequestTypes';
 
 export const plugins = {
   default: {
@@ -74,6 +75,7 @@ export const plugins = {
     jwt: defaultjwt,
     requiredMetadataKeys: defaultrequiredMetadataKeys,
     regexReplace: defaultregexReplace,
+    allowedRequestTypes: defaultallowedRequestTypes,
   },
   portkey: {
     moderateContent: portkeymoderateContent,


### PR DESCRIPTION
This pull request introduces a new guardrail plugin, `allowedRequestTypes`, which provides fine-grained control over which request types (endpoints) can be processed. The plugin supports both allowlist and blocklist approaches, can be configured via parameters or metadata, and is integrated into the plugin system for use in request validation.

**New Guardrail Plugin: Allowed Request Types**

* Added `allowedRequestTypes` plugin implementation in `plugins/default/allowedRequestTypes.ts`, supporting allowlist, blocklist, and combined modes, with conflict detection and detailed explanations. The plugin can read configuration from parameters or metadata and returns a verdict on whether a request type is permitted.

**Manifest and Plugin System Integration**

* Registered the new `allowedRequestTypes` guardrail in `plugins/default/manifest.json` with a comprehensive parameter schema and descriptions for configuration via UI or metadata.
* Imported and exposed the `allowedRequestTypes` handler in the plugin index (`plugins/index.ts`), making it available as part of the default plugin set. [[1]](diffhunk://#diff-66d2bde5f2434cab267001e9427ff3b2c4f875c88f9cc9b0976721f44fa7f49dR55) [[2]](diffhunk://#diff-66d2bde5f2434cab267001e9427ff3b2c4f875c88f9cc9b0976721f44fa7f49dR78)