### PR TITLE
fix: add tool_use, thinking and redacted_thinking content_block_start event handling in Bedrock messages transformer

### DIFF
--- a/src/providers/bedrock/messages.ts
+++ b/src/providers/bedrock/messages.ts
@@ -435,9 +435,9 @@ export const BedrockMessagesResponseTransform = (
   _gatewayRequestUrl: string,
   gatewayRequest: Params
 ): MessagesResponse | ErrorResponse => {
-  if (responseStatus !== 200 && 'error' in response) {
+  if (responseStatus !== 200) {
     return (
-      BedrockErrorResponseTransform(response) ||
+      BedrockErrorResponseTransform(response as BedrockErrorResponse) ||
       generateInvalidProviderResponseError(response, BEDROCK)
     );
   }

--- a/src/providers/bedrock/messages.ts
+++ b/src/providers/bedrock/messages.ts
@@ -533,6 +533,11 @@ function createContentBlockStartEvent(
       thinking: '',
       signature: '',
     };
+  } else if (parsedChunk.delta?.reasoningContent?.redactedContent) {
+    contentBlockStartEvent.content_block = {
+      type: 'redacted_thinking',
+      data: parsedChunk.delta.reasoningContent.redactedContent,
+    };
   }
 
   return contentBlockStartEvent;

--- a/src/providers/bedrock/messages.ts
+++ b/src/providers/bedrock/messages.ts
@@ -548,12 +548,12 @@ export const BedrockConverseMessagesStreamChunkTransform = (
     const contentBlockStartEvent: RawContentBlockStartEvent = JSON.parse(
       ANTHROPIC_CONTENT_BLOCK_START_EVENT
     );
-    if (parsedChunk.start?.toolUse) {
+    if (parsedChunk.start?.toolUse && parsedChunk.start.toolUse.toolUseId) {
       contentBlockStartEvent.content_block = {
         type: 'tool_use',
         id: parsedChunk.start.toolUse.toolUseId,
         name: parsedChunk.start.toolUse.name,
-        input: parsedChunk.start.toolUse.input || {},
+        input: {},
       };
     }
     contentBlockStartEvent.index = parsedChunk.contentBlockIndex;

--- a/src/providers/bedrock/messages.ts
+++ b/src/providers/bedrock/messages.ts
@@ -548,6 +548,14 @@ export const BedrockConverseMessagesStreamChunkTransform = (
     const contentBlockStartEvent: RawContentBlockStartEvent = JSON.parse(
       ANTHROPIC_CONTENT_BLOCK_START_EVENT
     );
+    if (parsedChunk.start?.toolUse) {
+      contentBlockStartEvent.content_block = {
+        type: 'tool_use',
+        id: parsedChunk.start.toolUse.toolUseId,
+        name: parsedChunk.start.toolUse.name,
+        input: parsedChunk.start.toolUse.input || {},
+      };
+    }
     contentBlockStartEvent.index = parsedChunk.contentBlockIndex;
     returnChunk += `event: content_block_start\ndata: ${JSON.stringify(contentBlockStartEvent)}\n\n`;
     const contentBlockDeltaEvent = transformContentBlock(parsedChunk);


### PR DESCRIPTION
## Description
Handling the toolUse contentBlockStart stream chunk in Bedrock messages response transformer.
https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ContentBlockStart.html

## Motivation
<!-- Provide a brief motivation of why the changes in this PR are needed -->

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
