### PR TITLE
add input_audio parameter support for vertex

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -51,6 +51,7 @@ import {
   getMimeType,
   recursivelyDeleteUnsupportedParameters,
   transformGeminiToolParameters,
+  transformInputAudioPart,
   transformVertexLogprobs,
 } from './utils';
 
@@ -119,8 +120,9 @@ export const VertexGoogleChatCompleteConfig: ProviderConfig = {
                 parts.push({
                   text: c.text,
                 });
-              }
-              if (c.type === 'image_url') {
+              } else if (c.type === 'input_audio') {
+                parts.push(transformInputAudioPart(c));
+              } else if (c.type === 'image_url') {
                 const { url, mime_type: passedMimeType } = c.image_url || {};
 
                 if (!url) {

--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -14,7 +14,7 @@ import {
 import { ErrorResponse, FinetuneRequest, Logprobs } from '../types';
 import { Context } from 'hono';
 import { env } from 'hono/adapter';
-import { JsonSchema } from '../../types/requestBody';
+import { ContentType, JsonSchema } from '../../types/requestBody';
 
 /**
  * Encodes an object as a Base64 URL-encoded string.
@@ -750,4 +750,22 @@ export const generateSignedURL = async (
   // Construct the final URL
   const schemeAndHost = `https://${host}`;
   return `${schemeAndHost}${canonicalUri}?${canonicalQueryString}&x-goog-signature=${signatureHex}`;
+};
+
+export const OPENAI_AUDIO_FORMAT_TO_VERTEX_MIME_TYPE_MAPPING = {
+  mp3: 'audio/mp3',
+  wav: 'audio/wav',
+};
+export const transformInputAudioPart = (c: ContentType) => {
+  const data = c.input_audio?.data;
+  const mimeType =
+    OPENAI_AUDIO_FORMAT_TO_VERTEX_MIME_TYPE_MAPPING[
+      c.input_audio?.format as 'mp3' | 'wav'
+    ];
+  return {
+    inlineData: {
+      data,
+      mimeType,
+    },
+  };
 };

--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -756,6 +756,7 @@ export const OPENAI_AUDIO_FORMAT_TO_VERTEX_MIME_TYPE_MAPPING = {
   mp3: 'audio/mp3',
   wav: 'audio/wav',
 };
+
 export const transformInputAudioPart = (c: ContentType) => {
   const data = c.input_audio?.data;
   const mimeType =

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -14,6 +14,7 @@ import {
   getMimeType,
   recursivelyDeleteUnsupportedParameters,
   transformGeminiToolParameters,
+  transformInputAudioPart,
   transformVertexLogprobs,
 } from '../google-vertex-ai/utils';
 import {
@@ -219,8 +220,9 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
                 parts.push({
                   text: c.text,
                 });
-              }
-              if (c.type === 'image_url') {
+              } else if (c.type === 'input_audio') {
+                parts.push(transformInputAudioPart(c));
+              } else if (c.type === 'image_url') {
                 const { url, mime_type: passedMimeType } = c.image_url || {};
                 if (!url) return;
 

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -248,7 +248,7 @@ export interface ContentType extends PromptCache {
   };
   input_audio?: {
     data: string;
-    format: string; //defaults to auto
+    format: 'mp3' | 'wav' | string; //defaults to auto
   };
 }
 


### PR DESCRIPTION
example payload

```json
{
    "messages": [
        {
            "content": [
                {
                    "type": "text",
                    "text": "what's this about?"
                },
                {
                    "type": "input_audio",
                    "input_audio": {
                        "format": "wav",
                        "data": "<your base 64 encoded string>"
                    }
                }
            ],
            "role": "user"
        }
    ],
    "model": "gemini-2.5-flash",
    "max_tokens": 65535,
    "n": 1,
    "stream": false,
    "stream_options": {
        "include_usage": true
    }
}
```