### PR TITLE
improvement: forward cache control parameter for plain text content (system messages)

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -337,7 +337,7 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
               typeof msg.content === 'string'
             ) {
               systemMessages.push({
-                ...((msg as any)?.cache_control && {
+                ...(msg?.cache_control && {
                   cache_control: { type: 'ephemeral' },
                 }),
                 text: msg.content,

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -337,6 +337,9 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
               typeof msg.content === 'string'
             ) {
               systemMessages.push({
+                ...((msg as any)?.cache_control && {
+                  cache_control: { type: 'ephemeral' },
+                }),
                 text: msg.content,
                 type: 'text',
               });


### PR DESCRIPTION
## Description
1. Adds `cache_control` parameter forwarding to anthropic models.

This follows the approach shown in the [official example](https://docs.claude.com/en/docs/build-with-claude/prompt-caching), which demonstrates another correct way to pass the cache parameter.

before
```json
"system": [
  {
    "text": "[...]",
    "type": "text"
  }
],
```
```json
"usage": {
  "prompt_tokens": 1472,
  "completion_tokens": 252,
  "total_tokens": 1724
}
```

after
```json
"system": [
  {
    "cache_control": {
      "type": "ephemeral"
    },
    "text": "[...]",
    "type": "text"
  }
],
```

```json
"usage": {
    "prompt_tokens": 25,
    "completion_tokens": 206,
    "total_tokens": 231,
    "cache_read_input_tokens": 0,
    "cache_creation_input_tokens": 1447
}
```

## Motivation
To handle both correct formats for prompt caching

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
