### PR TITLE
use invoke model to count tokens for anthropic through bedrock

### DIFF
--- a/src/providers/bedrock/countTokens.ts
+++ b/src/providers/bedrock/countTokens.ts
@@ -6,6 +6,7 @@ import { Params } from '../../types/requestBody';
 import { BEDROCK } from '../../globals';
 import { BedrockErrorResponseTransform } from './chatComplete';
 import { generateInvalidProviderResponseError } from '../utils';
+import { AnthropicMessagesConfig } from '../anthropic/messages';
 
 // https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_CountTokens.html#API_runtime_CountTokens_RequestSyntax
 export const BedrockConverseMessageCountTokensConfig: ProviderConfig = {
@@ -18,6 +19,31 @@ export const BedrockConverseMessageCountTokensConfig: ProviderConfig = {
           BedrockConverseMessagesConfig,
           params as Params
         ),
+      };
+    },
+  },
+};
+
+export const BedrockAnthropicMessageCountTokensConfig: ProviderConfig = {
+  messages: {
+    param: 'input',
+    required: true,
+    transform: (params: BedrockMessagesParams) => {
+      const anthropicParams = transformUsingProviderConfig(
+        AnthropicMessagesConfig,
+        params as Params
+      );
+      delete anthropicParams.model;
+      anthropicParams.anthropic_version =
+        params.anthropic_version || 'bedrock-2023-05-31';
+      return {
+        invokeModel: {
+          body: Buffer.from(
+            JSON.stringify({
+              ...anthropicParams,
+            })
+          ).toString('base64'),
+        },
       };
     },
   },

--- a/src/providers/bedrock/countTokens.ts
+++ b/src/providers/bedrock/countTokens.ts
@@ -36,6 +36,7 @@ export const BedrockAnthropicMessageCountTokensConfig: ProviderConfig = {
       delete anthropicParams.model;
       anthropicParams.anthropic_version =
         params.anthropic_version || 'bedrock-2023-05-31';
+      anthropicParams.max_tokens = anthropicParams.max_tokens || 10;
       return {
         invokeModel: {
           body: Buffer.from(

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -81,6 +81,7 @@ import {
   BedrockMessagesResponseTransform,
 } from './messages';
 import {
+  BedrockAnthropicMessageCountTokensConfig,
   BedrockConverseMessageCountTokensConfig,
   BedrockConverseMessageCountTokensResponseTransform,
 } from './countTokens';
@@ -110,6 +111,7 @@ const BedrockConfig: ProviderConfigs = {
             complete: BedrockAnthropicCompleteConfig,
             chatComplete: BedrockConverseAnthropicChatCompleteConfig,
             messages: BedrockAnthropicConverseMessagesConfig,
+            messagesCountTokens: BedrockAnthropicMessageCountTokensConfig,
             api: BedrockAPIConfig,
             responseTransforms: {
               'stream-complete': BedrockAnthropicCompleteStreamChunkTransform,


### PR DESCRIPTION
the [converse structure](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_ConverseTokensRequest.html) for counting tokens only considers message content and ignores tools
this change uses the invokeModel structure to directly pass the body to the anthropic count tokens endpoint