### PR TITLE
fix: work around `immutable` header guard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@cfworker/json-schema": "^4.0.3",
-        "@hono/node-server": "^1.3.3",
+        "@hono/node-server": "^1.19.5",
         "@hono/node-ws": "^1.2.0",
         "@portkey-ai/mustache": "^2.1.3",
         "@smithy/signature-v4": "^2.1.1",
@@ -1360,9 +1360,10 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.13.5.tgz",
-      "integrity": "sha512-lSo+CFlLqAFB4fX7ePqI9nauEn64wOfJHAfc9duYFTvAG3o416pC0nTGeNjuLHchLedH+XyWda5v79CVx1PIjg==",
+      "version": "1.19.5",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.5.tgz",
+      "integrity": "sha512-iBuhh+uaaggeAuf+TftcjZyWh2GEgZcVGXkNtskLVoWaXhnJtC5HLHrU8W1KHDoucqO1MswwglmkWLFyiDn4WQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
     "@cfworker/json-schema": "^4.0.3",
-    "@hono/node-server": "^1.3.3",
+    "@hono/node-server": "^1.19.5",
     "@hono/node-ws": "^1.2.0",
     "@portkey-ai/mustache": "^2.1.3",
     "@smithy/signature-v4": "^2.1.1",

--- a/src/handlers/services/responseService.ts
+++ b/src/handlers/services/responseService.ts
@@ -61,7 +61,11 @@ export class ResponseService {
       ));
     }
 
-    this.updateHeaders(finalMappedResponse, cache.cacheStatus, retryAttempt);
+    finalMappedResponse = this.updateHeaders(
+      finalMappedResponse,
+      cache.cacheStatus,
+      retryAttempt
+    );
 
     return {
       response: finalMappedResponse,
@@ -99,6 +103,13 @@ export class ResponseService {
     cacheStatus: string | undefined,
     retryAttempt: number
   ) {
+    // Clone response and headers to work around `immutable` header guard
+    response = new Response(response.body, {
+      status: response.status,
+      statusText: response.statusText,
+      headers: new Headers(response.headers),
+    });
+
     // Append headers directly
     response.headers.append(
       RESPONSE_HEADER_KEYS.LAST_USED_OPTION_INDEX,

--- a/tests/unit/src/handlers/services/responseService.test.ts
+++ b/tests/unit/src/handlers/services/responseService.test.ts
@@ -393,7 +393,7 @@ describe('ResponseService', () => {
     });
 
     it('should add required headers', () => {
-      responseService.updateHeaders(mockResponse, 'HIT', 2);
+      mockResponse = responseService.updateHeaders(mockResponse, 'HIT', 2);
 
       expect(
         mockResponse.headers.get(RESPONSE_HEADER_KEYS.LAST_USED_OPTION_INDEX)
@@ -411,14 +411,14 @@ describe('ResponseService', () => {
     });
 
     it('should remove problematic headers', () => {
-      responseService.updateHeaders(mockResponse, undefined, 0);
+      mockResponse = responseService.updateHeaders(mockResponse, undefined, 0);
 
       expect(mockResponse.headers.get('content-length')).toBeNull();
       expect(mockResponse.headers.get('transfer-encoding')).toBeNull();
     });
 
     it('should remove brotli encoding', () => {
-      responseService.updateHeaders(mockResponse, undefined, 0);
+      mockResponse = responseService.updateHeaders(mockResponse, undefined, 0);
 
       expect(mockResponse.headers.get('content-encoding')).toBeNull();
     });
@@ -429,7 +429,7 @@ describe('ResponseService', () => {
         headers: { 'content-encoding': 'gzip' },
       });
 
-      responseService.updateHeaders(response, undefined, 0);
+      mockResponse = responseService.updateHeaders(response, undefined, 0);
 
       expect(response.headers.get('content-encoding')).toBeNull();
     });
@@ -440,13 +440,13 @@ describe('ResponseService', () => {
         headers: { 'content-encoding': 'gzip' },
       });
 
-      responseService.updateHeaders(response, undefined, 0);
+      mockResponse = responseService.updateHeaders(response, undefined, 0);
 
       expect(response.headers.get('content-encoding')).toBe('gzip');
     });
 
     it('should not add cache status header when undefined', () => {
-      responseService.updateHeaders(mockResponse, undefined, 0);
+      mockResponse = responseService.updateHeaders(mockResponse, undefined, 0);
 
       expect(
         mockResponse.headers.get(RESPONSE_HEADER_KEYS.CACHE_STATUS)
@@ -466,7 +466,7 @@ describe('ResponseService', () => {
         mockLogsService
       );
 
-      serviceWithPortkey.updateHeaders(mockResponse, 'MISS', 0);
+      mockResponse = serviceWithPortkey.updateHeaders(mockResponse, 'MISS', 0);
 
       expect(mockResponse.headers.get(HEADER_KEYS.PROVIDER)).toBeNull();
     });
@@ -484,7 +484,11 @@ describe('ResponseService', () => {
         mockLogsService
       );
 
-      serviceWithEmptyProvider.updateHeaders(mockResponse, 'MISS', 0);
+      mockResponse = serviceWithEmptyProvider.updateHeaders(
+        mockResponse,
+        'MISS',
+        0
+      );
 
       expect(mockResponse.headers.get(HEADER_KEYS.PROVIDER)).toBeNull();
     });


### PR DESCRIPTION
## Description

This PR fixes the `ResponseService.updateHeaders` method to not try to mutate response headers, since it is forbidden by the `fetch` [spec](https://fetch.spec.whatwg.org/#headers-guard).

Resolves https://github.com/Portkey-AI/gateway/issues/1389.

## Motivation

Users who install incompatible (i.e. modern) versions of `@hono/node-server` will end up with response errors when using Portkey.

## Type of Change
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
- [ ] Unit Tests
- [ ] Integration Tests
- [x] Manual Testing

## Screenshots (if applicable)

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
https://github.com/Portkey-AI/gateway/issues/1389