### PR TITLE
send hook results when streaming response

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -1189,6 +1189,7 @@ export async function recursiveAfterRequestHookHandler(
     responseJson: mappedResponseJson,
     originalResponseJson,
   } = await responseHandler(
+    c,
     response,
     isStreamingMode,
     providerOption,
@@ -1198,7 +1199,8 @@ export async function recursiveAfterRequestHookHandler(
     gatewayParams,
     strictOpenAiCompliance,
     c.req.url,
-    areSyncHooksAvailable
+    areSyncHooksAvailable,
+    hookSpanId
   );
 
   const arhResponse = await afterRequestHookHandler(

--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -263,9 +263,6 @@ export async function afterRequestHookHandler(
 
     if (!responseJSON) {
       // For streaming responses, check if beforeRequestHooks failed without deny enabled.
-      const additionalHeaders = {
-        'x-portkey-hook-results': JSON.stringify(hooksResult),
-      };
       if (
         (failedBeforeRequestHooks.length || failedAfterRequestHooks.length) &&
         response.status === 200
@@ -275,12 +272,10 @@ export async function afterRequestHookHandler(
           ...response,
           status: 246,
           statusText: 'Hooks failed',
-          headers: { ...response.headers, ...additionalHeaders },
         });
       }
       return new Response(response.body, {
         ...response,
-        headers: { ...response.headers, ...additionalHeaders },
       });
     }
 

--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -274,9 +274,7 @@ export async function afterRequestHookHandler(
           statusText: 'Hooks failed',
         });
       }
-      return new Response(response.body, {
-        ...response,
-      });
+      return response;
     }
 
     if (shouldDeny) {

--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -99,23 +99,21 @@ export async function responseHandler(
     responseTransformerFunction = undefined;
   }
 
-  if (
-    streamingMode &&
-    isSuccessStatusCode &&
-    isCacheHit &&
-    responseTransformerFunction
-  ) {
-    const streamingResponse = await handleJSONToStreamResponse(
-      response,
-      provider,
-      responseTransformerFunction
-    );
-    return { response: streamingResponse, responseJson: null };
-  }
   if (streamingMode && isSuccessStatusCode) {
     const hooksManager = c.get('hooksManager');
     const span = hooksManager.getSpan(hookSpanId) as HookSpan;
     const hooksResult = span.getHooksResult();
+    if (isCacheHit && responseTransformerFunction) {
+      const streamingResponse = await handleJSONToStreamResponse(
+        response,
+        provider,
+        responseTransformerFunction,
+        strictOpenAiCompliance,
+        responseTransformer as endpointStrings,
+        hooksResult
+      );
+      return { response: streamingResponse, responseJson: null };
+    }
     return {
       response: handleStreamingMode(
         response,

--- a/src/handlers/responseHandlers.ts
+++ b/src/handlers/responseHandlers.ts
@@ -255,6 +255,9 @@ export async function afterRequestHookHandler(
 
     if (!responseJSON) {
       // For streaming responses, check if beforeRequestHooks failed without deny enabled.
+      const additionalHeaders = {
+        'x-portkey-hook-results': JSON.stringify(hooksResult),
+      };
       if (
         (failedBeforeRequestHooks.length || failedAfterRequestHooks.length) &&
         response.status === 200
@@ -264,10 +267,13 @@ export async function afterRequestHookHandler(
           ...response,
           status: 246,
           statusText: 'Hooks failed',
-          headers: response.headers,
+          headers: { ...response.headers, ...additionalHeaders },
         });
       }
-      return response;
+      return new Response(response.body, {
+        ...response,
+        headers: { ...response.headers, ...additionalHeaders },
+      });
     }
 
     if (shouldDeny) {

--- a/src/handlers/services/responseService.ts
+++ b/src/handlers/services/responseService.ts
@@ -81,6 +81,7 @@ export class ResponseService {
   }> {
     const url = this.context.requestURL;
     return await responseHandler(
+      this.context.honoContext,
       response,
       this.context.isStreaming,
       this.context.providerOption,
@@ -90,7 +91,8 @@ export class ResponseService {
       this.context.params,
       this.context.strictOpenAiCompliance,
       this.context.honoContext.req.url,
-      this.hooksService.areSyncHooksAvailable
+      this.hooksService.areSyncHooksAvailable,
+      this.hooksService.hookSpan?.id as string
     );
   }
 


### PR DESCRIPTION
I'm not a big fan of the approach here either, Separating hooks execution and response transforms was a good enough abstraction but there is no way to let the stream transformer be made aware of the hooks result than to pass it to the stream transform function

How to test:
configure a beforeRequestHook and set strict-open-ai-compliance flag to false
example payload
```sh
curl --location 'http://localhost:8787/v1/chat/completions' \
--header 'x-portkey-provider: openai' \
--header 'authorization: sk-' \
--header 'Content-Type: application/json' \
--header 'x-portkey-config: {"beforeRequestHooks":[{"type":"guardrail","id":"my_solid_guardrail","checks":[{"id":"default.regexMatch","parameters":{"rule": "*"}}]}],"retry": {"attempts": 1}}' \
--header 'x-portkey-strict-open-ai-compliance: false' \
--data '{
    "model": "gpt-3.5-turbo",
    "max_tokens": 100,
    "stream": true,
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful aaassistant"
        },
        {
            "role": "user",
            "content": "I am drowning under the water"
        }
    ]
}'
```