### PR TITLE
feat: Add Support for Additional Audio Formats in Vertex AI Provider

### DIFF
--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -716,13 +716,23 @@ export const isEmbeddingModel = (modelName: string) => {
 export const OPENAI_AUDIO_FORMAT_TO_VERTEX_MIME_TYPE_MAPPING = {
   mp3: 'audio/mp3',
   wav: 'audio/wav',
+  opus: 'audio/ogg',
+  flac: 'audio/flac',
+  pcm16: 'audio/pcm',
+  'x-aac': 'audio/aac',
+  'x-m4a': 'audio/m4a',
+  mpeg: 'audio/mpeg',
+  mpga: 'audio/mpga',
+  mp4: 'audio/mp4',
+  webm: 'audio/webm',
 };
 
 export const transformInputAudioPart = (c: ContentType): GoogleMessagePart => {
   const data = c.input_audio?.data;
   const mimeType =
     OPENAI_AUDIO_FORMAT_TO_VERTEX_MIME_TYPE_MAPPING[
-      c.input_audio?.format as 'mp3' | 'wav'
+      c.input_audio
+        ?.format as keyof typeof OPENAI_AUDIO_FORMAT_TO_VERTEX_MIME_TYPE_MAPPING
     ];
   return {
     inlineData: {


### PR DESCRIPTION
### Summary
Expanded audio format support when transforming OpenAI-format audio inputs to Google Vertex AI's MIME type format.

### Changes
- **Extended `OPENAI_AUDIO_FORMAT_TO_VERTEX_MIME_TYPE_MAPPING`** to include 9 additional audio formats:
  - `opus` → `audio/ogg`
  - `flac` → `audio/flac`
  - `pcm16` → `audio/pcm`
  - `x-aac` → `audio/aac`
  - `x-m4a` → `audio/m4a`
  - `mpeg` → `audio/mpeg`
  - `mpga` → `audio/mpga`
  - `mp4` → `audio/mp4`
  - `webm` → `audio/webm`

- **Improved type safety** in `transformInputAudioPart()` by using `keyof typeof` instead of hardcoded union type

### Impact
Users can now use a wider range of audio formats when making requests to Vertex AI through the OpenAI-compatible interface.