### PR TITLE
feat: add modal labs provider and related header keys to mask while logging

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -107,6 +107,7 @@ export const MATTERAI: string = 'matterai';
 export const MESHY: string = 'meshy';
 export const TRIPO3D: string = 'tripo3d';
 export const NEXTBIT: string = 'nextbit';
+export const MODAL: string = 'modal';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -177,6 +178,7 @@ export const VALID_PROVIDERS = [
   MESHY,
   TRIPO3D,
   NEXTBIT,
+  MODAL,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -68,6 +68,7 @@ import Tripo3DConfig from './tripo3d';
 import { NextBitConfig } from './nextbit';
 import CometAPIConfig from './cometapi';
 import MatterAIConfig from './matterai';
+import ModalConfig from './modal';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -136,6 +137,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   meshy: MeshyConfig,
   nextbit: NextBitConfig,
   tripo3d: Tripo3DConfig,
+  modal: ModalConfig,
 };
 
 export default Providers;

--- a/src/providers/modal/api.ts
+++ b/src/providers/modal/api.ts
@@ -1,0 +1,21 @@
+import { ProviderAPIConfig } from '../types';
+
+export const ModalAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => `https://api.modal.com/v1`, // This would ideally always be replaced by a custom host
+  headers({ providerOptions }) {
+    const { apiKey } = providerOptions;
+    const headers =
+      apiKey && apiKey.length > 0 ? { Authorization: `Bearer ${apiKey}` } : {};
+    // When API key is not provided, custom headers for `model-key` and `model-secret` will be used.
+    return headers;
+  },
+  getEndpoint({ fn }) {
+    switch (fn) {
+      case 'chatComplete': {
+        return '/chat/completions';
+      }
+      default:
+        return '';
+    }
+  },
+};

--- a/src/providers/modal/index.ts
+++ b/src/providers/modal/index.ts
@@ -1,0 +1,20 @@
+import { MODAL } from '../../globals';
+import {
+  chatCompleteParams,
+  completeParams,
+  responseTransformers,
+} from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import { ModalAPIConfig } from './api';
+
+export const ModalConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams([]),
+  complete: completeParams([]),
+  api: ModalAPIConfig,
+  responseTransforms: responseTransformers(MODAL, {
+    chatComplete: true,
+    complete: true,
+  }),
+};
+
+export default ModalConfig;


### PR DESCRIPTION
Backported from enterprise PR #642

This PR adds Modal Labs provider support and includes the necessary header keys to mask while logging.