### PR TITLE
fix: return null for empty tools in transformToolsConfig

### DIFF
--- a/src/providers/bedrock/utils/messagesUtils.ts
+++ b/src/providers/bedrock/utils/messagesUtils.ts
@@ -86,5 +86,8 @@ export const transformToolsConfig = (params: BedrockMessagesParams) => {
       }
     }
   }
+  if (tools.length === 0) {
+    return null;
+  }
   return { tools, toolChoice };
 };


### PR DESCRIPTION
## Description
This PR adds a fix for bedrock messagesUtils where we did not handle empty tool calls before. 

## Motivation
This was needed to fix claude code failing calls

## Type of Change
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

## How Has This Been Tested?
<!-- Describe the tests you ran to verify your changes -->
- [ ] Unit Tests
- [ ] Integration Tests
- [ ] Manual Testing

## Screenshots (if applicable)
<!-- Add screenshots to help explain your changes -->

## Checklist
<!-- Put an 'x' in the boxes that apply -->
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes

## Related Issues
<!-- Link related issues below. Insert the issue link or reference -->
