### PR TITLE
remove region identifier prefix when making request to count tokens endpoint

### DIFF
--- a/src/providers/anthropic/api.ts
+++ b/src/providers/anthropic/api.ts
@@ -3,12 +3,7 @@ import { ProviderAPIConfig } from '../types';
 const AnthropicAPIConfig: ProviderAPIConfig = {
   getBaseURL: () => 'https://api.anthropic.com/v1',
 
-  headers: ({
-    providerOptions,
-    fn,
-    headers: requestHeaders,
-    gatewayRequestBody,
-  }) => {
+  headers: ({ providerOptions, fn, gatewayRequestBody }) => {
     const apiKey =
       providerOptions.apiKey || providerOptions.anthropicApiKey || '';
     const headers: Record<string, string> = {

--- a/src/providers/bedrock/api.ts
+++ b/src/providers/bedrock/api.ts
@@ -7,6 +7,7 @@ import {
   generateAWSHeaders,
   getFoundationModelFromInferenceProfile,
   providerAssumedRoleCredentials,
+  getBedrockModelWithoutRegion,
 } from './utils';
 import { GatewayError } from '../../errors/GatewayError';
 
@@ -234,7 +235,10 @@ const BedrockAPIConfig: BedrockAPIConfigInterface = {
       return `/model-invocation-job/${batchId}/stop`;
     }
     const { model, stream } = gatewayRequestBody;
-    const uriEncodedModel = encodeURIComponent(decodeURIComponent(model ?? ''));
+    const decodedModel = decodeURIComponent(model ?? '');
+    const uriEncodedModel = encodeURIComponent(decodedModel);
+    const modelWithoutRegion = getBedrockModelWithoutRegion(decodedModel);
+    const uriEncodedModelWithoutRegion = encodeURIComponent(modelWithoutRegion);
     if (!model && !BEDROCK_NO_MODEL_ENDPOINTS.includes(fn as endpointStrings)) {
       throw new GatewayError('Model is required');
     }
@@ -305,7 +309,7 @@ const BedrockAPIConfig: BedrockAPIConfigInterface = {
         return `/model-customization-jobs/${jobId}/stop`;
       }
       case 'messagesCountTokens': {
-        return `/model/${uriEncodedModel}/count-tokens`;
+        return `/model/${uriEncodedModelWithoutRegion}/count-tokens`;
       }
       default:
         return '';

--- a/src/providers/bedrock/index.ts
+++ b/src/providers/bedrock/index.ts
@@ -85,6 +85,7 @@ import {
   BedrockConverseMessageCountTokensConfig,
   BedrockConverseMessageCountTokensResponseTransform,
 } from './countTokens';
+import { getBedrockModelWithoutRegion } from './utils';
 
 const BedrockConfig: ProviderConfigs = {
   api: BedrockAPIConfig,
@@ -101,7 +102,7 @@ const BedrockConfig: ProviderConfigs = {
 
     if (params.model) {
       let providerModel = providerOptions.foundationModel || params.model;
-      providerModel = providerModel.replace(/^(us\.|eu\.|apac\.)/, '');
+      providerModel = getBedrockModelWithoutRegion(providerModel);
       const providerModelArray = providerModel?.split('.');
       const provider = providerModelArray?.[0];
       const model = providerModelArray?.slice(1).join('.');

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -537,3 +537,7 @@ export const getBedrockErrorChunk = (id: string, model: string) => {
     `data: [DONE]\n\n`,
   ];
 };
+
+export const getBedrockModelWithoutRegion = (model: string) => {
+  return model.replace(/^(us\.|eu\.|apac\.|au\.|ca\.|jp\.|global\.)/, '');
+};


### PR DESCRIPTION
**Description:** (required)
- This removes region endpoint from url construction when making request to count tokens endpoint because it throws invalid model otherwise

**Tests Run/Test cases added:** (required)
- [x] Tested the count tokens endpoint for both anthropic and non anthropic models for with and without region prefix
example curl:
```sh
curl --location 'http://localhost:8787/v1/messages/count_tokens' \
--header 'x-portkey-provider: bedrock' \
--header 'Content-Type: application/json' \
--header 'x-portkey-aws-access-key-id: abc' \
--header 'x-portkey-aws-secret-access-key: abc' \
--header 'x-portkey-aws-region: us-west-2' \
--data-raw '{
    "model": "apac.anthropic.claude-sonnet-4-5-20250929-v1:0",
    "max_tokens": 10,
    "messages": [
      {
        "role": "user",
        "content": "hello there"
      }
    ]
    ]
  }'
```

**Type of Change:**
- [X] Bug fix (non-breaking change which fixes an issue)