### PR TITLE
Add length operator

### DIFF
--- a/src/services/conditionalRouter.ts
+++ b/src/services/conditionalRouter.ts
@@ -23,6 +23,7 @@ enum Operator {
   In = '$in',
   NotIn = '$nin',
   Regex = '$regex',
+  Length = '$length',
 
   // Logical Operators
   And = '$and',
@@ -125,6 +126,20 @@ export class ConditionalRouter {
           } catch (e) {
             return false;
           }
+        case Operator.Length:
+          if (!Array.isArray(value)) return false;
+          // compareValue could be a number or an object like {$gt: 5}
+          if (typeof compareValue === 'number') {
+            if (value.length !== compareValue) return false;
+          } else if (
+            typeof compareValue === 'object' &&
+            compareValue !== null
+          ) {
+            // Recursively evaluate the length with other operators
+            if (!this.evaluateOperator(compareValue, value.length))
+              return false;
+          }
+          break;
         default:
           throw new Error(
             `Unsupported operator used in the query router: ${op}`

--- a/tests/unit/src/services/conditionalRouter.test.ts
+++ b/tests/unit/src/services/conditionalRouter.test.ts
@@ -1,0 +1,512 @@
+import { ConditionalRouter } from '../../../../src/services/conditionalRouter';
+import { StrategyModes, Targets } from '../../../../src/types/requestBody';
+
+interface RouterContext {
+  metadata?: Record<string, any>;
+  params?: Record<string, any>;
+  url?: {
+    pathname: string;
+  };
+}
+
+describe('ConditionalRouter', () => {
+  describe('$length operator', () => {
+    it('should match when array length equals the specified number', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: 3 } },
+              then: 'target-1',
+            },
+          ],
+        },
+        targets: [{ name: 'target-1', virtualKey: 'vk1' }],
+      };
+
+      const context = {
+        params: {
+          messages: ['msg1', 'msg2', 'msg3'],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-1');
+      expect(result.index).toBe(0);
+    });
+
+    it('should not match when array length does not equal the specified number', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: 3 } },
+              then: 'target-1',
+            },
+          ],
+          default: 'target-2',
+        },
+        targets: [
+          { name: 'target-1', virtualKey: 'vk1' },
+          { name: 'target-2', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: ['msg1', 'msg2'],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-2');
+    });
+
+    it('should return false when value is not an array', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: 3 } },
+              then: 'target-1',
+            },
+          ],
+          default: 'target-2',
+        },
+        targets: [
+          { name: 'target-1', virtualKey: 'vk1' },
+          { name: 'target-2', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: 'not-an-array',
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-2');
+    });
+
+    it('should work with nested $gt operator', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: { $gt: 5 } } },
+              then: 'target-long-conversation',
+            },
+          ],
+          default: 'target-short-conversation',
+        },
+        targets: [
+          { name: 'target-long-conversation', virtualKey: 'vk1' },
+          { name: 'target-short-conversation', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: ['msg1', 'msg2', 'msg3', 'msg4', 'msg5', 'msg6'],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-long-conversation');
+    });
+
+    it('should work with nested $lt operator', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: { $lt: 3 } } },
+              then: 'target-short',
+            },
+          ],
+          default: 'target-long',
+        },
+        targets: [
+          { name: 'target-short', virtualKey: 'vk1' },
+          { name: 'target-long', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: ['msg1', 'msg2'],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-short');
+    });
+
+    it('should work with nested $gte operator', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: { $gte: 3 } } },
+              then: 'target-1',
+            },
+          ],
+          default: 'target-2',
+        },
+        targets: [
+          { name: 'target-1', virtualKey: 'vk1' },
+          { name: 'target-2', virtualKey: 'vk2' },
+        ],
+      };
+
+      const contextEqual = {
+        params: {
+          messages: ['msg1', 'msg2', 'msg3'],
+        },
+      };
+
+      const contextGreater = {
+        params: {
+          messages: ['msg1', 'msg2', 'msg3', 'msg4'],
+        },
+      };
+
+      const routerEqual = new ConditionalRouter(config, contextEqual);
+      expect(routerEqual.resolveTarget().name).toBe('target-1');
+
+      const routerGreater = new ConditionalRouter(config, contextGreater);
+      expect(routerGreater.resolveTarget().name).toBe('target-1');
+    });
+
+    it('should work with nested $lte operator', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: { $lte: 3 } } },
+              then: 'target-1',
+            },
+          ],
+          default: 'target-2',
+        },
+        targets: [
+          { name: 'target-1', virtualKey: 'vk1' },
+          { name: 'target-2', virtualKey: 'vk2' },
+        ],
+      };
+
+      const contextEqual = {
+        params: {
+          messages: ['msg1', 'msg2', 'msg3'],
+        },
+      };
+
+      const contextLess = {
+        params: {
+          messages: ['msg1', 'msg2'],
+        },
+      };
+
+      const routerEqual = new ConditionalRouter(config, contextEqual);
+      expect(routerEqual.resolveTarget().name).toBe('target-1');
+
+      const routerLess = new ConditionalRouter(config, contextLess);
+      expect(routerLess.resolveTarget().name).toBe('target-1');
+    });
+
+    it('should work with nested $eq operator', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: { $eq: 3 } } },
+              then: 'target-1',
+            },
+          ],
+          default: 'target-2',
+        },
+        targets: [
+          { name: 'target-1', virtualKey: 'vk1' },
+          { name: 'target-2', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: ['msg1', 'msg2', 'msg3'],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-1');
+    });
+
+    it('should work with nested $ne operator', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: { $ne: 3 } } },
+              then: 'target-1',
+            },
+          ],
+          default: 'target-2',
+        },
+        targets: [
+          { name: 'target-1', virtualKey: 'vk1' },
+          { name: 'target-2', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: ['msg1', 'msg2'],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-1');
+    });
+
+    it('should work with empty arrays', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: 0 } },
+              then: 'target-empty',
+            },
+          ],
+          default: 'target-not-empty',
+        },
+        targets: [
+          { name: 'target-empty', virtualKey: 'vk1' },
+          { name: 'target-not-empty', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: [],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-empty');
+    });
+
+    it('should work with $length in complex conditional queries', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: {
+                $and: [
+                  { 'params.messages': { $length: { $gt: 2 } } },
+                  { 'metadata.user': { $eq: 'premium' } },
+                ],
+              },
+              then: 'target-premium-long',
+            },
+            {
+              query: {
+                'params.messages': { $length: { $gt: 2 } },
+              },
+              then: 'target-long',
+            },
+          ],
+          default: 'target-default',
+        },
+        targets: [
+          { name: 'target-premium-long', virtualKey: 'vk1' },
+          { name: 'target-long', virtualKey: 'vk2' },
+          { name: 'target-default', virtualKey: 'vk3' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: ['msg1', 'msg2', 'msg3', 'msg4'],
+        },
+        metadata: {
+          user: 'premium',
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-premium-long');
+    });
+
+    it('should fall back to default when $length condition does not match', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'params.messages': { $length: { $gt: 10 } } },
+              then: 'target-very-long',
+            },
+          ],
+          default: 'target-default',
+        },
+        targets: [
+          { name: 'target-very-long', virtualKey: 'vk1' },
+          { name: 'target-default', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context = {
+        params: {
+          messages: ['msg1', 'msg2', 'msg3'],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-default');
+    });
+
+    it('should work with metadata arrays', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'metadata.tags': { $length: 2 } },
+              then: 'target-two-tags',
+            },
+          ],
+          default: 'target-other',
+        },
+        targets: [
+          { name: 'target-two-tags', virtualKey: 'vk1' },
+          { name: 'target-other', virtualKey: 'vk2' },
+        ],
+      };
+
+      const context: RouterContext = {
+        metadata: {
+          tags: ['tag1', 'tag2'],
+        },
+      };
+
+      const router = new ConditionalRouter(config, context as any);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-two-tags');
+    });
+  });
+
+  describe('other operators (existing functionality)', () => {
+    it('should work with $eq operator', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'metadata.user': { $eq: 'test-user' } },
+              then: 'target-1',
+            },
+          ],
+        },
+        targets: [{ name: 'target-1', virtualKey: 'vk1' }],
+      };
+
+      const context = {
+        metadata: {
+          user: 'test-user',
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+      const result = router.resolveTarget();
+
+      expect(result.name).toBe('target-1');
+    });
+
+    it('should throw error for unsupported operator', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'metadata.user': { $unsupported: 'value' } },
+              then: 'target-1',
+            },
+          ],
+        },
+        targets: [{ name: 'target-1', virtualKey: 'vk1' }],
+      };
+
+      const context = {
+        metadata: {
+          user: 'test-user',
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+
+      expect(() => router.resolveTarget()).toThrow(
+        'Unsupported operator used in the query router: $unsupported'
+      );
+    });
+
+    it('should throw error when no conditions matched and no default', () => {
+      const config: Targets = {
+        strategy: {
+          mode: StrategyModes.CONDITIONAL,
+          conditions: [
+            {
+              query: { 'metadata.user': { $eq: 'other-user' } },
+              then: 'target-1',
+            },
+          ],
+        },
+        targets: [{ name: 'target-1', virtualKey: 'vk1' }],
+      };
+
+      const context = {
+        metadata: {
+          user: 'test-user',
+        },
+      };
+
+      const router = new ConditionalRouter(config, context);
+
+      expect(() => router.resolveTarget()).toThrow(
+        'Query router did not resolve to any valid target'
+      );
+    });
+  });
+});


### PR DESCRIPTION
**Description:** (required)

Fixes #1438 

This pull request adds support for a new `$length` operator in the `ConditionalRouter` service, allowing conditional routing logic to evaluate the length of arrays. This enhancement makes it possible to write more expressive and flexible conditions based on array length, including direct comparisons or using other operators like `$gt` or `$lt` on the length.

**New Operator Support:**

* Added `Length` (`$length`) to the `Operator` enum in `conditionalRouter.ts` to enable length-based conditions.

**Conditional Evaluation Logic:**

* Implemented logic in `ConditionalRouter` to handle the `$length` operator, supporting both direct numeric comparisons and nested operator objects (e.g., `{ $gt: 5 }`) for array lengths.

**Tests Run/Test cases added:** (required)
- [x] Tests for all conditional operators

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)