### PR TITLE
fix: include thoughtsTokenCount in completion_tokens for Gemini

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -527,7 +527,7 @@ export const GoogleChatCompleteResponseTransform: (
         }) ?? [],
       usage: {
         prompt_tokens: promptTokenCount,
-        completion_tokens: candidatesTokenCount,
+        completion_tokens: candidatesTokenCount + thoughtsTokenCount,
         total_tokens: totalTokenCount,
         completion_tokens_details: {
           reasoning_tokens: thoughtsTokenCount,
@@ -625,7 +625,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
   if (parsedChunk.usageMetadata) {
     usageMetadata = {
       prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
-      completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
+      completion_tokens: (parsedChunk.usageMetadata.candidatesTokenCount ?? 0) + (parsedChunk.usageMetadata.thoughtsTokenCount ?? 0),
       total_tokens: parsedChunk.usageMetadata.totalTokenCount,
       completion_tokens_details: {
         reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -660,7 +660,7 @@ export const GoogleChatCompleteResponseTransform: (
         }) ?? [],
       usage: {
         prompt_tokens: promptTokenCount,
-        completion_tokens: candidatesTokenCount,
+        completion_tokens: candidatesTokenCount + thoughtsTokenCount,
         total_tokens: totalTokenCount,
         completion_tokens_details: {
           reasoning_tokens: thoughtsTokenCount,
@@ -713,7 +713,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
   if (parsedChunk.usageMetadata) {
     usageMetadata = {
       prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
-      completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
+      completion_tokens: (parsedChunk.usageMetadata.candidatesTokenCount ?? 0) + (parsedChunk.usageMetadata.thoughtsTokenCount ?? 0),
       total_tokens: parsedChunk.usageMetadata.totalTokenCount,
       completion_tokens_details: {
         reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,


### PR DESCRIPTION
- `completion_tokens` now includes `thoughtsTokenCount` for Gemini thinking models
- Fixes both streaming and non-streaming responses
- Aligns with OpenAI format where `completion_tokens` is the total (reasoning + output)
- `completion_tokens_details.reasoning_tokens` provides the breakdown

**Problem:**
- Gemini returns `candidatesTokenCount` (output) and `thoughtsTokenCount` (reasoning) separately
- OpenAI format expects `completion_tokens` to be the sum of both
- Previously only `candidatesTokenCount` was used

**Changes:**
- `src/providers/google/chatComplete.ts`
- `src/providers/google-vertex-ai/chatComplete.ts`