### PR TITLE
fix: Gemini completion tokens should include reasoning tokens

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -876,6 +876,7 @@ export function constructConfigFromRequestHeaders(
     azureEntraTenantId: requestHeaders[`x-${POWERED_BY}-azure-entra-tenant-id`],
     azureEntraScope: requestHeaders[`x-${POWERED_BY}-azure-entra-scope`],
     azureExtraParameters: requestHeaders[`x-${POWERED_BY}-azure-extra-params`],
+    anthropicVersion: requestHeaders[`x-${POWERED_BY}-anthropic-version`],
   };
 
   const awsConfig = {

--- a/src/providers/azure-ai-inference/index.ts
+++ b/src/providers/azure-ai-inference/index.ts
@@ -25,47 +25,69 @@ import {
   AzureAIInferenceCreateTranslationResponseTransform,
   AzureAIInferenceResponseTransform,
 } from './utils';
+import {
+  AnthropicChatCompleteConfig,
+  AnthropicChatCompleteResponseTransform,
+} from '../anthropic/chatComplete';
+import {
+  AzureAIInferenceMessagesConfig,
+  AzureAIInferenceMessagesResponseTransform,
+} from './messages';
 
 const AzureAIInferenceAPIConfig: ProviderConfigs = {
-  complete: AzureAIInferenceCompleteConfig,
-  embed: AzureAIInferenceEmbedConfig,
   api: AzureAIInferenceAPI,
-  chatComplete: AzureAIInferenceChatCompleteConfig,
-  imageGenerate: AzureOpenAIImageGenerateConfig,
-  imageEdit: {},
-  createSpeech: AzureOpenAICreateSpeechConfig,
-  createFinetune: OpenAICreateFinetuneConfig,
-  createTranscription: {},
-  createTranslation: {},
-  realtime: {},
-  cancelBatch: {},
-  createBatch: AzureOpenAICreateBatchConfig,
-  cancelFinetune: {},
-  requestHandlers: {
-    getBatchOutput: AzureAIInferenceGetBatchOutputRequestHandler,
-  },
-  requestTransforms: {
-    uploadFile: OpenAIFileUploadRequestTransform,
-  },
-  responseTransforms: {
-    complete: AzureAIInferenceCompleteResponseTransform(AZURE_AI_INFERENCE),
-    chatComplete:
-      AzureAIInferenceChatCompleteResponseTransform(AZURE_AI_INFERENCE),
-    embed: AzureAIInferenceEmbedResponseTransform(AZURE_AI_INFERENCE),
-    imageGenerate: AzureAIInferenceResponseTransform,
-    createSpeech: AzureAIInferenceCreateSpeechResponseTransform,
-    createTranscription: AzureAIInferenceCreateTranscriptionResponseTransform,
-    createTranslation: AzureAIInferenceCreateTranslationResponseTransform,
-    realtime: {},
-    createBatch: AzureAIInferenceResponseTransform,
-    retrieveBatch: AzureAIInferenceResponseTransform,
-    cancelBatch: AzureAIInferenceResponseTransform,
-    listBatches: AzureAIInferenceResponseTransform,
-    uploadFile: AzureAIInferenceResponseTransform,
-    listFiles: AzureAIInferenceResponseTransform,
-    retrieveFile: AzureAIInferenceResponseTransform,
-    deleteFile: AzureAIInferenceResponseTransform,
-    retrieveFileContent: AzureAIInferenceResponseTransform,
+  getConfig: ({ providerOptions }) => {
+    const { azureFoundryUrl } = providerOptions || {};
+    const isAnthropicModel = azureFoundryUrl?.includes('anthropic');
+    const chatCompleteConfig = isAnthropicModel
+      ? AnthropicChatCompleteConfig
+      : AzureAIInferenceChatCompleteConfig;
+    const chatCompleteResponseTransform = isAnthropicModel
+      ? AnthropicChatCompleteResponseTransform
+      : AzureAIInferenceChatCompleteResponseTransform(AZURE_AI_INFERENCE);
+    return {
+      complete: AzureAIInferenceCompleteConfig,
+      embed: AzureAIInferenceEmbedConfig,
+      chatComplete: chatCompleteConfig,
+      messages: AzureAIInferenceMessagesConfig,
+      imageGenerate: AzureOpenAIImageGenerateConfig,
+      imageEdit: {},
+      createSpeech: AzureOpenAICreateSpeechConfig,
+      createFinetune: OpenAICreateFinetuneConfig,
+      createTranscription: {},
+      createTranslation: {},
+      realtime: {},
+      cancelBatch: {},
+      createBatch: AzureOpenAICreateBatchConfig,
+      cancelFinetune: {},
+      requestHandlers: {
+        getBatchOutput: AzureAIInferenceGetBatchOutputRequestHandler,
+      },
+      requestTransforms: {
+        uploadFile: OpenAIFileUploadRequestTransform,
+      },
+      responseTransforms: {
+        complete: AzureAIInferenceCompleteResponseTransform(AZURE_AI_INFERENCE),
+        chatComplete: chatCompleteResponseTransform,
+        messages: AzureAIInferenceMessagesResponseTransform,
+        embed: AzureAIInferenceEmbedResponseTransform(AZURE_AI_INFERENCE),
+        imageGenerate: AzureAIInferenceResponseTransform,
+        createSpeech: AzureAIInferenceCreateSpeechResponseTransform,
+        createTranscription:
+          AzureAIInferenceCreateTranscriptionResponseTransform,
+        createTranslation: AzureAIInferenceCreateTranslationResponseTransform,
+        realtime: {},
+        createBatch: AzureAIInferenceResponseTransform,
+        retrieveBatch: AzureAIInferenceResponseTransform,
+        cancelBatch: AzureAIInferenceResponseTransform,
+        listBatches: AzureAIInferenceResponseTransform,
+        uploadFile: AzureAIInferenceResponseTransform,
+        listFiles: AzureAIInferenceResponseTransform,
+        retrieveFile: AzureAIInferenceResponseTransform,
+        deleteFile: AzureAIInferenceResponseTransform,
+        retrieveFileContent: AzureAIInferenceResponseTransform,
+      },
+    };
   },
 };
 

--- a/src/providers/azure-ai-inference/messages.ts
+++ b/src/providers/azure-ai-inference/messages.ts
@@ -1,0 +1,25 @@
+import { AZURE_AI_INFERENCE } from '../../globals';
+import { MessagesResponse } from '../../types/messagesResponse';
+import { getMessagesConfig } from '../anthropic-base/messages';
+import { AnthropicErrorResponse } from '../anthropic/types';
+import { AnthropicErrorResponseTransform } from '../anthropic/utils';
+import { ErrorResponse } from '../types';
+import { generateInvalidProviderResponseError } from '../utils';
+
+export const AzureAIInferenceMessagesConfig = getMessagesConfig({});
+
+export const AzureAIInferenceMessagesResponseTransform = (
+  response: MessagesResponse | AnthropicErrorResponse,
+  responseStatus: number
+): MessagesResponse | ErrorResponse => {
+  if (responseStatus !== 200) {
+    const errorResposne = AnthropicErrorResponseTransform(
+      response as AnthropicErrorResponse
+    );
+    if (errorResposne) return errorResposne;
+  }
+
+  if ('model' in response) return response;
+
+  return generateInvalidProviderResponseError(response, AZURE_AI_INFERENCE);
+};

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -527,7 +527,7 @@ export const GoogleChatCompleteResponseTransform: (
         }) ?? [],
       usage: {
         prompt_tokens: promptTokenCount,
-        completion_tokens: candidatesTokenCount,
+        completion_tokens: candidatesTokenCount + thoughtsTokenCount,
         total_tokens: totalTokenCount,
         completion_tokens_details: {
           reasoning_tokens: thoughtsTokenCount,
@@ -625,7 +625,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
   if (parsedChunk.usageMetadata) {
     usageMetadata = {
       prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
-      completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
+      completion_tokens:
+        parsedChunk.usageMetadata.candidatesTokenCount +
+        (parsedChunk.usageMetadata.thoughtsTokenCount ?? 0),
       total_tokens: parsedChunk.usageMetadata.totalTokenCount,
       completion_tokens_details: {
         reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -660,7 +660,7 @@ export const GoogleChatCompleteResponseTransform: (
         }) ?? [],
       usage: {
         prompt_tokens: promptTokenCount,
-        completion_tokens: candidatesTokenCount,
+        completion_tokens: candidatesTokenCount + thoughtsTokenCount,
         total_tokens: totalTokenCount,
         completion_tokens_details: {
           reasoning_tokens: thoughtsTokenCount,
@@ -713,7 +713,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
   if (parsedChunk.usageMetadata) {
     usageMetadata = {
       prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
-      completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
+      completion_tokens:
+        parsedChunk.usageMetadata.candidatesTokenCount +
+        (parsedChunk.usageMetadata.thoughtsTokenCount ?? 0),
       total_tokens: parsedChunk.usageMetadata.totalTokenCount,
       completion_tokens_details: {
         reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,


### PR DESCRIPTION
- **Update gemini response transform: calculate completion_tokens as the sum of candidatesTokenCount and thoughtsTokenCount to match OpenAI API expectations**

**Description:** (required)
- Calculates `completion_tokens` as the sum of `candidatesTokenCount` and `thoughtsTokenCount` to match the convention of the OpenAI API.
- Adds this update for both `gemini` and `vertex-ai`

**Tests Run/Test cases added:** (required)
- No additional tests added
- Need to add testing credential to run tests

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
