### PR TITLE
Update gemini response transform: calculate completion_tokens as the sum of candidatesTokenCount and thoughtsTokenCount to match OpenAI API expectations

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -527,7 +527,7 @@ export const GoogleChatCompleteResponseTransform: (
         }) ?? [],
       usage: {
         prompt_tokens: promptTokenCount,
-        completion_tokens: candidatesTokenCount,
+        completion_tokens: candidatesTokenCount + thoughtsTokenCount,
         total_tokens: totalTokenCount,
         completion_tokens_details: {
           reasoning_tokens: thoughtsTokenCount,
@@ -625,7 +625,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
   if (parsedChunk.usageMetadata) {
     usageMetadata = {
       prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
-      completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
+      completion_tokens:
+        parsedChunk.usageMetadata.candidatesTokenCount +
+        (parsedChunk.usageMetadata.thoughtsTokenCount ?? 0),
       total_tokens: parsedChunk.usageMetadata.totalTokenCount,
       completion_tokens_details: {
         reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -660,7 +660,7 @@ export const GoogleChatCompleteResponseTransform: (
         }) ?? [],
       usage: {
         prompt_tokens: promptTokenCount,
-        completion_tokens: candidatesTokenCount,
+        completion_tokens: candidatesTokenCount + thoughtsTokenCount,
         total_tokens: totalTokenCount,
         completion_tokens_details: {
           reasoning_tokens: thoughtsTokenCount,
@@ -713,7 +713,9 @@ export const GoogleChatCompleteStreamChunkTransform: (
   if (parsedChunk.usageMetadata) {
     usageMetadata = {
       prompt_tokens: parsedChunk.usageMetadata.promptTokenCount,
-      completion_tokens: parsedChunk.usageMetadata.candidatesTokenCount,
+      completion_tokens:
+        parsedChunk.usageMetadata.candidatesTokenCount +
+        (parsedChunk.usageMetadata.thoughtsTokenCount ?? 0),
       total_tokens: parsedChunk.usageMetadata.totalTokenCount,
       completion_tokens_details: {
         reasoning_tokens: parsedChunk.usageMetadata.thoughtsTokenCount ?? 0,


### PR DESCRIPTION
**Description:**
With the OpenAI API, `completion_tokens` is meant to be the total number of completions tokens, including the ones further specified in `completion_tokens_details`, like `reasoning_tokens`. The current behavior of the `google` provider in portkey is to return them separately, which leads to incorrect usage calculations down the line.

This PR tries to fix this by:
- Calculating `completion_tokens` as the sum of `candidatesTokenCount` and `thoughtsTokenCount` to match the convention of the OpenAI API. I think this should probably also apply to `audio_tokens`, but i'm not as confident there, which is why i'm focusing on reasoning first with this PR.
- Adding this update for both `google` and `google-vertex-ai` providers.

**Tests Run/Test cases added:**
- No additional tests added
- Unfortunately, i wasn't able to run all the tests due to missing credentials

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
