### PR TITLE
feat: add openai compatible response support for anthropic on azure

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -1,4 +1,4 @@
-import { ANTHROPIC, fileExtensionMimeTypeMap } from '../../globals';
+import { fileExtensionMimeTypeMap } from '../../globals';
 import {
   Params,
   Message,

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -518,7 +518,7 @@ export const getAnthropicChatCompleteResponseTransform = (provider: string) => {
     strictOpenAiCompliance
   ) => {
     if (responseStatus !== 200 && 'error' in response) {
-      return AnthropicErrorResponseTransform(response);
+      return AnthropicErrorResponseTransform(response, provider);
     }
 
     if ('content' in response) {

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -505,187 +505,290 @@ export interface AnthropicChatCompleteStreamResponse {
   error?: AnthropicErrorObject;
 }
 
-// TODO: The token calculation is wrong atm
-export const AnthropicChatCompleteResponseTransform: (
-  response: AnthropicChatCompleteResponse | AnthropicErrorResponse,
-  responseStatus: number,
-  responseHeaders: Headers,
-  strictOpenAiCompliance: boolean
-) => ChatCompletionResponse | ErrorResponse = (
-  response,
-  responseStatus,
-  _responseHeaders,
-  strictOpenAiCompliance
-) => {
-  if (responseStatus !== 200 && 'error' in response) {
-    return AnthropicErrorResponseTransform(response);
-  }
+export const getAnthropicChatCompleteResponseTransform = (provider: string) => {
+  const AnthropicChatCompleteResponseTransform: (
+    response: AnthropicChatCompleteResponse | AnthropicErrorResponse,
+    responseStatus: number,
+    responseHeaders: Headers,
+    strictOpenAiCompliance: boolean
+  ) => ChatCompletionResponse | ErrorResponse = (
+    response,
+    responseStatus,
+    _responseHeaders,
+    strictOpenAiCompliance
+  ) => {
+    if (responseStatus !== 200 && 'error' in response) {
+      return AnthropicErrorResponseTransform(response);
+    }
 
-  if ('content' in response) {
-    const {
-      input_tokens = 0,
-      output_tokens = 0,
-      cache_creation_input_tokens,
-      cache_read_input_tokens,
-    } = response?.usage;
+    if ('content' in response) {
+      const {
+        input_tokens = 0,
+        output_tokens = 0,
+        cache_creation_input_tokens,
+        cache_read_input_tokens,
+      } = response?.usage;
 
-    const shouldSendCacheUsage =
-      cache_creation_input_tokens || cache_read_input_tokens;
+      const shouldSendCacheUsage =
+        cache_creation_input_tokens || cache_read_input_tokens;
 
-    let content: string = '';
-    response.content.forEach((item) => {
-      if (item.type === 'text') {
-        content += item.text;
-      }
-    });
+      let content: string = '';
+      response.content.forEach((item) => {
+        if (item.type === 'text') {
+          content += item.text;
+        }
+      });
 
-    let toolCalls: any = [];
-    response.content.forEach((item) => {
-      if (item.type === 'tool_use') {
-        toolCalls.push({
-          id: item.id,
-          type: 'function',
-          function: {
-            name: item.name,
-            arguments: JSON.stringify(item.input),
-          },
-        });
-      }
-    });
+      let toolCalls: any = [];
+      response.content.forEach((item) => {
+        if (item.type === 'tool_use') {
+          toolCalls.push({
+            id: item.id,
+            type: 'function',
+            function: {
+              name: item.name,
+              arguments: JSON.stringify(item.input),
+            },
+          });
+        }
+      });
 
-    return {
-      id: response.id,
-      object: 'chat.completion',
-      created: Math.floor(Date.now() / 1000),
-      model: response.model,
-      provider: ANTHROPIC,
-      choices: [
-        {
-          message: {
-            role: 'assistant',
-            content,
-            ...(!strictOpenAiCompliance && {
-              content_blocks: response.content.filter(
-                (item) => item.type !== 'tool_use'
-              ),
-            }),
-            tool_calls: toolCalls.length ? toolCalls : undefined,
-          },
-          index: 0,
-          logprobs: null,
-          finish_reason: transformFinishReason(
-            response.stop_reason,
-            strictOpenAiCompliance
-          ),
-        },
-      ],
-      usage: {
-        prompt_tokens: input_tokens,
-        completion_tokens: output_tokens,
-        total_tokens:
-          input_tokens +
-          output_tokens +
-          (cache_creation_input_tokens ?? 0) +
-          (cache_read_input_tokens ?? 0),
-        prompt_tokens_details: {
-          cached_tokens: cache_read_input_tokens ?? 0,
-        },
-        ...(shouldSendCacheUsage && {
-          cache_read_input_tokens: cache_read_input_tokens,
-          cache_creation_input_tokens: cache_creation_input_tokens,
-        }),
-      },
-    };
-  }
-
-  return generateInvalidProviderResponseError(response, ANTHROPIC);
-};
-
-export const AnthropicChatCompleteStreamChunkTransform: (
-  response: string,
-  fallbackId: string,
-  streamState: AnthropicStreamState,
-  _strictOpenAiCompliance: boolean
-) => string | undefined = (
-  responseChunk,
-  fallbackId,
-  streamState,
-  strictOpenAiCompliance
-) => {
-  if (streamState.toolIndex == undefined) {
-    streamState.toolIndex = -1;
-  }
-  let chunk = responseChunk.trim();
-  if (
-    chunk.startsWith('event: ping') ||
-    chunk.startsWith('event: content_block_stop')
-  ) {
-    return;
-  }
-
-  if (chunk.startsWith('event: message_stop')) {
-    return 'data: [DONE]\n\n';
-  }
-
-  chunk = chunk.replace(/^event: content_block_delta[\r\n]*/, '');
-  chunk = chunk.replace(/^event: content_block_start[\r\n]*/, '');
-  chunk = chunk.replace(/^event: message_delta[\r\n]*/, '');
-  chunk = chunk.replace(/^event: message_start[\r\n]*/, '');
-  chunk = chunk.replace(/^event: error[\r\n]*/, '');
-  chunk = chunk.replace(/^data: /, '');
-  chunk = chunk.trim();
-
-  const parsedChunk: AnthropicChatCompleteStreamResponse = JSON.parse(chunk);
-
-  if (parsedChunk.type === 'error' && parsedChunk.error) {
-    return (
-      `data: ${JSON.stringify({
-        id: fallbackId,
-        object: 'chat.completion.chunk',
+      return {
+        id: response.id,
+        object: 'chat.completion',
         created: Math.floor(Date.now() / 1000),
-        model: '',
-        provider: ANTHROPIC,
+        model: response.model,
+        provider: provider,
         choices: [
           {
-            finish_reason: parsedChunk.error.type,
-            delta: {
-              content: '',
+            message: {
+              role: 'assistant',
+              content,
+              ...(!strictOpenAiCompliance && {
+                content_blocks: response.content.filter(
+                  (item) => item.type !== 'tool_use'
+                ),
+              }),
+              tool_calls: toolCalls.length ? toolCalls : undefined,
             },
+            index: 0,
+            logprobs: null,
+            finish_reason: transformFinishReason(
+              response.stop_reason,
+              strictOpenAiCompliance
+            ),
           },
         ],
-      })}` +
-      '\n\n' +
-      'data: [DONE]\n\n'
-    );
-  }
+        usage: {
+          prompt_tokens: input_tokens,
+          completion_tokens: output_tokens,
+          total_tokens:
+            input_tokens +
+            output_tokens +
+            (cache_creation_input_tokens ?? 0) +
+            (cache_read_input_tokens ?? 0),
+          prompt_tokens_details: {
+            cached_tokens: cache_read_input_tokens ?? 0,
+          },
+          ...(shouldSendCacheUsage && {
+            cache_read_input_tokens: cache_read_input_tokens,
+            cache_creation_input_tokens: cache_creation_input_tokens,
+          }),
+        },
+      };
+    }
 
-  const shouldSendCacheUsage =
-    parsedChunk.message?.usage?.cache_read_input_tokens ||
-    parsedChunk.message?.usage?.cache_creation_input_tokens;
+    return generateInvalidProviderResponseError(response, provider);
+  };
+  return AnthropicChatCompleteResponseTransform;
+};
 
-  if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
-    streamState.model = parsedChunk?.message?.model ?? '';
-    streamState.usage = {
-      prompt_tokens: parsedChunk.message?.usage?.input_tokens,
-      ...(shouldSendCacheUsage && {
-        cache_read_input_tokens:
-          parsedChunk.message?.usage?.cache_read_input_tokens,
-        cache_creation_input_tokens:
-          parsedChunk.message?.usage?.cache_creation_input_tokens,
-      }),
+export const getAnthropicStreamChunkTransform = (provider: string) => {
+  const AnthropicChatCompleteStreamChunkTransform: (
+    response: string,
+    fallbackId: string,
+    streamState: AnthropicStreamState,
+    _strictOpenAiCompliance: boolean
+  ) => string | undefined = (
+    responseChunk,
+    fallbackId,
+    streamState,
+    strictOpenAiCompliance
+  ) => {
+    if (streamState.toolIndex == undefined) {
+      streamState.toolIndex = -1;
+    }
+    let chunk = responseChunk.trim();
+    if (
+      chunk.startsWith('event: ping') ||
+      chunk.startsWith('event: content_block_stop')
+    ) {
+      return;
+    }
+
+    if (chunk.startsWith('event: message_stop')) {
+      return 'data: [DONE]\n\n';
+    }
+
+    chunk = chunk.replace(/^event: content_block_delta[\r\n]*/, '');
+    chunk = chunk.replace(/^event: content_block_start[\r\n]*/, '');
+    chunk = chunk.replace(/^event: message_delta[\r\n]*/, '');
+    chunk = chunk.replace(/^event: message_start[\r\n]*/, '');
+    chunk = chunk.replace(/^event: error[\r\n]*/, '');
+    chunk = chunk.replace(/^data: /, '');
+    chunk = chunk.trim();
+
+    const parsedChunk: AnthropicChatCompleteStreamResponse = JSON.parse(chunk);
+
+    if (parsedChunk.type === 'error' && parsedChunk.error) {
+      return (
+        `data: ${JSON.stringify({
+          id: fallbackId,
+          object: 'chat.completion.chunk',
+          created: Math.floor(Date.now() / 1000),
+          model: '',
+          provider: provider,
+          choices: [
+            {
+              finish_reason: parsedChunk.error.type,
+              delta: {
+                content: '',
+              },
+            },
+          ],
+        })}` +
+        '\n\n' +
+        'data: [DONE]\n\n'
+      );
+    }
+
+    const shouldSendCacheUsage =
+      parsedChunk.message?.usage?.cache_read_input_tokens ||
+      parsedChunk.message?.usage?.cache_creation_input_tokens;
+
+    if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
+      streamState.model = parsedChunk?.message?.model ?? '';
+      streamState.usage = {
+        prompt_tokens: parsedChunk.message?.usage?.input_tokens,
+        ...(shouldSendCacheUsage && {
+          cache_read_input_tokens:
+            parsedChunk.message?.usage?.cache_read_input_tokens,
+          cache_creation_input_tokens:
+            parsedChunk.message?.usage?.cache_creation_input_tokens,
+        }),
+      };
+      return (
+        `data: ${JSON.stringify({
+          id: fallbackId,
+          object: 'chat.completion.chunk',
+          created: Math.floor(Date.now() / 1000),
+          model: streamState.model,
+          provider: provider,
+          choices: [
+            {
+              delta: {
+                content: '',
+                role: 'assistant',
+              },
+              index: 0,
+              logprobs: null,
+              finish_reason: null,
+            },
+          ],
+        })}` + '\n\n'
+      );
+    }
+
+    // final chunk
+    if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
+      const totalTokens =
+        (streamState?.usage?.prompt_tokens ?? 0) +
+        (streamState?.usage?.cache_creation_input_tokens ?? 0) +
+        (streamState?.usage?.cache_read_input_tokens ?? 0) +
+        (parsedChunk.usage.output_tokens ?? 0);
+      return (
+        `data: ${JSON.stringify({
+          id: fallbackId,
+          object: 'chat.completion.chunk',
+          created: Math.floor(Date.now() / 1000),
+          model: streamState.model,
+          provider: provider,
+          choices: [
+            {
+              index: 0,
+              delta: {},
+              finish_reason: transformFinishReason(
+                parsedChunk.delta?.stop_reason,
+                strictOpenAiCompliance
+              ),
+            },
+          ],
+          usage: {
+            ...streamState.usage,
+            completion_tokens: parsedChunk.usage?.output_tokens,
+            total_tokens: totalTokens,
+            prompt_tokens_details: {
+              cached_tokens: streamState.usage?.cache_read_input_tokens ?? 0,
+            },
+          },
+        })}` + '\n\n'
+      );
+    }
+
+    const toolCalls = [];
+    const isToolBlockStart: boolean =
+      parsedChunk.type === 'content_block_start' &&
+      parsedChunk.content_block?.type === 'tool_use';
+    if (isToolBlockStart) {
+      streamState.toolIndex = streamState.toolIndex + 1;
+    }
+    const isToolBlockDelta: boolean =
+      parsedChunk.type === 'content_block_delta' &&
+      parsedChunk.delta?.partial_json != undefined;
+
+    if (isToolBlockStart && parsedChunk.content_block) {
+      toolCalls.push({
+        index: streamState.toolIndex,
+        id: parsedChunk.content_block.id,
+        type: 'function',
+        function: {
+          name: parsedChunk.content_block.name,
+          arguments: '',
+        },
+      });
+    } else if (isToolBlockDelta) {
+      toolCalls.push({
+        index: streamState.toolIndex,
+        function: {
+          arguments: parsedChunk.delta.partial_json,
+        },
+      });
+    }
+
+    const content = parsedChunk.delta?.text;
+
+    const contentBlockObject = {
+      index: parsedChunk.index,
+      delta: parsedChunk.delta ?? parsedChunk.content_block ?? {},
     };
+    delete contentBlockObject.delta.type;
+
     return (
       `data: ${JSON.stringify({
         id: fallbackId,
         object: 'chat.completion.chunk',
         created: Math.floor(Date.now() / 1000),
         model: streamState.model,
-        provider: ANTHROPIC,
+        provider: provider,
         choices: [
           {
             delta: {
-              content: '',
-              role: 'assistant',
+              content,
+              tool_calls: toolCalls.length ? toolCalls : undefined,
+              ...(!strictOpenAiCompliance &&
+                !toolCalls.length && {
+                  content_blocks: [contentBlockObject],
+                }),
             },
             index: 0,
             logprobs: null,
@@ -694,104 +797,6 @@ export const AnthropicChatCompleteStreamChunkTransform: (
         ],
       })}` + '\n\n'
     );
-  }
-
-  // final chunk
-  if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
-    const totalTokens =
-      (streamState?.usage?.prompt_tokens ?? 0) +
-      (streamState?.usage?.cache_creation_input_tokens ?? 0) +
-      (streamState?.usage?.cache_read_input_tokens ?? 0) +
-      (parsedChunk.usage.output_tokens ?? 0);
-    return (
-      `data: ${JSON.stringify({
-        id: fallbackId,
-        object: 'chat.completion.chunk',
-        created: Math.floor(Date.now() / 1000),
-        model: streamState.model,
-        provider: ANTHROPIC,
-        choices: [
-          {
-            index: 0,
-            delta: {},
-            finish_reason: transformFinishReason(
-              parsedChunk.delta?.stop_reason,
-              strictOpenAiCompliance
-            ),
-          },
-        ],
-        usage: {
-          ...streamState.usage,
-          completion_tokens: parsedChunk.usage?.output_tokens,
-          total_tokens: totalTokens,
-          prompt_tokens_details: {
-            cached_tokens: streamState.usage?.cache_read_input_tokens ?? 0,
-          },
-        },
-      })}` + '\n\n'
-    );
-  }
-
-  const toolCalls = [];
-  const isToolBlockStart: boolean =
-    parsedChunk.type === 'content_block_start' &&
-    parsedChunk.content_block?.type === 'tool_use';
-  if (isToolBlockStart) {
-    streamState.toolIndex = streamState.toolIndex + 1;
-  }
-  const isToolBlockDelta: boolean =
-    parsedChunk.type === 'content_block_delta' &&
-    parsedChunk.delta?.partial_json != undefined;
-
-  if (isToolBlockStart && parsedChunk.content_block) {
-    toolCalls.push({
-      index: streamState.toolIndex,
-      id: parsedChunk.content_block.id,
-      type: 'function',
-      function: {
-        name: parsedChunk.content_block.name,
-        arguments: '',
-      },
-    });
-  } else if (isToolBlockDelta) {
-    toolCalls.push({
-      index: streamState.toolIndex,
-      function: {
-        arguments: parsedChunk.delta.partial_json,
-      },
-    });
-  }
-
-  const content = parsedChunk.delta?.text;
-
-  const contentBlockObject = {
-    index: parsedChunk.index,
-    delta: parsedChunk.delta ?? parsedChunk.content_block ?? {},
   };
-  delete contentBlockObject.delta.type;
-
-  return (
-    `data: ${JSON.stringify({
-      id: fallbackId,
-      object: 'chat.completion.chunk',
-      created: Math.floor(Date.now() / 1000),
-      model: streamState.model,
-      provider: ANTHROPIC,
-      choices: [
-        {
-          delta: {
-            content,
-            tool_calls: toolCalls.length ? toolCalls : undefined,
-            ...(!strictOpenAiCompliance &&
-              !toolCalls.length && {
-                content_blocks: [contentBlockObject],
-              }),
-          },
-          index: 0,
-          logprobs: null,
-          finish_reason: null,
-        },
-      ],
-    })}` + '\n\n'
-  );
+  return AnthropicChatCompleteStreamChunkTransform;
 };

--- a/src/providers/anthropic/complete.ts
+++ b/src/providers/anthropic/complete.ts
@@ -86,7 +86,8 @@ export const AnthropicCompleteResponseTransform: (
 ) => {
   if (responseStatus !== 200) {
     const errorResposne = AnthropicErrorResponseTransform(
-      response as AnthropicErrorResponse
+      response as AnthropicErrorResponse,
+      ANTHROPIC
     );
     if (errorResposne) return errorResposne;
   }

--- a/src/providers/anthropic/index.ts
+++ b/src/providers/anthropic/index.ts
@@ -1,9 +1,10 @@
+import { ANTHROPIC } from '../../globals';
 import { ProviderConfigs } from '../types';
 import AnthropicAPIConfig from './api';
 import {
   AnthropicChatCompleteConfig,
-  AnthropicChatCompleteResponseTransform,
-  AnthropicChatCompleteStreamChunkTransform,
+  getAnthropicChatCompleteResponseTransform,
+  getAnthropicStreamChunkTransform,
 } from './chatComplete';
 import {
   AnthropicCompleteConfig,
@@ -24,8 +25,8 @@ const AnthropicConfig: ProviderConfigs = {
   responseTransforms: {
     'stream-complete': AnthropicCompleteStreamChunkTransform,
     complete: AnthropicCompleteResponseTransform,
-    chatComplete: AnthropicChatCompleteResponseTransform,
-    'stream-chatComplete': AnthropicChatCompleteStreamChunkTransform,
+    chatComplete: getAnthropicChatCompleteResponseTransform(ANTHROPIC),
+    'stream-chatComplete': getAnthropicStreamChunkTransform(ANTHROPIC),
     messages: AnthropicMessagesResponseTransform,
   },
 };

--- a/src/providers/anthropic/messages.ts
+++ b/src/providers/anthropic/messages.ts
@@ -13,7 +13,7 @@ export const AnthropicMessagesResponseTransform = (
   responseStatus: number
 ): MessagesResponse | ErrorResponse => {
   if (responseStatus !== 200 && 'error' in response) {
-    return AnthropicErrorResponseTransform(response);
+    return AnthropicErrorResponseTransform(response, ANTHROPIC);
   }
 
   if ('model' in response) return response;

--- a/src/providers/anthropic/utils.ts
+++ b/src/providers/anthropic/utils.ts
@@ -4,8 +4,9 @@ import { generateErrorResponse } from '../utils';
 import { AnthropicErrorResponse } from './types';
 
 export const AnthropicErrorResponseTransform: (
-  response: AnthropicErrorResponse
-) => ErrorResponse = (response) => {
+  response: AnthropicErrorResponse,
+  provider: string
+) => ErrorResponse = (response, provider) => {
   return generateErrorResponse(
     {
       message: response.error?.message,
@@ -13,6 +14,6 @@ export const AnthropicErrorResponseTransform: (
       param: null,
       code: null,
     },
-    ANTHROPIC
+    provider
   );
 };

--- a/src/providers/anthropic/utils.ts
+++ b/src/providers/anthropic/utils.ts
@@ -1,4 +1,3 @@
-import { ANTHROPIC } from '../../globals';
 import { ErrorResponse } from '../types';
 import { generateErrorResponse } from '../utils';
 import { AnthropicErrorResponse } from './types';

--- a/src/providers/azure-ai-inference/index.ts
+++ b/src/providers/azure-ai-inference/index.ts
@@ -27,8 +27,8 @@ import {
 } from './utils';
 import {
   AnthropicChatCompleteConfig,
-  AnthropicChatCompleteResponseTransform,
-  AnthropicChatCompleteStreamChunkTransform,
+  getAnthropicChatCompleteResponseTransform,
+  getAnthropicStreamChunkTransform,
 } from '../anthropic/chatComplete';
 import {
   AzureAIInferenceMessagesConfig,
@@ -44,7 +44,7 @@ const AzureAIInferenceAPIConfig: ProviderConfigs = {
       ? AnthropicChatCompleteConfig
       : AzureAIInferenceChatCompleteConfig;
     const chatCompleteResponseTransform = isAnthropicModel
-      ? AnthropicChatCompleteResponseTransform
+      ? getAnthropicChatCompleteResponseTransform(AZURE_AI_INFERENCE)
       : AzureAIInferenceChatCompleteResponseTransform(AZURE_AI_INFERENCE);
     return {
       complete: AzureAIInferenceCompleteConfig,
@@ -70,7 +70,8 @@ const AzureAIInferenceAPIConfig: ProviderConfigs = {
       responseTransforms: {
         complete: AzureAIInferenceCompleteResponseTransform(AZURE_AI_INFERENCE),
         ...(isAnthropicModel && {
-          'stream-chatComplete': AnthropicChatCompleteStreamChunkTransform,
+          'stream-chatComplete':
+            getAnthropicStreamChunkTransform(AZURE_AI_INFERENCE),
         }),
         chatComplete: chatCompleteResponseTransform,
         messages: AzureAIInferenceMessagesResponseTransform,

--- a/src/providers/azure-ai-inference/index.ts
+++ b/src/providers/azure-ai-inference/index.ts
@@ -28,6 +28,7 @@ import {
 import {
   AnthropicChatCompleteConfig,
   AnthropicChatCompleteResponseTransform,
+  AnthropicChatCompleteStreamChunkTransform,
 } from '../anthropic/chatComplete';
 import {
   AzureAIInferenceMessagesConfig,
@@ -68,6 +69,9 @@ const AzureAIInferenceAPIConfig: ProviderConfigs = {
       },
       responseTransforms: {
         complete: AzureAIInferenceCompleteResponseTransform(AZURE_AI_INFERENCE),
+        ...(isAnthropicModel && {
+          'stream-chatComplete': AnthropicChatCompleteStreamChunkTransform,
+        }),
         chatComplete: chatCompleteResponseTransform,
         messages: AzureAIInferenceMessagesResponseTransform,
         embed: AzureAIInferenceEmbedResponseTransform(AZURE_AI_INFERENCE),

--- a/src/providers/azure-ai-inference/messages.ts
+++ b/src/providers/azure-ai-inference/messages.ts
@@ -14,7 +14,8 @@ export const AzureAIInferenceMessagesResponseTransform = (
 ): MessagesResponse | ErrorResponse => {
   if (responseStatus !== 200) {
     const errorResposne = AnthropicErrorResponseTransform(
-      response as AnthropicErrorResponse
+      response as AnthropicErrorResponse,
+      AZURE_AI_INFERENCE
     );
     if (errorResposne) return errorResposne;
   }

--- a/src/providers/google-vertex-ai/messages.ts
+++ b/src/providers/google-vertex-ai/messages.ts
@@ -23,7 +23,8 @@ export const VertexAnthropicMessagesResponseTransform = (
 ): MessagesResponse | ErrorResponse => {
   if (responseStatus !== 200) {
     const errorResposne = AnthropicErrorResponseTransform(
-      response as AnthropicErrorResponse
+      response as AnthropicErrorResponse,
+      GOOGLE_VERTEX_AI
     );
     if (errorResposne) return errorResposne;
   }


### PR DESCRIPTION
**Description:** (required)
Without steam-chatComplete response transformer specified , stream response from anthropic model hosted on azure is native anthropic sse and not open ai compatible

```
curl --location 'http://localhost:8787/v1/chat/completions' \
--header 'x-portkey-provider: azure-ai' \
--header 'Authorization: $AZURE_API_KEY' \
--header 'x-portkey-azure-foundry-url: https://resource-name.services.ai.azure.com/anthropic' \
--header 'Content-Type: application/json' \
--data '{
    "model": "claude-sonnet-4-5",
    "max_tokens": 10000,
    "messages": [
        {
            "role": "system",
            "content": "You are a helpful assistant."
        },
        {
            "role": "user",
            "content": "why sky is blue?"
        }
    ],
    "stream": true,
    "stream_options": {
        "include_usage": true
    },
    "anthropicBeta": "fine-grained-tool-streaming-2025-05-14"
}'
```
example of stream chunk before change
```json
{
    "type": "content_block_delta",
    "index": 0,
    "delta": {
        "type": "text_delta",
        "text": " re"
    }
}
```
after the change
```json
{
    "id": "azure-ai-1765363108622",
    "object": "chat.completion.chunk",
    "created": 1765363114,
    "model": "claude-sonnet-4-5-20250929",
    "provider": "anthropic",
    "choices": [
        {
            "delta": {
                "content": " re"
            },
            "index": 0,
            "logprobs": null,
            "finish_reason": null
        }
    ]
}
```

**Tests Run/Test cases added:** (required)
- [ ] Description of test case

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)