### PR TITLE
concatenate multple text parts for gemini models

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -484,7 +484,7 @@ export const GoogleChatCompleteResponseTransform: (
               if (part.thought) {
                 contentBlocks.push({ type: 'thinking', thinking: part.text });
               } else {
-                content = part.text;
+                content = content ? content + part.text : part.text;
                 contentBlocks.push({ type: 'text', text: part.text });
               }
             } else if (part.inlineData) {
@@ -684,7 +684,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
               });
               streamState.containsChainOfThoughtMessage = true;
             } else {
-              content = part.text ?? '';
+              content += part.text ?? '';
               contentBlocks.push({
                 index: streamState.containsChainOfThoughtMessage ? 1 : 0,
                 delta: { text: part.text },

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -632,7 +632,7 @@ export const GoogleChatCompleteResponseTransform: (
               if (part.thought) {
                 contentBlocks.push({ type: 'thinking', thinking: part.text });
               } else {
-                content = part.text;
+                content = content ? content + part.text : part.text;
                 contentBlocks.push({ type: 'text', text: part.text });
               }
             } else if (part.inlineData) {
@@ -783,7 +783,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
                 });
                 streamState.containsChainOfThoughtMessage = true;
               } else {
-                content = part.text ?? '';
+                content += part.text ?? '';
                 contentBlocks.push({
                   index: streamState.containsChainOfThoughtMessage ? 1 : 0,
                   delta: { text: part.text },


### PR DESCRIPTION
## Description

When using Gemini models (especially `gemini-3-pro-image-preview`) that return responses with multiple text parts, the `content` field only contains the **last text fragment** instead of all text parts concatenated together.

## Root Cause

In the response transformation code, when iterating through multiple text parts:

```typescript
for (const part of generation.content?.parts ?? []) {
  // ...
  else if (part.text) {
    if (part.thought) {
      contentBlocks.push({ type: 'thinking', thinking: part.text });
    } else {
      content = part.text;  // ❌ BUG: OVERWRITES instead of CONCATENATING
      contentBlocks.push({ type: 'text', text: part.text });
    }
  }
}
```

## Example

**Response received:**
```json
{
  "message": {
    "content": " mostly obscured by the red one and very blurred...",  // ❌ Only last fragment
    "content_blocks": [
      { "type": "thinking", "thinking": "..." },
      { "type": "text", "text": "VERIFIED: A photorealistic rendering shows..." },  // ✅ First text part
      { "type": "text", "text": ", a blue die is on the left..." },  // ✅ Second text part
      { "type": "text", "text": " mostly obscured by the red one..." }  // ❌ Only this ends up in content
    ]
  }
}
```

**Expected `content` field:**
```
"VERIFIED: A photorealistic rendering shows..., a blue die is on the left..., mostly obscured by the red one..."
```

## Impact

- System instructions appear to be ignored because the `content` field doesn't include the first text part which contains the instruction-following prefix
- The full response is available in `content_blocks`, but OpenAI-compatible clients expect the complete text in `content`
- Affects `gemini-3-pro-image-preview`, `gemini-2.0-flash-thinking-exp`, and other models that split responses into multiple text parts

## Files Affected

**Non-streaming responses:**
- `src/providers/google-vertex-ai/chatComplete.ts` line 468
- `src/providers/google/chatComplete.ts` line 577

**Streaming responses:**
- `src/providers/google-vertex-ai/chatComplete.ts` line 644
- `src/providers/google/chatComplete.ts` line 704

## Proposed Fix

Change from overwriting to concatenating:

```typescript
// Current (buggy):
content = part.text;

// Fixed:
content = (content || '') + part.text;
```

## Workaround for Users

Until fixed, users can manually concatenate text blocks:

```typescript
const allText = message.content_blocks
  .filter(b => b.type === 'text')
  .map(b => b.text)
  .join('');
```

Requires `x-portkey-strict-open-ai-compliance: false` to receive `content_blocks`.