### PR TITLE
execute guardrails sequentially

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -250,6 +250,7 @@ export function convertHooksShorthand(
       'id',
       'type',
       'guardrail_version_id',
+      'sequential',
     ].forEach((key) => {
       if (hook.hasOwnProperty(key)) {
         hooksObject[key] = hook[key];

--- a/src/middlewares/hooks/types.ts
+++ b/src/middlewares/hooks/types.ts
@@ -19,6 +19,7 @@ export interface HookObject {
   id: string;
   checks?: Check[];
   async?: boolean;
+  sequential?: boolean;
   onFail?: HookOnFailObject;
   onSuccess?: HookOnSuccessObject;
   deny?: boolean;


### PR DESCRIPTION
This allows users to execute guardrail checks sequentially, 
useful for example when you have two regex replace checks in the same guardrails.

Previously, only the second replace guardrail would take effect, by passing this flag, the mutated response from one check is passed to the next one in the order they are passed in the config