### PR TITLE
improvements for nano banana

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -599,6 +599,10 @@ export const VertexLlamaChatCompleteConfig: ProviderConfig = {
     param: 'stream',
     default: false,
   },
+  image_config: {
+    param: 'generationConfig',
+    transform: (params: Params) => transformGenerationConfig(params),
+  },
 };
 
 export const GoogleChatCompleteStreamChunkTransform: (

--- a/src/providers/google-vertex-ai/transformGenerationConfig.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.ts
@@ -87,8 +87,12 @@ export function transformGenerationConfig(params: PortkeyGeminiParams) {
   }
   if (params.image_config) {
     generationConfig['imageConfig'] = {
-      aspectRatio: params.image_config.aspect_ratio,
-      imageSize: params.image_config.image_size,
+      ...(params.image_config.aspect_ratio && {
+        aspectRatio: params.image_config.aspect_ratio,
+      }),
+      ...(params.image_config.image_size && {
+        imageSize: params.image_config.image_size,
+      }),
     };
   }
   return generationConfig;

--- a/src/providers/google-vertex-ai/transformGenerationConfig.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.ts
@@ -1,10 +1,9 @@
-import { Params } from '../../types/requestBody';
 import {
   recursivelyDeleteUnsupportedParameters,
   transformGeminiToolParameters,
 } from './utils';
 import { GoogleEmbedParams } from './embed';
-import { EmbedInstancesData } from './types';
+import { EmbedInstancesData, PortkeyGeminiParams } from './types';
 
 export const openaiReasoningEffortToVertexThinkingLevel = (
   reasoningEffort: string
@@ -19,7 +18,7 @@ export const openaiReasoningEffortToVertexThinkingLevel = (
 /**
  * @see https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini#request_body
  */
-export function transformGenerationConfig(params: Params) {
+export function transformGenerationConfig(params: PortkeyGeminiParams) {
   const generationConfig: Record<string, any> = {};
   if (params['temperature'] != null && params['temperature'] != undefined) {
     generationConfig['temperature'] = params['temperature'];
@@ -86,7 +85,12 @@ export function transformGenerationConfig(params: Params) {
       };
     }
   }
-
+  if (params.image_config) {
+    generationConfig['imageConfig'] = {
+      aspectRatio: params.image_config.aspect_ratio,
+      imageSize: params.image_config.image_size,
+    };
+  }
   return generationConfig;
 }
 

--- a/src/providers/google-vertex-ai/types.ts
+++ b/src/providers/google-vertex-ai/types.ts
@@ -1,3 +1,4 @@
+import { Params } from '../../types/requestBody';
 import { ChatCompletionResponse, GroundingMetadata } from '../types';
 
 export interface GoogleErrorResponse {
@@ -275,4 +276,10 @@ export enum VERTEX_MODALITY {
   TEXT = 'TEXT',
   IMAGE = 'IMAGE',
   AUDIO = 'AUDIO',
+}
+export interface PortkeyGeminiParams extends Params {
+  image_config?: {
+    aspect_ratio: string; // '16:9', '4:3', '1:1'
+    image_size: string; // '2K', '4K', '8K'
+  };
 }

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -105,8 +105,12 @@ const transformGenerationConfig = (params: PortkeyGeminiParams) => {
   }
   if (params.image_config) {
     generationConfig['imageConfig'] = {
-      aspectRatio: params.image_config.aspect_ratio,
-      imageSize: params.image_config.image_size,
+      ...(params.image_config.aspect_ratio && {
+        aspectRatio: params.image_config.aspect_ratio,
+      }),
+      ...(params.image_config.image_size && {
+        imageSize: params.image_config.image_size,
+      }),
     };
   }
   return generationConfig;

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -32,14 +32,10 @@ import {
   generateInvalidProviderResponseError,
   transformFinishReason,
 } from '../utils';
-import { GOOGLE_GENERATE_CONTENT_FINISH_REASON } from './types';
-
-interface PortkeyGeminiParams extends Params {
-  image_config?: {
-    aspect_ratio: string; // '16:9', '4:3', '1:1'
-    image_size: string; // '2K', '4K', '8K'
-  };
-}
+import {
+  GOOGLE_GENERATE_CONTENT_FINISH_REASON,
+  PortkeyGeminiParams,
+} from './types';
 
 const transformGenerationConfig = (params: PortkeyGeminiParams) => {
   const generationConfig: Record<string, any> = {};

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -34,7 +34,14 @@ import {
 } from '../utils';
 import { GOOGLE_GENERATE_CONTENT_FINISH_REASON } from './types';
 
-const transformGenerationConfig = (params: Params) => {
+interface PortkeyGeminiParams extends Params {
+  image_config?: {
+    aspect_ratio: string; // '16:9', '4:3', '1:1'
+    image_size: string; // '2K', '4K', '8K'
+  };
+}
+
+const transformGenerationConfig = (params: PortkeyGeminiParams) => {
   const generationConfig: Record<string, any> = {};
   if (params['temperature'] != null && params['temperature'] != undefined) {
     generationConfig['temperature'] = params['temperature'];
@@ -99,6 +106,12 @@ const transformGenerationConfig = (params: Params) => {
         thinkingLevel,
       };
     }
+  }
+  if (params.image_config) {
+    generationConfig['imageConfig'] = {
+      aspectRatio: params.image_config.aspect_ratio,
+      imageSize: params.image_config.image_size,
+    };
   }
   return generationConfig;
 };
@@ -461,6 +474,10 @@ export const GoogleChatCompleteConfig: ProviderConfig = {
     transform: (params: Params) => transformGenerationConfig(params),
   },
   reasoning_effort: {
+    param: 'generationConfig',
+    transform: (params: Params) => transformGenerationConfig(params),
+  },
+  image_config: {
     param: 'generationConfig',
     transform: (params: Params) => transformGenerationConfig(params),
   },

--- a/src/providers/google/types.ts
+++ b/src/providers/google/types.ts
@@ -1,3 +1,5 @@
+import { Params } from '../../types/requestBody';
+
 export enum GOOGLE_GENERATE_CONTENT_FINISH_REASON {
   FINISH_REASON_UNSPECIFIED = 'FINISH_REASON_UNSPECIFIED',
   STOP = 'STOP',
@@ -11,4 +13,10 @@ export enum GOOGLE_GENERATE_CONTENT_FINISH_REASON {
   SPII = 'SPII',
   MALFORMED_FUNCTION_CALL = 'MALFORMED_FUNCTION_CALL',
   IMAGE_SAFETY = 'IMAGE_SAFETY',
+}
+export interface PortkeyGeminiParams extends Params {
+  image_config?: {
+    aspect_ratio: string; // '16:9', '4:3', '1:1'
+    image_size: string; // '2K', '4K', '8K'
+  };
 }


### PR DESCRIPTION
**Description:** (required)
- allow users to pass image_config parameter when making requests to nano banana models
- 
**Tests Run/Test cases added:** (required)
- payload

```json
{
    "model": "gemini-2.5-flash-image",
    "max_tokens": 32768,
    "stream": false,
    "modalities": [
        "text",
        "image"
    ],
    "image_config": {
        "aspect_ratio": "16:9",
        "image_size": "2K"
    },
    "messages": [
        {
            "role": "system",
            "content": "Say Hi"
        },
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "Add some sugar powder to the croissants. Include text across the top of the image that says \"Made Fresh Daily\"."
                },
                {
                    "type": "image_url",
                    "image_url": {
                        "url": "gs://cloud-samples-data/generative-ai/image/croissant.jpeg"
                    }
                }
            ]
        }
    ]
}
```

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [X] New feature (non-breaking change which adds functionality)