### PR TITLE
fix(anthropic): add support for tool_choice=none

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -412,7 +412,6 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
       return tools;
     },
   },
-  // None is not supported by Anthropic, defaults to auto
   tool_choice: {
     param: 'tool_choice',
     required: false,
@@ -421,6 +420,7 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
         if (typeof params.tool_choice === 'string') {
           if (params.tool_choice === 'required') return { type: 'any' };
           else if (params.tool_choice === 'auto') return { type: 'auto' };
+          else if (params.tool_choice === 'none') return { type: 'none' };
         } else if (typeof params.tool_choice === 'object') {
           return { type: 'tool', name: params.tool_choice.function.name };
         }


### PR DESCRIPTION
## Summary

- Adds support for `tool_choice="none"` in the Anthropic provider

## Problem

Portkey doesn't accept `tool_choice="none"` for Anthropic models, even though the provider already supports it since February 2025 ([release notes](https://platform.claude.com/docs/en/release-notes/overview#february-27th-2025)).

## Solution

Added handling for `tool_choice === 'none'` in the transform function to return `{ type: 'none' }` instead of silently ignoring it.

## Changes

- Updated `src/providers/anthropic/chatComplete.ts` to handle the `'none'` string value
- Removed outdated comment stating "None is not supported by Anthropic"

Fixes #1474