### PR TITLE
provider: Databricks

### DIFF
--- a/src/providers/databricks/api.ts
+++ b/src/providers/databricks/api.ts
@@ -1,0 +1,36 @@
+import { ProviderAPIConfig } from '../types';
+
+const DatabricksAPIConfig: ProviderAPIConfig = {
+  getBaseURL: ({ providerOptions }) => {
+    // Support custom base URL or construct from workspace
+    if (providerOptions.databricksBaseURL) {
+      return providerOptions.databricksBaseURL;
+    }
+    const workspace = providerOptions.databricksWorkspace;
+    if (!workspace) {
+      throw new Error('Databricks workspace or base URL must be provided');
+    }
+    return `https://${workspace}.cloud.databricks.com/serving-endpoints`;
+  },
+  headers: ({ providerOptions }) => {
+    const headersObj: Record<string, string> = {
+      Authorization: `Bearer ${providerOptions.apiKey}`,
+    };
+
+    return headersObj;
+  },
+  getEndpoint: ({ fn }) => {
+    // Databricks uses /invocations for all endpoints
+    // The base URL should include the model name: /serving-endpoints/{model}/invocations
+    switch (fn) {
+      case 'complete':
+      case 'chatComplete':
+      case 'embed':
+        return '/invocations';
+      default:
+        return '';
+    }
+  },
+};
+
+export default DatabricksAPIConfig;

--- a/src/providers/databricks/chatComplete.ts
+++ b/src/providers/databricks/chatComplete.ts
@@ -1,0 +1,416 @@
+import { ANTHROPIC, OPEN_AI } from '../../globals';
+import { ContentBlockChunk } from '../../types/requestBody';
+import {
+  ChatCompletionResponse,
+  ErrorResponse,
+  ProviderConfig,
+} from '../types';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAIChatCompleteConfig: ProviderConfig = {
+  model: {
+    param: 'model',
+    required: true,
+    default: 'gpt-3.5-turbo',
+  },
+  messages: {
+    param: 'messages',
+    default: '',
+  },
+  functions: {
+    param: 'functions',
+  },
+  function_call: {
+    param: 'function_call',
+  },
+  max_tokens: {
+    param: 'max_tokens',
+    default: 100,
+    min: 0,
+  },
+  temperature: {
+    param: 'temperature',
+    default: 1,
+    min: 0,
+    max: 2,
+  },
+  top_p: {
+    param: 'top_p',
+    default: 1,
+    min: 0,
+    max: 1,
+  },
+  n: {
+    param: 'n',
+    default: 1,
+  },
+  stream: {
+    param: 'stream',
+    default: false,
+  },
+  stop: {
+    param: 'stop',
+  },
+  presence_penalty: {
+    param: 'presence_penalty',
+    min: -2,
+    max: 2,
+  },
+  frequency_penalty: {
+    param: 'frequency_penalty',
+    min: -2,
+    max: 2,
+  },
+  logit_bias: {
+    param: 'logit_bias',
+  },
+  user: {
+    param: 'user',
+  },
+  seed: {
+    param: 'seed',
+  },
+  tools: {
+    param: 'tools',
+  },
+  tool_choice: {
+    param: 'tool_choice',
+  },
+  response_format: {
+    param: 'response_format',
+  },
+  logprobs: {
+    param: 'logprobs',
+    default: false,
+  },
+  top_logprobs: {
+    param: 'top_logprobs',
+  },
+  stream_options: {
+    param: 'stream_options',
+  },
+  service_tier: {
+    param: 'service_tier',
+  },
+  parallel_tool_calls: {
+    param: 'parallel_tool_calls',
+  },
+  max_completion_tokens: {
+    param: 'max_completion_tokens',
+  },
+  store: {
+    param: 'store',
+  },
+  metadata: {
+    param: 'metadata',
+  },
+  modalities: {
+    param: 'modalities',
+  },
+  audio: {
+    param: 'audio',
+  },
+  prediction: {
+    param: 'prediction',
+  },
+  reasoning_effort: {
+    param: 'reasoning_effort',
+  },
+  web_search_options: {
+    param: 'web_search_options',
+  },
+  prompt_cache_key: {
+    param: 'prompt_cache_key',
+  },
+  safety_identifier: {
+    param: 'safety_identifier',
+  },
+  verbosity: {
+    param: 'verbosity',
+  },
+};
+
+export interface OpenAIChatCompleteResponse extends ChatCompletionResponse {
+  system_fingerprint: string;
+}
+
+export const OpenAIChatCompleteResponseTransform: (
+  response: OpenAIChatCompleteResponse | ErrorResponse,
+  responseStatus: number
+) => ChatCompletionResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};
+
+/**
+ * Transforms an OpenAI-format chat completions JSON response into an array of formatted OpenAI compatible text/event-stream chunks.
+ *
+ * @param {Object} response - The OpenAIChatCompleteResponse object.
+ * @param {string} provider - The provider string.
+ * @returns {Array<string>} - An array of formatted stream chunks.
+ */
+export const OpenAIChatCompleteJSONToStreamResponseTransform: (
+  response: OpenAIChatCompleteResponse,
+  provider: string
+) => Array<string> = (response, provider) => {
+  const streamChunkArray: Array<string> = [];
+  const { id, model, system_fingerprint, choices, citations } = response;
+
+  const {
+    prompt_tokens,
+    completion_tokens,
+    cache_read_input_tokens,
+    cache_creation_input_tokens,
+    num_search_queries,
+  } = response.usage || {};
+
+  let total_tokens;
+  if (prompt_tokens && completion_tokens)
+    total_tokens = prompt_tokens + completion_tokens;
+
+  const shouldSendCacheUsage =
+    provider === ANTHROPIC &&
+    (Number.isInteger(cache_read_input_tokens) ||
+      Number.isInteger(cache_creation_input_tokens));
+
+  const streamChunkTemplate: Record<string, any> = {
+    id,
+    object: 'chat.completion.chunk',
+    created: Math.floor(Date.now() / 1000),
+    model: model || '',
+    system_fingerprint: system_fingerprint || null,
+    provider,
+    usage: {
+      ...(completion_tokens && { completion_tokens }),
+      ...(prompt_tokens && { prompt_tokens }),
+      ...(total_tokens && { total_tokens }),
+      ...(shouldSendCacheUsage && {
+        cache_read_input_tokens,
+        cache_creation_input_tokens,
+      }),
+      ...(num_search_queries && { num_search_queries }),
+    },
+    ...(citations && { citations }),
+  };
+
+  for (const [index, choice] of choices.entries()) {
+    if (choice.message?.content_blocks) {
+      for (const [
+        contentBlockIndex,
+        contentBlock,
+      ] of choice.message.content_blocks.entries()) {
+        const contentBlockDelta: ContentBlockChunk = {
+          ...contentBlock,
+        } as ContentBlockChunk;
+        delete contentBlockDelta.type;
+        if (contentBlockDelta.text) {
+          for (let i = 0; i < contentBlockDelta.text.length; i += 500) {
+            const content = contentBlockDelta.text.slice(i, i + 500);
+            streamChunkArray.push(
+              `data: ${JSON.stringify({
+                ...streamChunkTemplate,
+                choices: [
+                  {
+                    index: index,
+                    delta: {
+                      role: 'assistant',
+                      content,
+                      content_blocks: [
+                        {
+                          index: contentBlockIndex,
+                          delta: {
+                            text: content,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              })}\n\n`
+            );
+          }
+        } else if (contentBlockDelta.thinking) {
+          for (let i = 0; i < contentBlockDelta.thinking.length; i += 500) {
+            const thinking = contentBlockDelta.thinking.slice(i, i + 500);
+            streamChunkArray.push(
+              `data: ${JSON.stringify({
+                ...streamChunkTemplate,
+                choices: [
+                  {
+                    index: index,
+                    delta: {
+                      role: 'assistant',
+                      content_blocks: [
+                        {
+                          index: contentBlockIndex,
+                          delta: {
+                            thinking,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              })}\n\n`
+            );
+          }
+          streamChunkArray.push(
+            `data: ${JSON.stringify({
+              ...streamChunkTemplate,
+              choices: [
+                {
+                  index: index,
+                  delta: {
+                    role: 'assistant',
+                    content_blocks: [
+                      {
+                        index: contentBlockIndex,
+                        delta: {
+                          signature: contentBlockDelta.signature,
+                        },
+                      },
+                    ],
+                  },
+                },
+              ],
+            })}\n\n`
+          );
+        } else if (contentBlockDelta.data) {
+          for (let i = 0; i < contentBlockDelta.data.length; i += 500) {
+            const data = contentBlockDelta.data.slice(i, i + 500);
+            streamChunkArray.push(
+              `data: ${JSON.stringify({
+                ...streamChunkTemplate,
+                choices: [
+                  {
+                    index: index,
+                    delta: {
+                      role: 'assistant',
+                      content_blocks: [
+                        {
+                          index: contentBlockIndex,
+                          delta: {
+                            data,
+                          },
+                        },
+                      ],
+                    },
+                  },
+                ],
+              })}\n\n`
+            );
+          }
+        }
+      }
+    }
+
+    if (
+      choice.message &&
+      choice.message.tool_calls &&
+      choice.message.tool_calls.length
+    ) {
+      for (const [
+        toolCallIndex,
+        toolCall,
+      ] of choice.message.tool_calls.entries()) {
+        const toolCallNameChunk = {
+          index: toolCallIndex,
+          id: toolCall.id,
+          type: 'function',
+          function: {
+            name: toolCall.function.name,
+            arguments: '',
+          },
+        };
+
+        const toolCallArgumentChunk = {
+          index: toolCallIndex,
+          function: {
+            arguments: toolCall.function.arguments,
+          },
+        };
+
+        streamChunkArray.push(
+          `data: ${JSON.stringify({
+            ...streamChunkTemplate,
+            choices: [
+              {
+                index: index,
+                delta: {
+                  role: 'assistant',
+                  content: null,
+                  tool_calls: [toolCallNameChunk],
+                },
+              },
+            ],
+          })}\n\n`
+        );
+
+        streamChunkArray.push(
+          `data: ${JSON.stringify({
+            ...streamChunkTemplate,
+            choices: [
+              {
+                index: index,
+                delta: {
+                  role: 'assistant',
+                  tool_calls: [toolCallArgumentChunk],
+                },
+              },
+            ],
+          })}\n\n`
+        );
+      }
+    }
+
+    if (
+      choice.message &&
+      choice.message.content &&
+      typeof choice.message.content === 'string' &&
+      !choice.message.content_blocks
+    ) {
+      const inidividualWords: Array<string> = [];
+      for (let i = 0; i < choice.message.content.length; i += 500) {
+        inidividualWords.push(choice.message.content.slice(i, i + 500));
+      }
+      inidividualWords.forEach((word: string) => {
+        streamChunkArray.push(
+          `data: ${JSON.stringify({
+            ...streamChunkTemplate,
+            choices: [
+              {
+                index: index,
+                delta: {
+                  role: 'assistant',
+                  content: word,
+                },
+                ...(choice.groundingMetadata && {
+                  groundingMetadata: choice.groundingMetadata,
+                }),
+              },
+            ],
+          })}\n\n`
+        );
+      });
+    }
+
+    streamChunkArray.push(
+      `data: ${JSON.stringify({
+        ...streamChunkTemplate,
+        choices: [
+          {
+            index: index,
+            delta: {},
+            finish_reason: choice.finish_reason,
+          },
+        ],
+      })}\n\n`
+    );
+  }
+
+  streamChunkArray.push(`data: [DONE]\n\n`);
+  return streamChunkArray;
+};

--- a/src/providers/databricks/complete.ts
+++ b/src/providers/databricks/complete.ts
@@ -1,0 +1,165 @@
+import { OPEN_AI } from '../../globals';
+import { CompletionResponse, ErrorResponse, ProviderConfig } from '../types';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAICompleteConfig: ProviderConfig = {
+  model: {
+    param: 'model',
+    required: true,
+    default: 'text-davinci-003',
+  },
+  prompt: {
+    param: 'prompt',
+    default: '',
+  },
+  max_tokens: {
+    param: 'max_tokens',
+    default: 100,
+    min: 0,
+  },
+  temperature: {
+    param: 'temperature',
+    default: 1,
+    min: 0,
+    max: 2,
+  },
+  top_p: {
+    param: 'top_p',
+    default: 1,
+    min: 0,
+    max: 1,
+  },
+  n: {
+    param: 'n',
+    default: 1,
+  },
+  stream: {
+    param: 'stream',
+    default: false,
+  },
+  logprobs: {
+    param: 'logprobs',
+    max: 5,
+  },
+  echo: {
+    param: 'echo',
+    default: false,
+  },
+  stop: {
+    param: 'stop',
+  },
+  presence_penalty: {
+    param: 'presence_penalty',
+    min: -2,
+    max: 2,
+  },
+  frequency_penalty: {
+    param: 'frequency_penalty',
+    min: -2,
+    max: 2,
+  },
+  best_of: {
+    param: 'best_of',
+  },
+  logit_bias: {
+    param: 'logit_bias',
+  },
+  user: {
+    param: 'user',
+  },
+  seed: {
+    param: 'seed',
+  },
+  suffix: {
+    param: 'suffix',
+  },
+  stream_options: {
+    param: 'stream_options',
+  },
+};
+
+export interface OpenAICompleteResponse extends CompletionResponse {
+  system_fingerprint: string;
+}
+
+export const OpenAICompleteResponseTransform: (
+  response: OpenAICompleteResponse | ErrorResponse,
+  responseStatus: number
+) => CompletionResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};
+
+/**
+ * Transforms an OpenAI-format completions JSON into an array of formatted OpenAI compatible text/event-stream chunks.
+ *
+ * @param {Object} response - The OpenAICompleteResponse object.
+ * @param {string} provider - The provider string.
+ * @returns {Array<string>} - An array of formatted stream chunks.
+ */
+export const OpenAICompleteJSONToStreamResponseTransform: (
+  response: OpenAICompleteResponse,
+  provider: string
+) => Array<string> = (response, provider) => {
+  const streamChunkArray: Array<string> = [];
+  const { id, model, choices } = response;
+  const { prompt_tokens, completion_tokens } = response.usage || {};
+
+  let total_tokens;
+  if (prompt_tokens && completion_tokens)
+    total_tokens = prompt_tokens + completion_tokens;
+
+  const streamChunkTemplate = {
+    id: id,
+    object: 'text_completion',
+    created: Date.now(),
+    model: model ?? '',
+    provider,
+    usage: {
+      ...(completion_tokens && { completion_tokens }),
+      ...(prompt_tokens && { prompt_tokens }),
+      ...(total_tokens && { total_tokens }),
+    },
+  };
+
+  for (const [index, choice] of choices.entries()) {
+    if (choice.text) {
+      const inidividualWords = [];
+      for (let i = 0; i < choice.text.length; i += 500) {
+        inidividualWords.push(choice.text.slice(i, i + 500));
+      }
+      inidividualWords.forEach((word: string) => {
+        streamChunkArray.push(
+          `data: ${JSON.stringify({
+            ...streamChunkTemplate,
+            choices: [
+              {
+                index: index,
+                text: word,
+              },
+            ],
+          })}\n\n`
+        );
+      });
+    }
+
+    streamChunkArray.push(
+      `data: ${JSON.stringify({
+        ...streamChunkTemplate,
+        choices: [
+          {
+            index: index,
+            text: '',
+            finish_reason: choice.finish_reason,
+          },
+        ],
+      })}\n\n`
+    );
+  }
+
+  streamChunkArray.push(`data: [DONE]\n\n`);
+  return streamChunkArray;
+};

--- a/src/providers/databricks/embed.ts
+++ b/src/providers/databricks/embed.ts
@@ -1,0 +1,38 @@
+import { OPEN_AI } from '../../globals';
+import { EmbedResponse } from '../../types/embedRequestBody';
+import { ErrorResponse, ProviderConfig } from '../types';
+import { OpenAIErrorResponseTransform } from './utils';
+
+export const OpenAIEmbedConfig: ProviderConfig = {
+  model: {
+    param: 'model',
+    required: true,
+    default: 'text-embedding-ada-002',
+  },
+  input: {
+    param: 'input',
+    required: true,
+  },
+  encoding_format: {
+    param: 'encoding_format',
+  },
+  dimensions: {
+    param: 'dimensions',
+  },
+  user: {
+    param: 'user',
+  },
+};
+
+interface OpenAIEmbedResponse extends EmbedResponse {}
+
+export const OpenAIEmbedResponseTransform: (
+  response: OpenAIEmbedResponse | ErrorResponse,
+  responseStatus: number
+) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, OPEN_AI);
+  }
+
+  return response;
+};

--- a/src/providers/databricks/index.ts
+++ b/src/providers/databricks/index.ts
@@ -1,0 +1,25 @@
+import { ProviderConfigs } from '../types';
+import {
+  OpenAICompleteConfig,
+  OpenAICompleteResponseTransform,
+} from './complete';
+import { OpenAIEmbedConfig, OpenAIEmbedResponseTransform } from './embed';
+import DatabricksAPIConfig from './api';
+import {
+  OpenAIChatCompleteConfig,
+  OpenAIChatCompleteResponseTransform,
+} from './chatComplete';
+
+const DatabricksConfig: ProviderConfigs = {
+  complete: OpenAICompleteConfig,
+  embed: OpenAIEmbedConfig,
+  api: DatabricksAPIConfig,
+  chatComplete: OpenAIChatCompleteConfig,
+  responseTransforms: {
+    complete: OpenAICompleteResponseTransform,
+    chatComplete: OpenAIChatCompleteResponseTransform,
+    embed: OpenAIEmbedResponseTransform,
+  },
+};
+
+export default DatabricksConfig;

--- a/src/providers/databricks/utils.ts
+++ b/src/providers/databricks/utils.ts
@@ -1,0 +1,14 @@
+import { ErrorResponse } from '../types';
+import { generateErrorResponse } from '../utils';
+
+export const OpenAIErrorResponseTransform: (
+  response: ErrorResponse,
+  provider: string
+) => ErrorResponse = (response, provider) => {
+  return generateErrorResponse(
+    {
+      ...response.error,
+    },
+    provider
+  );
+};

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -39,6 +39,7 @@ import {
   GithubModelAPiConfig,
 } from './azure-ai-inference';
 import DeepbricksConfig from './deepbricks';
+import DatabricksConfig from './databricks';
 import SiliconFlowConfig from './siliconflow';
 import HuggingfaceConfig from './huggingface';
 import { cerebrasProviderAPIConfig } from './cerebras';
@@ -114,6 +115,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   'azure-ai': AzureAIInferenceAPIConfig,
   github: GithubModelAPiConfig,
   deepbricks: DeepbricksConfig,
+  databricks: DatabricksConfig,
   siliconflow: SiliconFlowConfig,
   cerebras: cerebrasProviderAPIConfig,
   'inference-net': InferenceNetProviderConfigs,


### PR DESCRIPTION
**Description:** (required)
- Add support for Databricks AI Gateway as a Portkey provider
- Implements chat completions, text completions, and embeddings
- Uses unified /invocations endpoint for all operations
- Maintains OpenAI-compatible request/response format
- Supports workspace-based and custom base URLs
- Bearer token authentication with Databricks PATs

**Tests Run/Test cases added:** (required)
- [X] Tested with Llama 4 Maverick, Claude Sonnet 4.5, and GTE embedding models to ensure it worked across multiple functionalities, not just completion or chat, and also that the /invocations endpoint standard on Databricks model serving was able to successfully exception handle non OpenAI API style requests

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)