### PR TITLE
fix: gemini minimal reasoning effort

### DIFF
--- a/src/providers/google-vertex-ai/transformGenerationConfig.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.ts
@@ -5,16 +5,6 @@ import {
 import { GoogleEmbedParams } from './embed';
 import { EmbedInstancesData, PortkeyGeminiParams } from './types';
 
-export const openaiReasoningEffortToVertexThinkingLevel = (
-  reasoningEffort: string
-) => {
-  if (['minimal', 'low'].includes(reasoningEffort)) {
-    return 'low';
-  } else if (['medium', 'high'].includes(reasoningEffort)) {
-    return 'high';
-  }
-};
-
 /**
  * @see https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini#request_body
  */
@@ -76,9 +66,7 @@ export function transformGenerationConfig(params: PortkeyGeminiParams) {
     );
   }
   if (params.reasoning_effort && params.reasoning_effort !== 'none') {
-    const thinkingLevel = openaiReasoningEffortToVertexThinkingLevel(
-      params.reasoning_effort
-    );
+    const thinkingLevel = params.reasoning_effort;
     if (thinkingLevel) {
       generationConfig['thinkingConfig'] = {
         thinkingLevel,

--- a/src/providers/google-vertex-ai/transformGenerationConfig.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.ts
@@ -66,12 +66,9 @@ export function transformGenerationConfig(params: PortkeyGeminiParams) {
     );
   }
   if (params.reasoning_effort && params.reasoning_effort !== 'none') {
-    const thinkingLevel = params.reasoning_effort;
-    if (thinkingLevel) {
-      generationConfig['thinkingConfig'] = {
-        thinkingLevel,
-      };
-    }
+    generationConfig['thinkingConfig'] = {
+      thinkingLevel: params.reasoning_effort,
+    };
   }
   if (params.image_config) {
     generationConfig['imageConfig'] = {

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -93,12 +93,9 @@ const transformGenerationConfig = (params: PortkeyGeminiParams) => {
     );
   }
   if (params.reasoning_effort && params.reasoning_effort !== 'none') {
-    const thinkingLevel = params.reasoning_effort;
-    if (thinkingLevel) {
-      generationConfig['thinkingConfig'] = {
-        thinkingLevel,
-      };
-    }
+    generationConfig['thinkingConfig'] = {
+      thinkingLevel: params.reasoning_effort,
+    };
   }
   if (params.image_config) {
     generationConfig['imageConfig'] = {

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -9,7 +9,6 @@ import {
   SYSTEM_MESSAGE_ROLES,
   MESSAGE_ROLES,
 } from '../../types/requestBody';
-import { openaiReasoningEffortToVertexThinkingLevel } from '../google-vertex-ai/transformGenerationConfig';
 import { VERTEX_MODALITY } from '../google-vertex-ai/types';
 import {
   getMimeType,
@@ -94,9 +93,7 @@ const transformGenerationConfig = (params: PortkeyGeminiParams) => {
     );
   }
   if (params.reasoning_effort && params.reasoning_effort !== 'none') {
-    const thinkingLevel = openaiReasoningEffortToVertexThinkingLevel(
-      params.reasoning_effort
-    );
+    const thinkingLevel = params.reasoning_effort;
     if (thinkingLevel) {
       generationConfig['thinkingConfig'] = {
         thinkingLevel,


### PR DESCRIPTION
**Description:** (required)
- Gemini supports new reasoning modes (minimal and medium) (previously only low and high were supported) for the gemini 3 flash models, this PR just updates the mapping

payload to test
```json
{
    "model": "gemini-3-flash-preview",
    "stream": false,
    "stop": ["NO_RESPONSE_REQUIRED"],
    "reasoning_effort": "minimal",
    "messages": [
        {
            "role": "user",
            "content": [
                {
                    "type": "text",
                    "text": "Give me the flight ticket details from BLR to LDX"
                }
            ]
        }
    ]
}
```

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [X] Refactoring (no functional changes)