### PR TITLE
make anthropic beta header usage consistent

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -902,6 +902,12 @@ export function constructConfigFromRequestHeaders(
       requestHeaders[
         `x-${POWERED_BY}-amz-server-side-encryption-aws-kms-key-id`
       ],
+    anthropicBeta:
+      requestHeaders[`x-${POWERED_BY}-anthropic-beta`] ||
+      requestHeaders[`anthropic-beta`],
+    anthropicVersion:
+      requestHeaders[`x-${POWERED_BY}-anthropic-version`] ||
+      requestHeaders[`anthropic-version`],
   };
 
   const sagemakerConfig = {
@@ -955,6 +961,9 @@ export function constructConfigFromRequestHeaders(
     anthropicBeta:
       requestHeaders[`x-${POWERED_BY}-anthropic-beta`] ||
       requestHeaders[`anthropic-beta`],
+    anthropicVersion:
+      requestHeaders[`x-${POWERED_BY}-anthropic-version`] ||
+      requestHeaders[`anthropic-version`],
   };
 
   const fireworksConfig = {

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -11,6 +11,7 @@ import {
   SYSTEM_MESSAGE_ROLES,
   ContentType,
   ToolChoiceObject,
+  Options,
 } from '../../types/requestBody';
 import {
   ChatCompletionResponse,
@@ -718,38 +719,59 @@ export const BedrockConverseAnthropicChatCompleteConfig: ProviderConfig = {
   ...BedrockConverseChatCompleteConfig,
   additionalModelRequestFields: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (
+      params: BedrockConverseAnthropicChatCompletionsParams,
+      providerOptions?: Options
+    ) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   additional_model_request_fields: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (
+      params: BedrockConverseAnthropicChatCompletionsParams,
+      providerOptions?: Options
+    ) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   top_k: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (
+      params: BedrockConverseAnthropicChatCompletionsParams,
+      providerOptions?: Options
+    ) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   anthropic_version: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (
+      params: BedrockConverseAnthropicChatCompletionsParams,
+      providerOptions?: Options
+    ) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   user: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (
+      params: BedrockConverseAnthropicChatCompletionsParams,
+      providerOptions?: Options
+    ) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   thinking: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (
+      params: BedrockConverseAnthropicChatCompletionsParams,
+      providerOptions?: Options
+    ) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   anthropic_beta: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockConverseAnthropicChatCompletionsParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (
+      params: BedrockConverseAnthropicChatCompletionsParams,
+      providerOptions?: Options
+    ) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
 };
 

--- a/src/providers/bedrock/messages.ts
+++ b/src/providers/bedrock/messages.ts
@@ -14,7 +14,7 @@ import {
   RawContentBlockStartEvent,
   RawContentBlockStopEvent,
 } from '../../types/MessagesStreamResponse';
-import { Params } from '../../types/requestBody';
+import { Options, Params } from '../../types/requestBody';
 import {
   ANTHROPIC_CONTENT_BLOCK_START_EVENT,
   ANTHROPIC_CONTENT_BLOCK_STOP_EVENT,
@@ -364,33 +364,33 @@ export const AnthropicBedrockConverseMessagesConfig: ProviderConfig = {
   ...BedrockConverseMessagesConfig,
   additional_model_request_fields: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockMessagesParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (params: BedrockMessagesParams, providerOptions?: Options) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   top_k: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockMessagesParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (params: BedrockMessagesParams, providerOptions?: Options) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   anthropic_version: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockMessagesParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (params: BedrockMessagesParams, providerOptions?: Options) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   user: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockMessagesParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (params: BedrockMessagesParams, providerOptions?: Options) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   thinking: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockMessagesParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (params: BedrockMessagesParams, providerOptions?: Options) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
   anthropic_beta: {
     param: 'additionalModelRequestFields',
-    transform: (params: BedrockMessagesParams) =>
-      transformAnthropicAdditionalModelRequestFields(params),
+    transform: (params: BedrockMessagesParams, providerOptions?: Options) =>
+      transformAnthropicAdditionalModelRequestFields(params, providerOptions),
   },
 };
 

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -111,18 +111,20 @@ export const transformAdditionalModelRequestFields = (
 };
 
 export const transformAnthropicAdditionalModelRequestFields = (
-  params: BedrockConverseAnthropicChatCompletionsParams
+  params: BedrockConverseAnthropicChatCompletionsParams,
+  providerOptions?: Options
 ) => {
   const additionalModelRequestFields: Record<string, any> =
     params.additionalModelRequestFields ||
     params.additional_model_request_fields ||
     {};
-  if (params['top_k'] !== null && params['top_k'] !== undefined) {
+  if (params['top_k'] !== undefined && params['top_k'] !== null) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }
-  if (params['anthropic_version']) {
-    additionalModelRequestFields['anthropic_version'] =
-      params['anthropic_version'];
+  const anthropicVersion =
+    providerOptions?.anthropicVersion || params['anthropic_version'];
+  if (anthropicVersion) {
+    additionalModelRequestFields['anthropic_version'] = anthropicVersion;
   }
   if (params['user']) {
     additionalModelRequestFields['metadata'] = {
@@ -132,13 +134,13 @@ export const transformAnthropicAdditionalModelRequestFields = (
   if (params['thinking']) {
     additionalModelRequestFields['thinking'] = params['thinking'];
   }
-  if (params['anthropic_beta']) {
-    if (typeof params['anthropic_beta'] === 'string') {
-      additionalModelRequestFields['anthropic_beta'] = [
-        params['anthropic_beta'],
-      ];
+  const anthropicBeta =
+    providerOptions?.anthropicBeta || params['anthropic_beta'];
+  if (anthropicBeta) {
+    if (typeof anthropicBeta === 'string') {
+      additionalModelRequestFields['anthropic_beta'] = [anthropicBeta];
     } else {
-      additionalModelRequestFields['anthropic_beta'] = params['anthropic_beta'];
+      additionalModelRequestFields['anthropic_beta'] = anthropicBeta;
     }
   }
   if (params.tools && params.tools.length) {

--- a/src/providers/bedrock/utils/messagesUtils.ts
+++ b/src/providers/bedrock/utils/messagesUtils.ts
@@ -1,3 +1,4 @@
+import { Options } from '../../../types/requestBody';
 import { BedrockMessagesParams } from '../types';
 
 export const transformInferenceConfig = (params: BedrockMessagesParams) => {
@@ -18,7 +19,8 @@ export const transformInferenceConfig = (params: BedrockMessagesParams) => {
 };
 
 export const transformAnthropicAdditionalModelRequestFields = (
-  params: BedrockMessagesParams
+  params: BedrockMessagesParams,
+  providerOptions?: Options
 ) => {
   const additionalModelRequestFields: Record<string, any> =
     params.additionalModelRequestFields ||
@@ -27,20 +29,21 @@ export const transformAnthropicAdditionalModelRequestFields = (
   if (params['top_k']) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }
-  if (params['anthropic_version']) {
-    additionalModelRequestFields['anthropic_version'] =
-      params['anthropic_version'];
+  const anthropicVersion =
+    providerOptions?.anthropicVersion || params['anthropic_version'];
+  if (anthropicVersion) {
+    additionalModelRequestFields['anthropic_version'] = anthropicVersion;
   }
   if (params['thinking']) {
     additionalModelRequestFields['thinking'] = params['thinking'];
   }
-  if (params['anthropic_beta']) {
-    if (typeof params['anthropic_beta'] === 'string') {
-      additionalModelRequestFields['anthropic_beta'] = [
-        params['anthropic_beta'],
-      ];
+  const anthropicBeta =
+    providerOptions?.anthropicBeta || params['anthropic_beta'];
+  if (anthropicBeta) {
+    if (typeof anthropicBeta === 'string') {
+      additionalModelRequestFields['anthropic_beta'] = [anthropicBeta];
     } else {
-      additionalModelRequestFields['anthropic_beta'] = params['anthropic_beta'];
+      additionalModelRequestFields['anthropic_beta'] = anthropicBeta;
     }
   }
   return additionalModelRequestFields;

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -9,6 +9,7 @@ import {
   ToolCall,
   SYSTEM_MESSAGE_ROLES,
   MESSAGE_ROLES,
+  Options,
 } from '../../types/requestBody';
 import {
   AnthropicChatCompleteConfig,
@@ -398,6 +399,13 @@ export const VertexAnthropicChatCompleteConfig: ProviderConfig = {
     param: 'anthropic_version',
     required: true,
     default: 'vertex-2023-10-16',
+    transform: (params: Params, providerOptions?: Options) => {
+      return (
+        providerOptions?.anthropicVersion ||
+        params.anthropic_version ||
+        'vertex-2023-10-16'
+      );
+    },
   },
   model: {
     param: 'model',

--- a/src/providers/google-vertex-ai/messages.ts
+++ b/src/providers/google-vertex-ai/messages.ts
@@ -1,5 +1,6 @@
 import { GOOGLE_VERTEX_AI } from '../../globals';
 import { MessagesResponse } from '../../types/messagesResponse';
+import { Options } from '../../types/requestBody';
 import { getMessagesConfig } from '../anthropic-base/messages';
 import { AnthropicErrorResponse } from '../anthropic/types';
 import { AnthropicErrorResponseTransform } from '../anthropic/utils';
@@ -12,6 +13,13 @@ export const VertexAnthropicMessagesConfig = getMessagesConfig({
       param: 'anthropic_version',
       required: true,
       default: 'vertex-2023-10-16',
+      transform: (params: Params, providerOptions?: Options) => {
+        return (
+          providerOptions?.anthropicVersion ||
+          params['anthropic_version'] ||
+          'vertex-2023-10-16'
+        );
+      },
     },
   },
   exclude: ['model'],


### PR DESCRIPTION
**Description:** (required)
-This PR makes anthropic beta header usage consistent across multiple providers (vertex, anthropic and bedrock)
- the precedence order now is header > body as it should've been all along

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [X] New feature (non-breaking change which adds functionality)