### PR TITLE
revert changes to anthropic version behaviour

### DIFF
--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -121,10 +121,9 @@ export const transformAnthropicAdditionalModelRequestFields = (
   if (params['top_k'] !== undefined && params['top_k'] !== null) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }
-  const anthropicVersion =
-    providerOptions?.anthropicVersion || params['anthropic_version'];
-  if (anthropicVersion) {
-    additionalModelRequestFields['anthropic_version'] = anthropicVersion;
+  if (params['anthropic_version']) {
+    additionalModelRequestFields['anthropic_version'] =
+      params['anthropic_version'];
   }
   if (params['user']) {
     additionalModelRequestFields['metadata'] = {

--- a/src/providers/bedrock/utils/messagesUtils.ts
+++ b/src/providers/bedrock/utils/messagesUtils.ts
@@ -29,10 +29,9 @@ export const transformAnthropicAdditionalModelRequestFields = (
   if (params['top_k']) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }
-  const anthropicVersion =
-    providerOptions?.anthropicVersion || params['anthropic_version'];
-  if (anthropicVersion) {
-    additionalModelRequestFields['anthropic_version'] = anthropicVersion;
+  if (params['anthropic_version']) {
+    additionalModelRequestFields['anthropic_version'] =
+      params['anthropic_version'];
   }
   if (params['thinking']) {
     additionalModelRequestFields['thinking'] = params['thinking'];


### PR DESCRIPTION
**Description:** (required)
- Remove anthropic version mapping from headers 
previously we were not respecting the anthropic version  and beta headers when sent to bedrock, we were only considering these fields when sent in body, while anthropic beta is required to access specific features from anthropic (useful when using claude code etc) anthropic version is always the same and shouldnt be overridden

I've reverted anthropic version changes to what they were before these changes https://github.com/Portkey-AI/gateway/pull/1491/changes

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)