### PR TITLE
fix anthropic beta claude code on bedrock

### DIFF
--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -137,7 +137,9 @@ export const transformAnthropicAdditionalModelRequestFields = (
     providerOptions?.anthropicBeta || params['anthropic_beta'];
   if (anthropicBeta) {
     if (typeof anthropicBeta === 'string') {
-      additionalModelRequestFields['anthropic_beta'] = [anthropicBeta];
+      additionalModelRequestFields['anthropic_beta'] = anthropicBeta
+        .split(',')
+        .map((beta: string) => beta.trim());
     } else {
       additionalModelRequestFields['anthropic_beta'] = anthropicBeta;
     }

--- a/src/providers/bedrock/utils/messagesUtils.ts
+++ b/src/providers/bedrock/utils/messagesUtils.ts
@@ -40,7 +40,9 @@ export const transformAnthropicAdditionalModelRequestFields = (
     providerOptions?.anthropicBeta || params['anthropic_beta'];
   if (anthropicBeta) {
     if (typeof anthropicBeta === 'string') {
-      additionalModelRequestFields['anthropic_beta'] = [anthropicBeta];
+      additionalModelRequestFields['anthropic_beta'] = anthropicBeta
+        .split(',')
+        .map((beta: string) => beta.trim());
     } else {
       additionalModelRequestFields['anthropic_beta'] = anthropicBeta;
     }


### PR DESCRIPTION
**Description:** (required)
- we recently made a change to respect anthropic beta header, while the standard way to send it is as an array or a string of arrays, claude code sends a string like this "claude-code-20250219,interleaved-thinking-2025-05-14" this case is currently not handled

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [X] Bug fix (non-breaking change which fixes an issue)