### PR TITLE
Initial Crowdstrike AIDR Guardrail Plugin

### DIFF
--- a/plugins/crowdstrike-aidr/aidr.test.ts
+++ b/plugins/crowdstrike-aidr/aidr.test.ts
@@ -1,0 +1,120 @@
+import { handler } from './guardChatCompletion';
+import testCredsFile from './.creds.json';
+import { HookEventType, PluginContext } from '../types';
+
+const options = {
+  env: {},
+};
+
+const testCreds = {
+  baseUrl: testCredsFile.baseUrl,
+  blockApiKey: testCredsFile.blockApiKey,
+  redactApiKey: testCredsFile.redactApiKey,
+};
+
+describe('AIDR Handlers', () => {
+  it('should return an error if hook type is not supported', async () => {
+    const context = {
+      request: { text: 'This is a message' },
+    };
+    const eventType = 'unsupported';
+    const parameters = {};
+    const result = await handler(
+      context,
+      parameters,
+      // @ts-ignore
+      eventType,
+      options
+    );
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+
+  it('should return an error if fetch request fails', async () => {
+    const context = {
+      request: { text: 'This is a message' },
+    };
+    const eventType = 'beforeRequestHook';
+    const parameters = {
+      credentials: {},
+    };
+    const result = await handler(context, parameters, eventType, options);
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+
+  it('should return an error if no apiKey', async () => {
+    const context = {
+      request: { text: 'This is a message' },
+    };
+    const eventType = 'beforeRequestHook';
+    const parameters = {
+      credentials: { baseUrl: testCreds.baseUrl },
+    };
+    const result = await handler(context, parameters, eventType, options);
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+
+  it('should return verdict as false if blocked', async () => {
+    const context = {
+      request: {
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content:
+                'My email is john.smith@crowdstrike.com and my IP address is 200.0.16.24',
+            },
+          ],
+        },
+      },
+    };
+    const eventType = 'beforeRequestHook';
+    const parameters = {
+      credentials: {
+        baseUrl: testCreds.baseUrl,
+        apiKey: testCreds.blockApiKey,
+      },
+    };
+    const result = await handler(context, parameters, eventType, options);
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(false);
+  });
+
+  it('should return transformation', async () => {
+    const origMsg =
+      'My email is john.smith@crowdstrike.com and my IP address is 200.0.16.24';
+    const context = {
+      request: {
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: origMsg,
+            },
+          ],
+        },
+      },
+    };
+    const eventType = 'beforeRequestHook';
+    const parameters = {
+      credentials: {
+        baseUrl: testCreds.baseUrl,
+        apiKey: testCreds.redactApiKey,
+      },
+    };
+    const result = await handler(context, parameters, eventType, options);
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(true);
+    expect(result.transformed).toBe(true);
+    expect(result.transformedData).toBeDefined();
+    expect(result.transformedData?.request?.json?.messages.length).toBe(1);
+    expect(result.transformedData.request.json.messages[0].content).not.toBe(
+      origMsg
+    );
+  });
+});

--- a/plugins/crowdstrike-aidr/guardChatCompletion.ts
+++ b/plugins/crowdstrike-aidr/guardChatCompletion.ts
@@ -1,0 +1,151 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { post, HttpError } from '../utils';
+import { VERSION } from './version';
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let error = null;
+  let verdict = true;
+  let data = null;
+
+  if (!parameters.credentials?.baseUrl) {
+    return {
+      error: `'parameters.credentials.baseUrl' must be set`,
+      verdict: true,
+      data,
+    };
+  }
+
+  if (!parameters.credentials?.apiKey) {
+    return {
+      error: `'parameters.credentials.apiKey' must be set`,
+      verdict: true,
+      data,
+    };
+  }
+
+  const url = `${parameters.credentials.baseUrl}/v1/guard_chat_completions`;
+  const target = eventType === 'beforeRequestHook' ? 'request' : 'response';
+  const json = context[target].json;
+  const aidrEventType = target === 'request' ? 'input' : 'output';
+
+  const requestBody: object = {
+    guard_input: json,
+    event_type: aidrEventType,
+    app_id: 'Portkey AI Gateway',
+    // TODO: Add as much other metadata as we have
+  };
+
+  const requestOptions: object = {
+    headers: {
+      'Content-Type': 'application/json',
+      'User-Agent': `portkey-ai-plugin/${VERSION}`,
+      Authorization: `Bearer ${parameters.credentials.apiKey}`,
+    },
+  };
+
+  let response;
+  try {
+    response = await post(url, requestBody, requestOptions, parameters.timeout);
+  } catch (e) {
+    if (e instanceof HttpError) {
+      error = `${e.message}. body: ${e.response.body}`;
+    } else {
+      error = e as Error;
+    }
+  }
+
+  if (!response) {
+    return {
+      error,
+      verdict,
+      data,
+    };
+  }
+
+  if (response.status != 'Success') {
+    error = errorToString(response);
+    return {
+      error,
+      verdict,
+      data,
+    };
+  }
+
+  const result = response.result;
+  if (!result) {
+    return {
+      error: `Missing result from response body: ${response}`,
+      verdict,
+      data,
+    };
+  }
+
+  if (result.blocked) {
+    data = {
+      explanation: `Blocked by AIDR Policy '${result.policy}'`,
+    };
+    return {
+      error,
+      verdict: false,
+      data,
+    };
+  }
+
+  if (!result.transformed) {
+    // Not blocked, not transformed, nothing else to do
+    data = {
+      explanation: `Allowed by AIDR Policy '${result.policy}'`,
+    };
+    return {
+      error,
+      verdict,
+      data,
+    };
+  }
+
+  data = {
+    explanation: `Allowed by AIDR policy '${result.policy}', but requires transformations`,
+  };
+
+  let transformedData: Record<string, any> = {
+    request: {
+      json: null,
+    },
+    response: {
+      json: null,
+    },
+  };
+
+  const redactedJson = result.guard_output;
+  transformedData[target].json = redactedJson;
+
+  // Apply transformations
+  return {
+    error,
+    verdict,
+    data,
+    transformedData,
+    transformed: true,
+  };
+};
+
+function errorToString(response: any): string {
+  let ret = `Summary: ${response.summary}\n`;
+  ret += `status: ${response.status}\n`;
+  ret += `request_id: ${response.request_id}\n`;
+  ret += `request_time: ${response.request_time}\n`;
+  ret += `response_time: ${response.response_time}\n`;
+  (response.result?.errors || []).forEach((ef: any) => {
+    ret += `\t${ef.source} ${ef.code}: ${ef.detail}\n`;
+  });
+  return ret;
+}

--- a/plugins/crowdstrike-aidr/manifest.json
+++ b/plugins/crowdstrike-aidr/manifest.json
@@ -1,0 +1,35 @@
+{
+  "id": "crowdstrike-aidr",
+  "description": "CrowdStrike AIDR for scanning LLM inputs and outputs",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "label": "AIDR API token",
+        "description": "AIDR Token. Get your token from the Falcon console.",
+        "encrypted": true
+      },
+      "baseUrl": {
+        "type": "string",
+        "label": "Base url",
+        "description": "Base URL"
+      }
+    },
+    "required": ["baseUrl", "apiKey"]
+  },
+  "functions": [
+    {
+      "name": "Guard Chat Completions",
+      "id": "guardChatCompletions",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "type": "guardrail",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Pass LLM Input and Output to the guard_chat_completions endpoint. Able to block or sanitize text depending on configured rules."
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/crowdstrike-aidr/version.ts
+++ b/plugins/crowdstrike-aidr/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = 'v1.0.0-beta';


### PR DESCRIPTION
**Description:** (required)
This is effectively an update for the Pangea Guardrails plugin. First, it is a rebrand, since Pangea has been acquired by crowdstrike, and has a new product name

It's updated for much newer APIs. The current APIs support blocking and redaction based on configured upstream rules. The new endpoint is designed to work with structued LLM inputs, e.g. you should pass it the entire `messages` array, but also supports having `tools` and other properties a well. 

I think we should consider removing the Pangea guardrails as well. 

**Tests Run/Test cases added:** (required)
- [x] Added tests for the new guardrails

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)