### PR TITLE
fix: ensure prompt_tokens is always present in Anthropic streaming responses

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -731,8 +731,14 @@ export const getAnthropicStreamChunkTransform = (provider: string) => {
 
     // final chunk
     if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
+      // Use input_tokens from message_delta if not available from message_start
+      const promptTokens =
+        streamState?.usage?.prompt_tokens ??
+        parsedChunk.usage?.input_tokens ??
+        0;
+
       const totalTokens =
-        (streamState?.usage?.prompt_tokens ?? 0) +
+        promptTokens +
         (streamState?.usage?.cache_creation_input_tokens ?? 0) +
         (streamState?.usage?.cache_read_input_tokens ?? 0) +
         (parsedChunk.usage.output_tokens ?? 0);
@@ -755,6 +761,7 @@ export const getAnthropicStreamChunkTransform = (provider: string) => {
           ],
           usage: {
             ...streamState.usage,
+            prompt_tokens: promptTokens,
             completion_tokens: parsedChunk.usage?.output_tokens,
             total_tokens: totalTokens,
             prompt_tokens_details: {

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -1014,8 +1014,12 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
   }
 
   if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
+    // Use input_tokens from message_delta if not available from message_start
+    const promptTokens =
+      streamState?.usage?.prompt_tokens ?? parsedChunk.usage?.input_tokens ?? 0;
+
     const totalTokens =
-      (streamState?.usage?.prompt_tokens ?? 0) +
+      promptTokens +
       (streamState?.usage?.cache_creation_input_tokens ?? 0) +
       (streamState?.usage?.cache_read_input_tokens ?? 0) +
       (parsedChunk.usage.output_tokens ?? 0);
@@ -1039,6 +1043,7 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
         ],
         usage: {
           ...streamState.usage,
+          prompt_tokens: promptTokens,
           completion_tokens: parsedChunk.usage?.output_tokens,
           total_tokens: totalTokens,
           prompt_tokens_details: {


### PR DESCRIPTION
## Summary

Fixes an issue where `prompt_tokens` was missing from streaming responses for Anthropic models (both direct Anthropic API and via Vertex AI), causing billing/usage tracking to be incorrect.

**Root cause:** When streaming, the `message_start` event may not always include `input_tokens`. The code relied solely on this event to set `prompt_tokens`, resulting in `undefined` values that were omitted from the JSON response.

**The fix:**
- Checks for `input_tokens` in the `message_delta` event as a fallback (per Anthropic docs, these are cumulative counts)
- Defaults to `0` if neither source provides the value
- Explicitly sets `prompt_tokens` in the usage object to ensure it's always present

## Changes

- `src/providers/google-vertex-ai/chatComplete.ts` - Vertex AI Claude streaming
- `src/providers/anthropic/chatComplete.ts` - Direct Anthropic streaming

## Test plan

- [ ] Test streaming responses from Anthropic `/v1/chat/completions` - verify `prompt_tokens` is present
- [ ] Test streaming responses from Vertex AI Claude `/v1/chat/completions` - verify `prompt_tokens` is present
- [ ] Test with tool use / structured output calls specifically (the reported issue scenario)
- [ ] Verify `total_tokens` calculation is still correct

## Before (problematic response)

```json
"usage": {
  "completion_tokens": 52,
  "prompt_tokens_details": {
    "cached_tokens": 0
  }
}
```

## After (fixed response)

```json
"usage": {
  "prompt_tokens": <value>,
  "completion_tokens": 52,
  "total_tokens": <calculated>,
  "prompt_tokens_details": {
    "cached_tokens": 0
  }
}
```