### PR TITLE
feat: propagate OpenAI service_tier for flex pricing support

### DIFF
--- a/src/handlers/services/logsService.ts
+++ b/src/handlers/services/logsService.ts
@@ -39,6 +39,7 @@ export interface LogObject {
     rubeusURL: string;
     modelPricingConfig?: Record<string, any> | undefined;
   };
+  serviceTier?: string | null;
   transformedRequest: {
     body: any;
     headers: Record<string, string>;
@@ -200,6 +201,7 @@ export class LogsService {
       cacheMaxAge: requestContext.cacheConfig.maxAge,
       hookSpanId: hookSpanId,
       executionTime: executionTime,
+      serviceTier: originalResponseJSON?.service_tier ?? null,
     };
   }
 
@@ -254,6 +256,7 @@ export class LogObjectBuilder {
       cacheStatus: this.logData.cacheStatus,
       hookSpanId: this.logData.hookSpanId,
       executionTime: this.logData.executionTime,
+      serviceTier: this.logData.serviceTier,
     };
     if (this.logData.transformedRequest) {
       clonedLogData.transformedRequest = {
@@ -303,6 +306,10 @@ export class LogObjectBuilder {
     this.logData.originalResponse = {
       body: originalResponseJson,
     };
+    // Capture service_tier from the provider response for pricing attribution
+    if (originalResponseJson?.service_tier !== undefined) {
+      this.logData.serviceTier = originalResponseJson.service_tier;
+    }
     return this;
   }
 

--- a/src/providers/openai/chatComplete.ts
+++ b/src/providers/openai/chatComplete.ts
@@ -159,7 +159,8 @@ export const OpenAIChatCompleteJSONToStreamResponseTransform: (
   provider: string
 ) => Array<string> = (response, provider) => {
   const streamChunkArray: Array<string> = [];
-  const { id, model, system_fingerprint, choices, citations } = response;
+  const { id, model, system_fingerprint, choices, citations, service_tier } =
+    response;
 
   const {
     prompt_tokens,
@@ -196,6 +197,7 @@ export const OpenAIChatCompleteJSONToStreamResponseTransform: (
       ...(num_search_queries && { num_search_queries }),
     },
     ...(citations && { citations }),
+    ...(service_tier !== undefined && { service_tier }),
   };
 
   for (const [index, choice] of choices.entries()) {

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -171,6 +171,7 @@ export interface BaseResponse {
 export interface CResponse extends BaseResponse {
   id: string;
   created: number;
+  service_tier?: string | null;
   usage?: {
     prompt_tokens: number;
     completion_tokens: number;

--- a/src/types/messagesResponse.ts
+++ b/src/types/messagesResponse.ts
@@ -277,7 +277,7 @@ export interface Usage {
   /**
    * If the request used the priority, standard, or batch tier.
    */
-  service_tier?: 'standard' | 'priority' | 'batch' | null;
+  service_tier?: 'standard' | 'priority' | 'batch' | 'flex' | null;
 }
 
 export interface MessagesResponse {

--- a/tests/unit/src/handlers/services/flexPricing.test.ts
+++ b/tests/unit/src/handlers/services/flexPricing.test.ts
@@ -1,0 +1,285 @@
+import { Context } from 'hono';
+import {
+  LogsService,
+  LogObjectBuilder,
+} from '../../../../../src/handlers/services/logsService';
+import { RequestContext } from '../../../../../src/handlers/services/requestContext';
+import { OpenAIChatCompleteJSONToStreamResponseTransform } from '../../../../../src/providers/openai/chatComplete';
+import { OPEN_AI } from '../../../../../src/globals';
+
+describe('Flex Pricing Support', () => {
+  describe('LogObjectBuilder.addResponse - service_tier handling', () => {
+    let mockLogsService: LogsService;
+    let mockRequestContext: RequestContext;
+    let logObjectBuilder: LogObjectBuilder;
+
+    beforeEach(() => {
+      mockLogsService = {
+        addRequestLog: jest.fn(),
+      } as unknown as LogsService;
+
+      mockRequestContext = {
+        providerOption: { provider: 'openai' },
+        requestURL: 'https://api.openai.com/v1/chat/completions',
+        endpoint: 'chatComplete',
+        requestBody: { model: 'gpt-4o', messages: [] },
+        index: 0,
+        cacheConfig: { mode: 'simple', maxAge: 3600 },
+      } as unknown as RequestContext;
+
+      logObjectBuilder = new LogObjectBuilder(
+        mockLogsService,
+        mockRequestContext
+      );
+    });
+
+    it('should capture service_tier: "flex" from response JSON', () => {
+      const mockResponse = new Response('{}');
+      const originalJson = {
+        id: 'chatcmpl-123',
+        choices: [],
+        service_tier: 'flex',
+      };
+
+      logObjectBuilder.addResponse(mockResponse, originalJson);
+      logObjectBuilder.log();
+
+      expect(mockLogsService.addRequestLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceTier: 'flex',
+        })
+      );
+    });
+
+    it('should capture service_tier: "auto" (standard tier)', () => {
+      const mockResponse = new Response('{}');
+      const originalJson = {
+        id: 'chatcmpl-123',
+        choices: [],
+        service_tier: 'auto',
+      };
+
+      logObjectBuilder.addResponse(mockResponse, originalJson);
+      logObjectBuilder.log();
+
+      expect(mockLogsService.addRequestLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          serviceTier: 'auto',
+        })
+      );
+    });
+
+    it('should handle missing service_tier gracefully (undefined)', () => {
+      const mockResponse = new Response('{}');
+      const originalJson = {
+        id: 'chatcmpl-123',
+        choices: [],
+      };
+
+      logObjectBuilder.addResponse(mockResponse, originalJson);
+      logObjectBuilder.log();
+
+      const loggedData = (mockLogsService.addRequestLog as jest.Mock).mock
+        .calls[0][0];
+      // service_tier is not in the response, so serviceTier should not be set
+      expect(loggedData.serviceTier).toBeUndefined();
+    });
+
+    it('should handle service_tier: null', () => {
+      const mockResponse = new Response('{}');
+      const originalJson = {
+        id: 'chatcmpl-123',
+        choices: [],
+        service_tier: null,
+      };
+
+      logObjectBuilder.addResponse(mockResponse, originalJson);
+      logObjectBuilder.log();
+
+      const loggedData = (mockLogsService.addRequestLog as jest.Mock).mock
+        .calls[0][0];
+      // null is a defined value, so it should be captured
+      expect(loggedData.serviceTier).toBeNull();
+    });
+
+    it('should preserve serviceTier through clone (via log())', () => {
+      const mockResponse = new Response('{}');
+      const originalJson = {
+        id: 'chatcmpl-123',
+        choices: [],
+        service_tier: 'flex',
+      };
+
+      logObjectBuilder.addResponse(mockResponse, originalJson);
+      logObjectBuilder.log();
+      logObjectBuilder.log(); // log again to verify clone preserves serviceTier
+
+      const firstLog = (mockLogsService.addRequestLog as jest.Mock).mock
+        .calls[0][0];
+      const secondLog = (mockLogsService.addRequestLog as jest.Mock).mock
+        .calls[1][0];
+      expect(firstLog.serviceTier).toBe('flex');
+      expect(secondLog.serviceTier).toBe('flex');
+    });
+  });
+
+  describe('LogsService.createLogObject - service_tier handling', () => {
+    let mockContext: Context;
+    let logsService: LogsService;
+    let mockRequestContext: RequestContext;
+    let mockResponse: Response;
+
+    beforeEach(() => {
+      mockContext = {
+        get: jest.fn(),
+        set: jest.fn(),
+      } as unknown as Context;
+
+      logsService = new LogsService(mockContext);
+
+      mockRequestContext = {
+        providerOption: { provider: 'openai' },
+        requestURL: 'https://api.openai.com/v1/chat/completions',
+        endpoint: 'chatComplete',
+        transformedRequestBody: { model: 'gpt-4o', messages: [] },
+        params: { model: 'gpt-4o', messages: [] },
+        index: 0,
+        cacheConfig: { mode: 'simple', maxAge: 3600 },
+      } as unknown as RequestContext;
+
+      mockResponse = new Response('{}', { status: 200 });
+    });
+
+    it('should capture service_tier: "flex" in createLogObject', async () => {
+      const result = await logsService.createLogObject(
+        mockRequestContext,
+        {} as any,
+        'hook-span',
+        undefined,
+        { headers: {} },
+        undefined,
+        mockResponse,
+        { choices: [], service_tier: 'flex' }
+      );
+
+      expect(result.serviceTier).toBe('flex');
+    });
+
+    it('should set serviceTier to null when originalResponseJSON has no service_tier', async () => {
+      const result = await logsService.createLogObject(
+        mockRequestContext,
+        {} as any,
+        'hook-span',
+        undefined,
+        { headers: {} },
+        undefined,
+        mockResponse,
+        { choices: [] }
+      );
+
+      expect(result.serviceTier).toBeNull();
+    });
+
+    it('should set serviceTier to null when originalResponseJSON is null', async () => {
+      const result = await logsService.createLogObject(
+        mockRequestContext,
+        {} as any,
+        'hook-span',
+        undefined,
+        { headers: {} },
+        undefined,
+        mockResponse,
+        null
+      );
+
+      expect(result.serviceTier).toBeNull();
+    });
+  });
+
+  describe('OpenAIChatCompleteJSONToStreamResponseTransform - service_tier in chunks', () => {
+    const baseResponse = {
+      id: 'chatcmpl-123',
+      object: 'chat.completion' as const,
+      created: 1234567890,
+      model: 'gpt-4o',
+      system_fingerprint: 'fp_abc',
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant' as const,
+            content: 'Hello',
+          },
+          finish_reason: 'stop' as const,
+        },
+      ],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 5,
+        total_tokens: 15,
+      },
+    };
+
+    it('should include service_tier in stream chunks when present', () => {
+      const response = {
+        ...baseResponse,
+        service_tier: 'flex',
+      };
+
+      const chunks = OpenAIChatCompleteJSONToStreamResponseTransform(
+        response as any,
+        OPEN_AI
+      );
+
+      // Parse the first data chunk
+      const firstDataChunk = chunks[0];
+      const parsed = JSON.parse(firstDataChunk.replace('data: ', '').trim());
+      expect(parsed.service_tier).toBe('flex');
+    });
+
+    it('should omit service_tier from stream chunks when not present', () => {
+      const response = { ...baseResponse };
+
+      const chunks = OpenAIChatCompleteJSONToStreamResponseTransform(
+        response as any,
+        OPEN_AI
+      );
+
+      const firstDataChunk = chunks[0];
+      const parsed = JSON.parse(firstDataChunk.replace('data: ', '').trim());
+      expect(parsed).not.toHaveProperty('service_tier');
+    });
+
+    it('should include service_tier: null in stream chunks when explicitly null', () => {
+      const response = {
+        ...baseResponse,
+        service_tier: null,
+      };
+
+      const chunks = OpenAIChatCompleteJSONToStreamResponseTransform(
+        response as any,
+        OPEN_AI
+      );
+
+      const firstDataChunk = chunks[0];
+      const parsed = JSON.parse(firstDataChunk.replace('data: ', '').trim());
+      expect(parsed.service_tier).toBeNull();
+    });
+
+    it('should include service_tier: "auto" in stream chunks', () => {
+      const response = {
+        ...baseResponse,
+        service_tier: 'auto',
+      };
+
+      const chunks = OpenAIChatCompleteJSONToStreamResponseTransform(
+        response as any,
+        OPEN_AI
+      );
+
+      const firstDataChunk = chunks[0];
+      const parsed = JSON.parse(firstDataChunk.replace('data: ', '').trim());
+      expect(parsed.service_tier).toBe('auto');
+    });
+  });
+});

--- a/tests/unit/src/handlers/services/logsService.test.ts
+++ b/tests/unit/src/handlers/services/logsService.test.ts
@@ -214,6 +214,7 @@ describe('LogsService', () => {
         cacheMaxAge: 3600,
         hookSpanId: 'hook-span-123',
         executionTime: 1500,
+        serviceTier: null,
       });
     });
 


### PR DESCRIPTION
## Summary

- Adds `service_tier` field to the gateway's response type (`CResponse`) so flex/standard/batch tier is part of the typed response chain
- Captures `service_tier` from OpenAI responses into `LogObject` (via both `LogObjectBuilder.addResponse()` and `createLogObject()`) so the backend pricing system can detect flex tier and apply the 50% discount
- Preserves `service_tier` in JSON-to-stream response transforms, using `!== undefined` check to correctly handle `null` values
- Adds `'flex'` to the Anthropic-style `service_tier` union type in `messagesResponse.ts`

## Files Changed

- `src/providers/types.ts` — added `service_tier?: string | null` to `CResponse`
- `src/handlers/services/logsService.ts` — added `serviceTier` to `LogObject`, capture in `addResponse()`, `clone()`, and `createLogObject()`
- `src/providers/openai/chatComplete.ts` — include `service_tier` in JSON-to-stream transform
- `src/types/messagesResponse.ts` — added `'flex'` to union type
- `tests/unit/src/handlers/services/flexPricing.test.ts` — 12 new tests
- `tests/unit/src/handlers/services/logsService.test.ts` — updated for new field

## Test plan

- [x] 12 unit tests covering: flex/standard/null/absent service_tier in logs, clone preservation, stream transforms
- [x] Existing test suite passes (47/47 tests)
- [x] Build compiles cleanly
- [x] Dynamic red team (19 tests) against live gateway + mock OpenAI server: type confusion, injection attacks, SSE injection, prototype pollution, 100KB payloads, concurrent stress, cross-request contamination — all passed

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)