### PR TITLE
feat: Add support for Cerebras text completion endpoints

### DIFF
--- a/src/providers/cerebras/api.ts
+++ b/src/providers/cerebras/api.ts
@@ -12,6 +12,8 @@ export const cerebrasAPIConfig: ProviderAPIConfig = {
     switch (fn) {
       case 'chatComplete':
         return '/chat/completions';
+      case 'complete':
+        return '/completions';
       default:
         return '';
     }

--- a/src/providers/cerebras/index.ts
+++ b/src/providers/cerebras/index.ts
@@ -1,5 +1,9 @@
 import { CEREBRAS } from '../../globals';
-import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import {
+  chatCompleteParams,
+  completeParams,
+  responseTransformers,
+} from '../open-ai-base';
 import { ProviderConfigs } from '../types';
 import { cerebrasAPIConfig } from './api';
 
@@ -12,8 +16,17 @@ export const cerebrasProviderAPIConfig: ProviderConfigs = {
     'parallel_tool_calls',
     'service_tier',
   ]),
+  complete: completeParams([
+    'frequency_penalty',
+    'logit_bias',
+    'logprobs',
+    'presence_penalty',
+    'best_of',
+    'echo',
+  ]),
   api: cerebrasAPIConfig,
   responseTransforms: responseTransformers(CEREBRAS, {
     chatComplete: true,
+    complete: true,
   }),
 };


### PR DESCRIPTION
**Description:**
- Added text completion endpoint support for Cerebras provider at `/completions`
- Configured `completeParams` with excluded parameters that Cerebras doesn't support (frequency_penalty, logit_bias, logprobs, presence_penalty, best_of, echo)
- Added response transformers to handle text completion responses in OpenAI-compatible format

Closes #1342.

**The code in this pull request was generated by GitHub Copilot with the Claude Sonnet 4.5 model.**

**Tests Run/Test cases added:**
- [x] Build verification: `npm run build` passes successfully
- [x] Code formatting: `npm run format:check` passes
- [x] Pre-push validation: `npm run pre-push` completes successfully
- [x] Manual API testing with Cerebras API key (requires Cerebras credentials)

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)