### PR TITLE
Z.ai GLM-Image integration — Ascend Corp | EGG Digital

### DIFF
--- a/src/providers/z-ai/api.ts
+++ b/src/providers/z-ai/api.ts
@@ -9,6 +9,8 @@ const ZAIAPIConfig: ProviderAPIConfig = {
     switch (fn) {
       case 'chatComplete':
         return '/chat/completions';
+      case 'imageGenerate':
+        return '/images/generations';
       default:
         return '';
     }

--- a/src/providers/z-ai/imageGenerate.ts
+++ b/src/providers/z-ai/imageGenerate.ts
@@ -1,0 +1,56 @@
+import { Z_AI } from '../../globals';
+import { ErrorResponse, ImageGenerateResponse, ProviderConfig } from '../types';
+import { OpenAIErrorResponseTransform } from '../openai/utils';
+
+export const ZAIImageGenerateConfig: ProviderConfig = {
+  prompt: {
+    param: 'prompt',
+    required: true,
+  },
+  model: {
+    param: 'model',
+    required: true,
+    default: 'cogview-4-250304',
+  },
+  n: {
+    param: 'n',
+    min: 1,
+    max: 10,
+  },
+  quality: {
+    param: 'quality',
+  },
+  response_format: {
+    param: 'response_format',
+  },
+  size: {
+    param: 'size',
+  },
+  style: {
+    param: 'style',
+  },
+  user: {
+    param: 'user',
+  },
+};
+
+interface ZAIImageObject {
+  b64_json?: string;
+  url?: string;
+  revised_prompt?: string;
+}
+
+interface ZAIImageGenerateResponse extends ImageGenerateResponse {
+  data: ZAIImageObject[];
+}
+
+export const ZAIImageGenerateResponseTransform: (
+  response: ZAIImageGenerateResponse | ErrorResponse,
+  responseStatus: number
+) => ImageGenerateResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, Z_AI);
+  }
+
+  return response;
+};

--- a/src/providers/z-ai/index.ts
+++ b/src/providers/z-ai/index.ts
@@ -2,14 +2,20 @@ import { ProviderConfigs } from '../types';
 import { Z_AI } from '../../globals';
 import ZAIAPIConfig from './api';
 import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import {
+  ZAIImageGenerateConfig,
+  ZAIImageGenerateResponseTransform,
+} from './imageGenerate';
 
 const ZAIConfig: ProviderConfigs = {
   chatComplete: chatCompleteParams([], { model: 'glm-4.6' }),
+  imageGenerate: ZAIImageGenerateConfig,
   api: ZAIAPIConfig,
   responseTransforms: {
     ...responseTransformers(Z_AI, {
       chatComplete: true,
     }),
+    imageGenerate: ZAIImageGenerateResponseTransform,
   },
 };
 


### PR DESCRIPTION
## Summary

Add image generation (imageGenerate) support to the Z.ai provider for the GLM-Image / CogView models

## Customer Gap

**Customer:** Ascend Corp | EGG Digital
**Category:** feature commitment
**Gap:** Support for Z.ai image generation (GLM-Image model) was promised with a target date of around Feb 20th. Commitment was made to keep customer updated if timeline changes.

> "We do plan to support image generation with this model and it's on our near-term roadmap... targeting to have support available around 20th Feb"

## References

- **Pylon Ticket:** [#2610](https://app.usepylon.com/issues/760e2e8a-2f3f-43f5-bdd9-b17b69e28def)
- **Linear:** [FDE-19](https://linear.app/portkey/issue/FDE-19/gap-zai-glm-image-integration-ascend-corp-or-egg-digital)

## Acceptance Criteria

- [ ] POST /v1/images/generations with provider=z-ai and model=cogview-4-250304 (or GLM-Image) successfully proxies to Z.ai's /images/generations endpoint
- [ ] The request body correctly maps OpenAI-compatible image generation params (prompt, model, n, size, response_format) to the Z.ai API
- [ ] Successful Z.ai image generation responses are returned in OpenAI-compatible format with data array containing url/b64_json
- [ ] Error responses from Z.ai are properly transformed with provider attribution (provider: 'z-ai')
- [ ] The Z.ai provider index.ts exports both chatComplete and imageGenerate configurations
- [ ] Gateway builds successfully with no TypeScript errors after changes

## Changed Files

- `src/providers/z-ai/api.ts` (modified)
- `src/providers/z-ai/imageGenerate.ts` (added)
- `src/providers/z-ai/index.ts` (modified)
