### PR TITLE
feat: Add ModelsLab provider for image generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,8 +32,6 @@
 
 <br/>
 
-
-
 The [**AI Gateway**](https://portkey.wiki/gh-10) is designed for fast, reliable & secure routing to 1600+ language, vision, audio, and image models. It is a lightweight, open-source, and enterprise-ready solution that allows you to integrate with any language model in under 2 minutes.
 
 - [x] **Blazing fast** (<1ms latency) with a tiny footprint (122kb)

--- a/README.md
+++ b/README.md
@@ -3,17 +3,17 @@
    <strong>English</strong> | <a href="./.github/README.cn.md">中文</a> | <a href="./.github/README.jp.md">日本語</a>
 </p>
 
+> [!IMPORTANT]
+> :rocket: Gateway 2.0 (Pre-Release) Portkey's core enterprise gateway is merging into open-source with our 2.0 release. You can try the pre-release branch [here](https://github.com/portkey-ai/gateway/tree/2.0.0).
+> Read more about what's next for Portkey in our [**Series A announcement**](https://portkey.wiki/rohit-a).
+
+
 <div align="center">
 
 🆕 **[Portkey Models](https://github.com/Portkey-AI/models)** - Open-source LLM pricing for 2,300+ models across 40+ providers. [Explore →](https://portkey.ai/models)
 
 
 # AI Gateway
-
-> [!IMPORTANT]
-> :rocket: Gateway 2.0 (Pre-Release) Portkey's core enterprise gateway is merging into open-source with our 2.0 release. You can try the pre-release branch [here](https://github.com/portkey-ai/gateway/tree/2.0.0).
-> Read more about what's next for Portkey in our [**Series A announcement**](https://portkey.wiki/rohit-a).
-
 #### Route to 250+ LLMs with 1 fast & friendly API
 
 <img src="https://cfassets.portkey.ai/sdk.gif" width="550px" alt="Portkey AI Gateway Demo showing LLM routing capabilities" style="margin-left:-35px">

--- a/README.md
+++ b/README.md
@@ -9,6 +9,11 @@
 
 
 # AI Gateway
+
+> [!IMPORTANT]
+> :rocket: Gateway 2.0 (Pre-Release) Portkey's core enterprise gateway is merging into open-source with our 2.0 release. You can try the pre-release branch [here](https://github.com/portkey-ai/gateway/tree/2.0.0).
+> Read more about what's next for Portkey in our [**Series A announcement**](https://portkey.wiki/rohit-a).
+
 #### Route to 250+ LLMs with 1 fast & friendly API
 
 <img src="https://cfassets.portkey.ai/sdk.gif" width="550px" alt="Portkey AI Gateway Demo showing LLM routing capabilities" style="margin-left:-35px">
@@ -26,6 +31,8 @@
 </div>
 
 <br/>
+
+
 
 The [**AI Gateway**](https://portkey.wiki/gh-10) is designed for fast, reliable & secure routing to 1600+ language, vision, audio, and image models. It is a lightweight, open-source, and enterprise-ready solution that allows you to integrate with any language model in under 2 minutes.
 

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -63,6 +63,7 @@ export const AI21: string = 'ai21';
 export const BEDROCK: string = 'bedrock';
 export const GROQ: string = 'groq';
 export const SEGMIND: string = 'segmind';
+export const MODELSLAB: string = 'modelslab';
 export const JINA: string = 'jina';
 export const FIREWORKS_AI: string = 'fireworks-ai';
 export const WORKERS_AI: string = 'workers-ai';
@@ -136,6 +137,7 @@ export const VALID_PROVIDERS = [
   BEDROCK,
   GROQ,
   SEGMIND,
+  MODELSLAB,
   JINA,
   FIREWORKS_AI,
   WORKERS_AI,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -20,6 +20,7 @@ import OllamaAPIConfig from './ollama';
 import { ProviderConfigs } from './types';
 import GroqConfig from './groq';
 import SegmindConfig from './segmind';
+import ModelsLabConfig from './modelslab';
 import JinaConfig from './jina';
 import FireworksAIConfig from './fireworks-ai';
 import WorkersAiConfig from './workers-ai';
@@ -97,6 +98,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   bedrock: BedrockConfig,
   groq: GroqConfig,
   segmind: SegmindConfig,
+  modelslab: ModelsLabConfig,
   jina: JinaConfig,
   'fireworks-ai': FireworksAIConfig,
   'workers-ai': WorkersAiConfig,

--- a/src/providers/modelslab/api.ts
+++ b/src/providers/modelslab/api.ts
@@ -1,0 +1,18 @@
+import { ProviderAPIConfig } from '../types';
+
+const ModelsLabAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://modelslab.com/api/v6',
+  headers: () => {
+    return { 'Content-Type': 'application/json' };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'imageGenerate':
+        return '/images/text2img';
+      default:
+        return '';
+    }
+  },
+};
+
+export default ModelsLabAPIConfig;

--- a/src/providers/modelslab/imageGenerate.ts
+++ b/src/providers/modelslab/imageGenerate.ts
@@ -1,0 +1,151 @@
+import { MODELSLAB } from '../../globals';
+import { Options } from '../../types/requestBody';
+import { ErrorResponse, ImageGenerateResponse, ProviderConfig } from '../types';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+} from '../utils';
+
+export const ModelsLabImageGenerateConfig: ProviderConfig = {
+  // Inject the API key into the request body (ModelsLab requires "key" in JSON body)
+  _key: {
+    param: 'key',
+    required: true,
+    default: (_params: any, providerOptions: Options) => providerOptions.apiKey,
+  },
+  prompt: {
+    param: 'prompt',
+    required: true,
+  },
+  model: {
+    param: 'model_id',
+    default: 'flux',
+  },
+  n: {
+    param: 'samples',
+    default: 1,
+    min: 1,
+    max: 4,
+  },
+  size: [
+    {
+      param: 'width',
+      transform: (params: any) => {
+        if (!params.size) return 512;
+        return parseInt(params.size.toLowerCase().split('x')[0]);
+      },
+      min: 256,
+    },
+    {
+      param: 'height',
+      transform: (params: any) => {
+        if (!params.size) return 512;
+        return parseInt(params.size.toLowerCase().split('x')[1]);
+      },
+      min: 256,
+    },
+  ],
+  steps: {
+    param: 'num_inference_steps',
+    default: 30,
+    min: 1,
+    max: 50,
+  },
+  guidance_scale: {
+    param: 'guidance_scale',
+    default: 7.5,
+    min: 1,
+    max: 20,
+  },
+  seed: {
+    param: 'seed',
+  },
+  negative_prompt: {
+    param: 'negative_prompt',
+  },
+  safety_checker: {
+    param: 'safety_checker',
+    default: 'no',
+  },
+  webhook: {
+    param: 'webhook',
+  },
+  track_id: {
+    param: 'track_id',
+  },
+};
+
+interface ModelsLabImageGenerateSuccessResponse {
+  status: 'success';
+  generationTime: number;
+  id: number;
+  output: string[];
+  nsfw_content_detected: string[] | null;
+  meta: Record<string, any>;
+}
+
+interface ModelsLabImageGenerateProcessingResponse {
+  status: 'processing';
+  id: number;
+  output: string[] | null;
+  fetch_result: string;
+  eta: number;
+  message: string;
+  messege?: string;
+}
+
+interface ModelsLabImageGenerateErrorResponse {
+  status: 'error';
+  message: string;
+  messege?: string; // Legacy typo in older API versions
+}
+
+type ModelsLabImageGenerateResponse =
+  | ModelsLabImageGenerateSuccessResponse
+  | ModelsLabImageGenerateProcessingResponse
+  | ModelsLabImageGenerateErrorResponse;
+
+export const ModelsLabImageGenerateResponseTransform: (
+  response: ModelsLabImageGenerateResponse,
+  responseStatus: number
+) => ImageGenerateResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200 || response.status === 'error') {
+    const message =
+      ('message' in response && response.message) ||
+      ('messege' in response && response.messege) ||
+      'Unknown error occurred';
+    return generateErrorResponse(
+      {
+        message: message as string,
+        type: 'ModelsLabError',
+        param: null,
+        code: String(responseStatus),
+      },
+      MODELSLAB
+    );
+  }
+
+  if (response.status === 'processing') {
+    // Generation is queued; return a processing response with the fetch URL.
+    // Consumers should use webhooks or poll `response.fetch_result` for the result.
+    return generateErrorResponse(
+      {
+        message: `Image generation is processing. Poll fetch URL: ${response.fetch_result} | ETA: ${response.eta}s`,
+        type: 'ModelsLabProcessing',
+        param: null,
+        code: '202',
+      },
+      MODELSLAB
+    );
+  }
+
+  if (response.status === 'success' && response.output?.length) {
+    return {
+      created: Math.floor(Date.now() / 1000),
+      data: response.output.map((url) => ({ url })),
+      provider: MODELSLAB,
+    } as ImageGenerateResponse;
+  }
+
+  return generateInvalidProviderResponseError(response, MODELSLAB);
+};

--- a/src/providers/modelslab/index.ts
+++ b/src/providers/modelslab/index.ts
@@ -1,0 +1,16 @@
+import { ProviderConfigs } from '../types';
+import ModelsLabAPIConfig from './api';
+import {
+  ModelsLabImageGenerateConfig,
+  ModelsLabImageGenerateResponseTransform,
+} from './imageGenerate';
+
+const ModelsLabConfig: ProviderConfigs = {
+  api: ModelsLabAPIConfig,
+  imageGenerate: ModelsLabImageGenerateConfig,
+  responseTransforms: {
+    imageGenerate: ModelsLabImageGenerateResponseTransform,
+  },
+};
+
+export default ModelsLabConfig;


### PR DESCRIPTION
## Summary

Adds **[ModelsLab](https://modelslab.com)** as a new AI provider for image generation (text-to-image) via the Portkey AI Gateway.

ModelsLab is a developer-first AI API platform offering 200+ models for image, video, voice, and 3D generation. It currently routes to providers like Stability AI, FLUX, SDXL, and thousands of community fine-tuned models.

---

## What this PR adds

| File | Purpose |
|------|---------|
| `src/providers/modelslab/api.ts` | Base URL, headers, endpoint routing |
| `src/providers/modelslab/imageGenerate.ts` | ProviderConfig + response transform |
| `src/providers/modelslab/index.ts` | Provider config registry |
| `src/globals.ts` | `MODELSLAB` provider constant |
| `src/providers/index.ts` | Register modelslab in provider map |

---

## Parameter Mapping

| Portkey param | ModelsLab param | Notes |
|---|---|---|
| `prompt` | `prompt` | Required |
| `model` | `model_id` | Default: `flux` |
| `n` | `samples` | 1–4 |
| `size` (e.g. `1024x1024`) | `width`, `height` | Min 256px |
| `steps` | `num_inference_steps` | 1–50, default 30 |
| `guidance_scale` | `guidance_scale` | 1–20, default 7.5 |
| `seed` | `seed` | |
| `negative_prompt` | `negative_prompt` | |

**Auth:** ModelsLab uses key-in-body authentication. The API key from `providerOptions.apiKey` is automatically injected into the request body as `"key"`.

**Async/Webhook:** For slow models, ModelsLab returns `"status": "processing"` with a `fetch_result` poll URL. This provider surfaces that as an error message with the poll URL; consumers should use the `webhook` parameter for async workflows.

---

## Usage

```bash
curl http://localhost:8787/v1/images/generations \
  -H 'Content-Type: application/json' \
  -H 'x-portkey-provider: modelslab' \
  -H 'Authorization: Bearer YOUR_MODELSLAB_API_KEY' \
  -d '{
    "prompt": "a photorealistic sunset over mountain peaks",
    "model": "flux",
    "n": 1,
    "size": "1024x1024"
  }'
```

Response:
```json
{
  "created": 1708512345,
  "data": [
    { "url": "https://...modelslab.com/.../output.png" }
  ]
}
```

---

## API Reference

- Docs: https://docs.modelslab.com
- Image generation: https://docs.modelslab.com/image-generation/community-models/text2img
- Get API key: https://modelslab.com/dashboard/api-keys

---

## Checklist

- [x] Follows existing provider file structure (api.ts / imageGenerate.ts / index.ts)
- [x] Added provider constant to `globals.ts`
- [x] Registered in `providers/index.ts`
- [x] TypeScript compiles (no new errors)
- [x] Prettier check passes
- [x] Build succeeds (`rollup -c`)