### PR TITLE
fix: return tool_calls finish_reason for Gemini function calls

### DIFF
--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -24,6 +24,7 @@ import { GOOGLE_GENERATE_CONTENT_FINISH_REASON } from '../google/types';
 import {
   ChatCompletionResponse,
   ErrorResponse,
+  FINISH_REASON,
   Logprobs,
   ProviderConfig,
 } from '../types';
@@ -44,6 +45,7 @@ import {
   getMimeType,
   getThoughtSignature,
   googleTools,
+  hasToolCalls,
   recursivelyDeleteUnsupportedParameters,
   transformGeminiToolParameters,
   transformGoogleTools,
@@ -595,7 +597,7 @@ export const GoogleChatCompleteResponseTransform: (
             index: index,
             finish_reason:
               toolCalls.length > 0
-                ? 'tool_calls'
+                ? FINISH_REASON.tool_calls
                 : transformFinishReason(
                     generation.finishReason as GOOGLE_GENERATE_CONTENT_FINISH_REASON,
                     strictOpenAiCompliance
@@ -735,12 +737,10 @@ export const GoogleChatCompleteStreamChunkTransform: (
     provider: GOOGLE_VERTEX_AI,
     choices:
       parsedChunk.candidates?.map((generation, index) => {
-        const hasToolCalls = generation.content?.parts?.some(
-          (part) => part.functionCall
-        );
+        const containsToolCalls = hasToolCalls(generation.content?.parts);
         const finishReason = generation.finishReason
-          ? hasToolCalls
-            ? 'tool_calls'
+          ? containsToolCalls
+            ? FINISH_REASON.tool_calls
             : transformFinishReason(
                 parsedChunk.candidates[0]
                   .finishReason as GOOGLE_GENERATE_CONTENT_FINISH_REASON,

--- a/src/providers/google-vertex-ai/utils.ts
+++ b/src/providers/google-vertex-ai/utils.ts
@@ -1027,3 +1027,11 @@ export const getThoughtSignature = (
     return undefined; // older models do not require thought signature
   return 'skip_thought_signature_validator';
 };
+
+/**
+ * Determines if a Gemini response candidate contains tool/function calls.
+ * Used to override finish_reason since Gemini returns "STOP" even for function calls.
+ */
+export const hasToolCalls = (parts?: { functionCall?: unknown }[]): boolean => {
+  return parts?.some((part) => part.functionCall) ?? false;
+};

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -750,10 +750,13 @@ export const GoogleChatCompleteResponseTransform: (
             message: message,
             logprobs,
             index: generation.index ?? idx,
-            finish_reason: transformFinishReason(
-              generation.finishReason,
-              strictOpenAiCompliance
-            ),
+            finish_reason:
+              toolCalls.length > 0
+                ? 'tool_calls'
+                : transformFinishReason(
+                    generation.finishReason,
+                    strictOpenAiCompliance
+                  ),
             ...(!strictOpenAiCompliance && generation.groundingMetadata
               ? { groundingMetadata: generation.groundingMetadata }
               : {}),
@@ -842,11 +845,16 @@ export const GoogleChatCompleteStreamChunkTransform: (
       choices:
         parsedChunk.candidates?.map((generation, index) => {
           let message: any = { role: 'assistant', content: '' };
+          const hasToolCalls = generation.content?.parts?.some(
+            (part) => part.functionCall
+          );
           const finishReason = generation.finishReason
-            ? transformFinishReason(
-                generation.finishReason,
-                strictOpenAiCompliance
-              )
+            ? hasToolCalls
+              ? 'tool_calls'
+              : transformFinishReason(
+                  generation.finishReason,
+                  strictOpenAiCompliance
+                )
             : null;
           if (generation.content?.parts?.[0]?.text) {
             const contentBlocks = [];

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -20,10 +20,12 @@ import {
   transformGoogleTools,
   googleTools,
   getThoughtSignature,
+  hasToolCalls,
 } from '../google-vertex-ai/utils';
 import {
   ChatCompletionResponse,
   ErrorResponse,
+  FINISH_REASON,
   GroundingMetadata,
   Logprobs,
   ProviderConfig,
@@ -752,7 +754,7 @@ export const GoogleChatCompleteResponseTransform: (
             index: generation.index ?? idx,
             finish_reason:
               toolCalls.length > 0
-                ? 'tool_calls'
+                ? FINISH_REASON.tool_calls
                 : transformFinishReason(
                     generation.finishReason,
                     strictOpenAiCompliance
@@ -845,12 +847,10 @@ export const GoogleChatCompleteStreamChunkTransform: (
       choices:
         parsedChunk.candidates?.map((generation, index) => {
           let message: any = { role: 'assistant', content: '' };
-          const hasToolCalls = generation.content?.parts?.some(
-            (part) => part.functionCall
-          );
+          const containsToolCalls = hasToolCalls(generation.content?.parts);
           const finishReason = generation.finishReason
-            ? hasToolCalls
-              ? 'tool_calls'
+            ? containsToolCalls
+              ? FINISH_REASON.tool_calls
               : transformFinishReason(
                   generation.finishReason,
                   strictOpenAiCompliance


### PR DESCRIPTION
## Summary

- Fixes Gemini/Vertex AI returning `finish_reason: "stop"` instead of `"tool_calls"` when function calls are present
- Gemini API returns `finishReason: "STOP"` even when the response contains function calls (there is no `FUNCTION_CALL` finish reason in Gemini's API)
- This fix detects tool calls in the response content and returns `finish_reason: "tool_calls"` for OpenAI compatibility

## Changes

- Modified `GoogleChatCompleteResponseTransform` (non-streaming) for both Google and Vertex AI
- Modified `GoogleChatCompleteStreamChunkTransform` (streaming) for both Google and Vertex AI

## Test plan

- [ ] Verify Gemini tool calls return `finish_reason: "tool_calls"` in non-streaming mode
- [ ] Verify Gemini tool calls return `finish_reason: "tool_calls"` in streaming mode
- [ ] Verify regular completions still return appropriate finish reasons


Made with [Cursor](https://cursor.com)