### PR TITLE
fix(oracle): emit tool_calls in streaming responses

### DIFF
--- a/src/providers/oracle/chatComplete.test.ts
+++ b/src/providers/oracle/chatComplete.test.ts
@@ -1,0 +1,235 @@
+import {
+  initOracleStreamState,
+  OracleChatCompleteResponseTransform,
+  OracleChatCompleteStreamChunkTransform,
+  OracleChatDetailsConfig,
+} from './chatComplete';
+import { Message } from './types/ChatDetails';
+
+const baseProviderOptions = {
+  oracleCompartmentId: 'ocid1.compartment.oc1..test',
+} as any;
+
+const transformMessages = (messages: any[]): Message[] => {
+  const config = OracleChatDetailsConfig.messages as any;
+  return config.transform({ messages }, baseProviderOptions);
+};
+
+describe('Oracle Chat Complete — tool calls in request transform', () => {
+  it('attaches toolCalls to assistant messages', () => {
+    const out = transformMessages([
+      {
+        role: 'assistant',
+        content: '',
+        tool_calls: [
+          {
+            id: 'call_1',
+            type: 'function',
+            function: { name: 'get_weather', arguments: '{"city":"NYC"}' },
+          },
+        ],
+      },
+    ]);
+
+    expect(out[0].toolCalls).toEqual([
+      {
+        id: 'call_1',
+        type: 'FUNCTION',
+        name: 'get_weather',
+        arguments: '{"city":"NYC"}',
+      },
+    ]);
+  });
+
+  it('attaches toolCallId to tool messages', () => {
+    const out = transformMessages([
+      {
+        role: 'tool',
+        tool_call_id: 'call_1',
+        content: '{"temp":72}',
+      },
+    ]);
+
+    expect(out[0].toolCallId).toBe('call_1');
+    expect(out[0].role).toBe('TOOL');
+  });
+
+  it('does not attach toolCallId to non-tool messages', () => {
+    const out = transformMessages([{ role: 'user', content: 'hi' }]);
+    expect(out[0].toolCallId).toBeUndefined();
+  });
+});
+
+describe('Oracle Chat Complete — non-streaming response with tool_calls', () => {
+  it('extracts tool_calls into OpenAI shape', () => {
+    const response: any = {
+      modelId: 'meta.llama-3.3-70b-instruct',
+      chatResponse: {
+        timeCreated: '2026-01-01T00:00:00Z',
+        choices: [
+          {
+            index: 0,
+            finishReason: 'tool_calls',
+            message: {
+              role: 'ASSISTANT',
+              content: [],
+              toolCalls: [
+                {
+                  id: 'call_abc',
+                  name: 'get_weather',
+                  arguments: '{"city":"NYC"}',
+                },
+              ],
+            },
+          },
+        ],
+        usage: {
+          promptTokens: 10,
+          completionTokens: 5,
+          totalTokens: 15,
+        },
+      },
+    };
+
+    const result: any = OracleChatCompleteResponseTransform(
+      response,
+      200,
+      new Headers()
+    );
+
+    expect(result.choices[0].message.tool_calls).toEqual([
+      {
+        id: 'call_abc',
+        type: 'function',
+        function: { name: 'get_weather', arguments: '{"city":"NYC"}' },
+      },
+    ]);
+    expect(result.choices[0].finish_reason).toBe('tool_calls');
+  });
+
+  it('synthesises an id when the provider omits it', () => {
+    const response: any = {
+      modelId: 'google.gemini-2.5-flash',
+      chatResponse: {
+        timeCreated: '2026-01-01T00:00:00Z',
+        choices: [
+          {
+            index: 0,
+            finishReason: 'tool_calls',
+            message: {
+              role: 'ASSISTANT',
+              content: [],
+              toolCalls: [{ name: 'get_weather', arguments: '{}' }],
+            },
+          },
+        ],
+        usage: { promptTokens: 1, completionTokens: 1, totalTokens: 2 },
+      },
+    };
+
+    const result: any = OracleChatCompleteResponseTransform(
+      response,
+      200,
+      new Headers()
+    );
+
+    expect(result.choices[0].message.tool_calls[0].id).toMatch(/^call_/);
+  });
+});
+
+describe('Oracle Chat Complete — streaming chunk transform tool calls', () => {
+  const params: any = { model: 'meta.llama-3.3-70b-instruct' };
+
+  it('emits tool_calls delta separately from the finish chunk', () => {
+    const state = initOracleStreamState();
+
+    const sseChunk =
+      'data: ' +
+      JSON.stringify({
+        index: 0,
+        finishReason: 'tool_calls',
+        message: {
+          role: 'ASSISTANT',
+          content: [],
+          toolCalls: [
+            {
+              id: 'call_xyz',
+              name: 'get_weather',
+              arguments: '{"city":"NYC"}',
+            },
+          ],
+        },
+      });
+
+    const out = OracleChatCompleteStreamChunkTransform(
+      sseChunk,
+      'fallback-id',
+      state,
+      false,
+      params
+    );
+
+    expect(Array.isArray(out)).toBe(true);
+    const arr = out as string[];
+    // Expect: [tool_calls delta, finish chunk, [DONE]]
+    expect(arr.length).toBe(3);
+    expect(arr[0]).toContain('"tool_calls"');
+    expect(arr[0]).toContain('"call_xyz"');
+    expect(arr[1]).toContain('"finish_reason":"tool_calls"');
+    expect(arr[2]).toBe('data: [DONE]\n\n');
+  });
+
+  it('preserves stable indices across multiple tool calls', () => {
+    const state = initOracleStreamState();
+
+    const sseChunk =
+      'data: ' +
+      JSON.stringify({
+        index: 0,
+        finishReason: 'tool_calls',
+        message: {
+          role: 'ASSISTANT',
+          content: [],
+          toolCalls: [
+            { id: 'call_a', name: 'fn_a', arguments: '{}' },
+            { id: 'call_b', name: 'fn_b', arguments: '{}' },
+          ],
+        },
+      });
+
+    const out = OracleChatCompleteStreamChunkTransform(
+      sseChunk,
+      'fallback-id',
+      state,
+      false,
+      params
+    ) as string[];
+
+    const toolDelta = JSON.parse(out[0].replace(/^data: /, ''));
+    const calls = toolDelta.choices[0].delta.tool_calls;
+    expect(calls.map((c: any) => c.index)).toEqual([0, 1]);
+    expect(calls.map((c: any) => c.id)).toEqual(['call_a', 'call_b']);
+  });
+
+  it('returns DONE marker for [DONE] line', () => {
+    const out = OracleChatCompleteStreamChunkTransform(
+      'data: [DONE]',
+      'fallback-id',
+      initOracleStreamState(),
+      false,
+      params
+    );
+    expect(out).toBe('data: [DONE]\n\n');
+  });
+
+  it('skips ping events', () => {
+    const out = OracleChatCompleteStreamChunkTransform(
+      'event: ping',
+      'fallback-id',
+      initOracleStreamState(),
+      false,
+      params
+    );
+    expect(out).toBeUndefined();
+  });
+});

--- a/src/providers/oracle/chatComplete.test.ts
+++ b/src/providers/oracle/chatComplete.test.ts
@@ -140,7 +140,24 @@ describe('Oracle Chat Complete — non-streaming response with tool_calls', () =
 describe('Oracle Chat Complete — streaming chunk transform tool calls', () => {
   const params: any = { model: 'meta.llama-3.3-70b-instruct' };
 
-  it('emits tool_calls delta separately from the finish chunk', () => {
+  // Helper: split a concatenated SSE payload into individual event JSON objects.
+  const splitSse = (payload: string): { events: any[]; hasDone: boolean } => {
+    const events: any[] = [];
+    let hasDone = false;
+    for (const block of payload.split('\n\n')) {
+      const trimmed = block.trim();
+      if (!trimmed.startsWith('data:')) continue;
+      const body = trimmed.slice('data:'.length).trim();
+      if (body === '[DONE]') {
+        hasDone = true;
+        continue;
+      }
+      events.push(JSON.parse(body));
+    }
+    return { events, hasDone };
+  };
+
+  it('emits a tool_calls delta SSE then finish then [DONE] (bundled-finish chunk)', () => {
     const state = initOracleStreamState();
 
     const sseChunk =
@@ -167,19 +184,19 @@ describe('Oracle Chat Complete — streaming chunk transform tool calls', () => 
       state,
       false,
       params
-    );
+    ) as string;
 
-    expect(Array.isArray(out)).toBe(true);
-    const arr = out as string[];
-    // Expect: [tool_calls delta, finish chunk, [DONE]]
-    expect(arr.length).toBe(3);
-    expect(arr[0]).toContain('"tool_calls"');
-    expect(arr[0]).toContain('"call_xyz"');
-    expect(arr[1]).toContain('"finish_reason":"tool_calls"');
-    expect(arr[2]).toBe('data: [DONE]\n\n');
+    const { events, hasDone } = splitSse(out);
+    expect(events.length).toBe(2);
+    expect(events[0].choices[0].delta.tool_calls[0].id).toBe('call_xyz');
+    expect(events[0].choices[0].delta.tool_calls[0].function.name).toBe(
+      'get_weather'
+    );
+    expect(events[1].choices[0].finish_reason).toBe('tool_calls');
+    expect(hasDone).toBe(true);
   });
 
-  it('preserves stable indices across multiple tool calls', () => {
+  it('assigns stable indices when OCI bundles multiple tool calls', () => {
     const state = initOracleStreamState();
 
     const sseChunk =
@@ -203,12 +220,58 @@ describe('Oracle Chat Complete — streaming chunk transform tool calls', () => 
       state,
       false,
       params
-    ) as string[];
+    ) as string;
 
-    const toolDelta = JSON.parse(out[0].replace(/^data: /, ''));
-    const calls = toolDelta.choices[0].delta.tool_calls;
+    const { events } = splitSse(out);
+    const calls = events[0].choices[0].delta.tool_calls;
     expect(calls.map((c: any) => c.index)).toEqual([0, 1]);
     expect(calls.map((c: any) => c.id)).toEqual(['call_a', 'call_b']);
+  });
+
+  it('keeps continuation chunks attached to the same tool index when id is omitted', () => {
+    const state = initOracleStreamState();
+
+    const first = OracleChatCompleteStreamChunkTransform(
+      'data: ' +
+        JSON.stringify({
+          index: 0,
+          message: {
+            role: 'ASSISTANT',
+            content: [],
+            toolCalls: [
+              { id: 'call_progressive', name: 'get_weather', arguments: '' },
+            ],
+          },
+        }),
+      'fallback-id',
+      state,
+      false,
+      params
+    ) as string;
+
+    const second = OracleChatCompleteStreamChunkTransform(
+      'data: ' +
+        JSON.stringify({
+          index: 0,
+          message: {
+            role: 'ASSISTANT',
+            content: [],
+            toolCalls: [{ arguments: '{"city":"' }],
+          },
+        }),
+      'fallback-id',
+      state,
+      false,
+      params
+    ) as string;
+
+    const firstEvent = JSON.parse(first.split('\n\n')[0].slice('data:'.length));
+    const secondEvent = JSON.parse(
+      second.split('\n\n')[0].slice('data:'.length)
+    );
+    expect(firstEvent.choices[0].delta.tool_calls[0].index).toBe(0);
+    expect(secondEvent.choices[0].delta.tool_calls[0].index).toBe(0);
+    expect(secondEvent.choices[0].delta.tool_calls[0].id).toBeUndefined();
   });
 
   it('returns DONE marker for [DONE] line', () => {

--- a/src/providers/oracle/chatComplete.ts
+++ b/src/providers/oracle/chatComplete.ts
@@ -377,7 +377,7 @@ export const OracleChatCompleteStreamChunkTransform: (
   streamState: OracleStreamState,
   _strictOpenAiCompliance: boolean,
   gatewayRequest: Params
-) => string | string[] | undefined = (
+) => string | undefined = (
   responseChunk,
   fallbackId,
   streamState,
@@ -407,44 +407,50 @@ export const OracleChatCompleteStreamChunkTransform: (
   }
 
   // Map OCI toolCalls to OpenAI tool_calls deltas with stable indices.
-  // OCI emits tool calls in the same chunk as finishReason, so we must split
-  // them across two SSE events: first the tool_calls delta, then the finish.
+  // OCI may stream tool calls progressively across multiple chunks: the first
+  // chunk per tool carries `id` + `name`, subsequent chunks carry argument
+  // fragments without an `id`. Anchor on `id` when present; otherwise inherit
+  // the current index so continuation fragments stay attached to the right
+  // tool call.
   const rawToolCalls = (parsedChunk.message as any)?.toolCalls || [];
   const toolCalls: Array<{
     index: number;
-    id: string;
+    id?: string;
     type: string;
-    function: { name: string; arguments: string };
+    function: { name?: string; arguments: string };
   }> = [];
 
   for (const tc of rawToolCalls) {
-    if (!streamState.seenToolCallIds.has(tc.id)) {
-      streamState.currentToolCallIndex++;
-      streamState.seenToolCallIds.add(tc.id);
+    let toolIndex = streamState.currentToolCallIndex;
+    if (tc.id) {
+      if (!streamState.seenToolCallIds.has(tc.id)) {
+        streamState.currentToolCallIndex++;
+        streamState.seenToolCallIds.add(tc.id);
+      }
+      toolIndex = Array.from(streamState.seenToolCallIds).indexOf(tc.id);
     }
-    const toolCallIndex = Array.from(streamState.seenToolCallIds).indexOf(
-      tc.id
-    );
     toolCalls.push({
-      index:
-        toolCallIndex >= 0 ? toolCallIndex : streamState.currentToolCallIndex,
-      id: tc.id,
+      index: toolIndex >= 0 ? toolIndex : 0,
+      ...(tc.id ? { id: tc.id } : {}),
       type: 'function',
       function: {
-        name: tc.name,
+        ...(tc.name ? { name: tc.name } : {}),
         arguments:
           typeof tc.arguments === 'string'
             ? tc.arguments
-            : JSON.stringify(tc.arguments),
+            : JSON.stringify(tc.arguments ?? ''),
       },
     });
   }
 
+  // Final chunk: emit (optional bundled tool_calls delta) + finish + DONE
+  // as a single concatenated SSE payload. (`readStream` only handles single
+  // strings, not arrays.)
   if (parsedChunk.finishReason) {
-    const chunks: string[] = [];
+    const parts: string[] = [];
 
     if (toolCalls.length > 0) {
-      chunks.push(
+      parts.push(
         `data: ${JSON.stringify({
           id: fallbackId,
           object: 'chat.completion.chunk',
@@ -462,7 +468,7 @@ export const OracleChatCompleteStreamChunkTransform: (
       );
     }
 
-    chunks.push(
+    parts.push(
       `data: ${JSON.stringify({
         id: fallbackId,
         object: 'chat.completion.chunk',
@@ -478,9 +484,9 @@ export const OracleChatCompleteStreamChunkTransform: (
         ],
       })}\n\n`
     );
-    chunks.push('data: [DONE]\n\n');
+    parts.push('data: [DONE]\n\n');
 
-    return chunks;
+    return parts.join('');
   }
 
   const content = parsedChunk.message?.content?.find(

--- a/src/providers/oracle/chatComplete.ts
+++ b/src/providers/oracle/chatComplete.ts
@@ -28,6 +28,22 @@ import {
 } from './types/GenericChatResponse';
 import { openAIToOracleRoleMap, oracleToOpenAIRoleMap } from './utils';
 
+/**
+ * Stream state for tracking tool calls across streaming chunks.
+ * OCI sends tool calls in the message together with finishReason, so we need to
+ * track seen tool call IDs to assign stable indices for OpenAI-format deltas.
+ */
+export interface OracleStreamState {
+  currentToolCallIndex: number;
+  seenToolCallIds: Set<string>;
+  finishReason?: string;
+}
+
+export const initOracleStreamState = (): OracleStreamState => ({
+  currentToolCallIndex: -1,
+  seenToolCallIds: new Set(),
+});
+
 // transforms from openai format to oracle format for chat completions request
 export const OracleChatCompleteConfig: ProviderConfig = {
   model: [
@@ -127,10 +143,20 @@ export const OracleChatDetailsConfig: ProviderConfig = {
             }
           }
         }
-        transformedMessages.push({
+        const transformedMessage: Message = {
           role,
           content,
-        });
+        };
+
+        if (toolCalls.length > 0) {
+          transformedMessage.toolCalls = toolCalls;
+        }
+
+        if (message.role === 'tool' && message.tool_call_id) {
+          transformedMessage.toolCallId = message.tool_call_id;
+        }
+
+        transformedMessages.push(transformedMessage);
       }
       return transformedMessages;
     },
@@ -290,6 +316,21 @@ export const OracleChatCompleteResponseTransform: (
         const content = choice.message?.content?.find(
           (item) => item.type === 'TEXT'
         )?.text;
+
+        const toolCalls = (choice.message as any)?.toolCalls?.map(
+          (tc: ToolCall, index: number) => ({
+            id: tc.id || `call_${Date.now().toString(36)}_${index}`,
+            type: 'function',
+            function: {
+              name: tc.name,
+              arguments:
+                typeof tc.arguments === 'string'
+                  ? tc.arguments
+                  : JSON.stringify(tc.arguments),
+            },
+          })
+        );
+
         return {
           index: choice.index,
           message: {
@@ -297,6 +338,7 @@ export const OracleChatCompleteResponseTransform: (
               choice.message.role as OracleMessageRole
             ],
             content,
+            ...(toolCalls && toolCalls.length > 0 && { tool_calls: toolCalls }),
           },
           finish_reason: choice.finishReason,
         };
@@ -332,14 +374,14 @@ export const OracleChatCompleteResponseTransform: (
 export const OracleChatCompleteStreamChunkTransform: (
   response: string,
   fallbackId: string,
-  streamState: any,
+  streamState: OracleStreamState,
   _strictOpenAiCompliance: boolean,
   gatewayRequest: Params
-) => string | undefined = (
+) => string | string[] | undefined = (
   responseChunk,
   fallbackId,
   streamState,
-  strictOpenAiCompliance,
+  _strictOpenAiCompliance,
   gatewayRequest
 ) => {
   let chunk = responseChunk.trim();
@@ -350,17 +392,83 @@ export const OracleChatCompleteStreamChunkTransform: (
   chunk = chunk.replace(/^data: /, '');
   chunk = chunk.trim();
   if (chunk === '[DONE]') {
-    return chunk;
+    return 'data: [DONE]\n\n';
   }
+
+  if (streamState.currentToolCallIndex === undefined) {
+    streamState.currentToolCallIndex = -1;
+    streamState.seenToolCallIds = new Set();
+  }
+
   const parsedChunk: ChatChoice = JSON.parse(chunk);
 
   if (parsedChunk.finishReason) {
-    return (
+    streamState.finishReason = parsedChunk.finishReason;
+  }
+
+  // Map OCI toolCalls to OpenAI tool_calls deltas with stable indices.
+  // OCI emits tool calls in the same chunk as finishReason, so we must split
+  // them across two SSE events: first the tool_calls delta, then the finish.
+  const rawToolCalls = (parsedChunk.message as any)?.toolCalls || [];
+  const toolCalls: Array<{
+    index: number;
+    id: string;
+    type: string;
+    function: { name: string; arguments: string };
+  }> = [];
+
+  for (const tc of rawToolCalls) {
+    if (!streamState.seenToolCallIds.has(tc.id)) {
+      streamState.currentToolCallIndex++;
+      streamState.seenToolCallIds.add(tc.id);
+    }
+    const toolCallIndex = Array.from(streamState.seenToolCallIds).indexOf(
+      tc.id
+    );
+    toolCalls.push({
+      index:
+        toolCallIndex >= 0 ? toolCallIndex : streamState.currentToolCallIndex,
+      id: tc.id,
+      type: 'function',
+      function: {
+        name: tc.name,
+        arguments:
+          typeof tc.arguments === 'string'
+            ? tc.arguments
+            : JSON.stringify(tc.arguments),
+      },
+    });
+  }
+
+  if (parsedChunk.finishReason) {
+    const chunks: string[] = [];
+
+    if (toolCalls.length > 0) {
+      chunks.push(
+        `data: ${JSON.stringify({
+          id: fallbackId,
+          object: 'chat.completion.chunk',
+          created: Math.floor(Date.now() / 1000),
+          model: gatewayRequest.model || '',
+          provider: ORACLE,
+          choices: [
+            {
+              index: 0,
+              delta: { tool_calls: toolCalls },
+              finish_reason: null,
+            },
+          ],
+        })}\n\n`
+      );
+    }
+
+    chunks.push(
       `data: ${JSON.stringify({
         id: fallbackId,
         object: 'chat.completion.chunk',
         created: Math.floor(Date.now() / 1000),
         model: gatewayRequest.model || '',
+        provider: ORACLE,
         choices: [
           {
             index: 0,
@@ -368,11 +476,27 @@ export const OracleChatCompleteStreamChunkTransform: (
             finish_reason: parsedChunk.finishReason,
           },
         ],
-        provider: ORACLE,
-      })}` +
-      '\n\n' +
-      'data: [DONE]\n\n'
+      })}\n\n`
     );
+    chunks.push('data: [DONE]\n\n');
+
+    return chunks;
+  }
+
+  const content = parsedChunk.message?.content?.find(
+    (item) => item.type === 'TEXT'
+  )?.text;
+
+  const delta: Record<string, unknown> = {};
+  if (parsedChunk.message?.role) {
+    delta.role =
+      oracleToOpenAIRoleMap[parsedChunk.message.role as OracleMessageRole];
+  }
+  if (content) {
+    delta.content = content;
+  }
+  if (toolCalls.length > 0) {
+    delta.tool_calls = toolCalls;
   }
 
   return (
@@ -384,15 +508,8 @@ export const OracleChatCompleteStreamChunkTransform: (
       provider: ORACLE,
       choices: [
         {
-          index: parsedChunk.index,
-          delta: {
-            role: oracleToOpenAIRoleMap[
-              parsedChunk.message.role as OracleMessageRole
-            ],
-            content: parsedChunk.message?.content?.find(
-              (item) => item.type === 'TEXT'
-            )?.text,
-          },
+          index: parsedChunk.index ?? 0,
+          delta,
         },
       ],
     })}` + '\n\n'

--- a/src/providers/oracle/types/ChatDetails.ts
+++ b/src/providers/oracle/types/ChatDetails.ts
@@ -57,6 +57,21 @@ export interface Message {
   content?: Array<ChatContent>;
 
   role: string;
+
+  /**
+   * Tool calls made by the assistant (for ASSISTANT messages).
+   */
+  toolCalls?: Array<{
+    id: string;
+    type: string;
+    name: string;
+    arguments: string;
+  }>;
+
+  /**
+   * The ID of the tool call this message is responding to (for TOOL messages).
+   */
+  toolCallId?: string;
 }
 
 export interface StreamOptions {


### PR DESCRIPTION
## Summary

Fixes the OCI streaming chunk transform so that `tool_calls` are actually emitted to clients. Without this fix, agents using streamed tool calling against OCI models receive `finish_reason: "tool_calls"` with no tool data — see #1538.

## What changed

`src/providers/oracle/chatComplete.ts` (+ supporting types in `types/ChatDetails.ts`):

- **Streaming chunk transform** — split the OCI message chunk that bundles `toolCalls` together with `finishReason` into:
  1. a `tool_calls` delta chunk
  2. the finish-reason chunk
  3. a `data: [DONE]` marker
- **`OracleStreamState`** — tracks stable tool-call indices across streamed chunks (via a seen-id set) so the OpenAI-format `tool_calls[].index` stays consistent.
- **Request transform** — propagate `toolCalls` (assistant) and `toolCallId` (tool) onto the OCI request envelope so tool-call round-trips are correctly wired in.
- **Non-streaming response transform** — extract `toolCalls` into OpenAI-shape `tool_calls`, with an id fallback for providers (e.g. Gemini) that omit it.

## Tests

`src/providers/oracle/chatComplete.test.ts` — focused on the new behaviour:

- request shaping (`toolCalls` on assistant, `toolCallId` on tool, omitted otherwise)
- non-stream extraction (incl. synthesised id when provider omits one)
- streaming chunk shape (tool_calls delta → finish chunk → DONE)
- index stability across multiple parallel tool calls
- `[DONE]` and ping passthroughs

## Scope note (re: prior review)

This PR has been trimmed per @narengogi's review on the previous version. The earlier branch bundled embeddings, multi-vendor handler dispatch, GPT-5 `maxCompletionTokens` routing, multimodal content types, and unrelated changes to `open-ai-base/index.ts`, `utils/env.ts`, `requestBody.ts`, and `jest.config.js`. All of that is out — this PR is now scoped solely to the streaming tool-call fix referenced in #1538 plus the minimum supporting types and tests.

The split-off items now live in their own focused PRs:

- **Cohere embeddings** → #1634 (approved)
- **GPT-5 `maxCompletionTokens` routing** → #1635
- **Multi-vendor handler dispatch** → will follow in a separate PR once the current queue clears

The older kitchen-sink branch (#1540) has been closed in favour of these focused PRs.

## Verification

- `npm run build` ✓
- `npm run format:check` ✓
- Unit tests pass for the new test file (`chatComplete.test.ts`)
- Verified against live OCI (`inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/chat`) for streaming tool calls on Llama and Grok families.

Closes #1538
