### PR TITLE
feat: Add Zscaler AI Guard guardrail plugin

### DIFF
--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -57,6 +57,7 @@ import { handler as azureContentSafety } from './azure/contentSafety';
 import { handler as promptSecurityProtectPrompt } from './promptsecurity/protectPrompt';
 import { handler as promptSecurityProtectResponse } from './promptsecurity/protectResponse';
 import { handler as panwPrismaAirsintercept } from './panw-prisma-airs/intercept';
+import { handler as zscalerAiguardintercept } from './zscaler-aiguard/intercept';
 import { handler as defaultjwt } from './default/jwt';
 import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
 import { handler as walledaiguardrails } from './walledai/walledprotect';
@@ -166,6 +167,9 @@ export const plugins = {
   },
   'panw-prisma-airs': {
     intercept: panwPrismaAirsintercept,
+  },
+  'zscaler-aiguard': {
+    intercept: zscalerAiguardintercept,
   },
   walledai: {
     walledprotect: walledaiguardrails,

--- a/plugins/zscaler-aiguard/intercept.ts
+++ b/plugins/zscaler-aiguard/intercept.ts
@@ -1,0 +1,78 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { getText, post } from '../utils';
+
+const buildApiUrl = (cloud: string): string =>
+  `https://api.${cloud}.zseclipse.net/v1/detection/resolve-and-execute-policy`;
+
+const fetchAIGuard = async (url: string, payload: any, apiKey: string) => {
+  const opts = {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  };
+  return post(url, payload, opts, 10000);
+};
+
+export const handler: PluginHandler = async (
+  ctx: PluginContext,
+  params: PluginParameters,
+  hook: HookEventType
+) => {
+  const apiKey =
+    (params.credentials?.AIGUARD_API_KEY as string | undefined) ||
+    process.env.AIGUARD_API_KEY ||
+    '';
+
+  if (!apiKey || apiKey.trim() === '') {
+    return {
+      verdict: true,
+      error:
+        'AIGUARD_API_KEY is required but not configured. Please add your API key in the Portkey dashboard.',
+      data: null,
+    };
+  }
+
+  let verdict = true;
+  let data: any = null;
+  let error: any = null;
+
+  try {
+    const text = getText(ctx, hook);
+    const cloud = params.cloud ?? 'us1';
+    const url = buildApiUrl(cloud);
+
+    const direction = hook === 'beforeRequestHook' ? 'IN' : 'OUT';
+
+    const traceId =
+      ctx?.request?.headers?.['x-portkey-trace-id'] ||
+      (typeof crypto !== 'undefined' && typeof crypto.randomUUID === 'function'
+        ? crypto.randomUUID()
+        : Math.random().toString(36).substring(2) + Date.now().toString(36));
+
+    const payload = {
+      content: text,
+      direction: direction,
+      transaction_id: traceId,
+    };
+
+    const res: any = await fetchAIGuard(url, payload, apiKey);
+
+    if (!res || typeof res.action !== 'string') {
+      throw new Error('Malformed AI Guard response');
+    }
+
+    if (res.action.toLowerCase() === 'block') {
+      verdict = false;
+    }
+
+    data = res;
+  } catch (e: any) {
+    error = e;
+    verdict = false;
+  }
+
+  return { verdict, data, error };
+};

--- a/plugins/zscaler-aiguard/intercept.ts
+++ b/plugins/zscaler-aiguard/intercept.ts
@@ -5,13 +5,17 @@ import {
   PluginParameters,
 } from '../types';
 import { getText, post } from '../utils';
+import { VERSION } from './version';
 
 const buildApiUrl = (cloud: string): string =>
   `https://api.${cloud}.zseclipse.net/v1/detection/resolve-and-execute-policy`;
 
 const fetchAIGuard = async (url: string, payload: any, apiKey: string) => {
   const opts = {
-    headers: { Authorization: `Bearer ${apiKey}` },
+    headers: {
+      Authorization: `Bearer ${apiKey}`,
+      'User-Agent': `portkey-ai-plugin/${VERSION}`,
+    },
   };
   return post(url, payload, opts, 10000);
 };

--- a/plugins/zscaler-aiguard/manifest.json
+++ b/plugins/zscaler-aiguard/manifest.json
@@ -1,0 +1,48 @@
+{
+  "id": "zscalerAiguard",
+  "name": "Zscaler AI Guard Guardrail",
+  "description": "Zscaler AI Guard provides real-time AI security scanning for prompt injections, PII leakage, secrets exposure, toxicity, and policy violations. Uses automatic policy resolution — no profile or policy ID is needed at the gateway level.",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "AIGUARD_API_KEY": {
+        "type": "string",
+        "label": "AI Guard API Key",
+        "description": "API key for Zscaler AI Guard. Generate one in the Zscaler admin portal under AI Guard settings.",
+        "encrypted": true
+      }
+    },
+    "required": ["AIGUARD_API_KEY"]
+  },
+  "functions": [
+    {
+      "id": "intercept",
+      "name": "Zscaler AI Guard Guardrail",
+      "type": "guardrail",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Scan prompts and responses for security threats using Zscaler AI Guard with automatic policy resolution."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "cloud": {
+            "type": "string",
+            "label": "Cloud Region",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Zscaler cloud region (e.g., us1, us2, eu1). Determines the API endpoint."
+              }
+            ],
+            "default": "us1"
+          }
+        },
+        "required": []
+      }
+    }
+  ]
+}

--- a/plugins/zscaler-aiguard/version.ts
+++ b/plugins/zscaler-aiguard/version.ts
@@ -1,0 +1,1 @@
+export const VERSION = 'v1.0.0-beta';

--- a/plugins/zscaler-aiguard/zscaler.aiguard.test.ts
+++ b/plugins/zscaler-aiguard/zscaler.aiguard.test.ts
@@ -1,0 +1,262 @@
+import { handler as zscalerAIGuardHandler } from './intercept';
+
+jest.mock('../utils', () => ({
+  ...jest.requireActual('../utils'),
+  post: jest.fn(),
+}));
+
+import * as utils from '../utils';
+const mockPost = utils.post as jest.MockedFunction<typeof utils.post>;
+
+describe('Zscaler AI Guard Guardrail', () => {
+  const mockContext = {
+    request: { text: 'This is a test prompt.' },
+    response: { text: 'This is a test response.' },
+  };
+
+  const params = {
+    credentials: { AIGUARD_API_KEY: 'dummy-key' },
+    cloud: 'us1',
+  };
+
+  beforeEach(() => {
+    mockPost.mockClear();
+  });
+
+  it('should return a result object with verdict, data, and error', async () => {
+    mockPost.mockResolvedValue({ action: 'ALLOW', severity: 'LOW' });
+
+    const result = await zscalerAIGuardHandler(
+      mockContext,
+      params,
+      'beforeRequestHook'
+    );
+    expect(result).toHaveProperty('verdict');
+    expect(result).toHaveProperty('data');
+    expect(result).toHaveProperty('error');
+  });
+
+  it('should allow when AI Guard returns action=ALLOW', async () => {
+    mockPost.mockResolvedValue({
+      action: 'ALLOW',
+      severity: 'LOW',
+      direction: 'IN',
+      policyName: 'TestPolicy',
+      detectorResponses: {},
+    });
+
+    const result = await zscalerAIGuardHandler(
+      mockContext,
+      params,
+      'beforeRequestHook'
+    );
+
+    expect(result.verdict).toBe(true);
+    expect(result.data.action).toBe('ALLOW');
+    expect(result.error).toBeNull();
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('should block when AI Guard returns action=BLOCK', async () => {
+    mockPost.mockResolvedValue({
+      action: 'BLOCK',
+      severity: 'CRITICAL',
+      direction: 'IN',
+      policyName: 'TestPolicy',
+      detectorResponses: {
+        pii: { triggered: true, action: 'BLOCK' },
+      },
+    });
+
+    const result = await zscalerAIGuardHandler(
+      mockContext,
+      params,
+      'beforeRequestHook'
+    );
+
+    expect(result.verdict).toBe(false);
+    expect(result.data.action).toBe('BLOCK');
+    expect(result.error).toBeNull();
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('should call the correct API URL based on cloud region', async () => {
+    mockPost.mockResolvedValue({ action: 'ALLOW' });
+
+    const eu1Params = {
+      credentials: { AIGUARD_API_KEY: 'dummy-key' },
+      cloud: 'eu1',
+    };
+
+    await zscalerAIGuardHandler(mockContext, eu1Params, 'beforeRequestHook');
+
+    expect(mockPost).toHaveBeenCalledWith(
+      'https://api.eu1.zseclipse.net/v1/detection/resolve-and-execute-policy',
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Number)
+    );
+  });
+
+  it('should default to us1 cloud when not specified', async () => {
+    mockPost.mockResolvedValue({ action: 'ALLOW' });
+
+    const paramsNoCloud = {
+      credentials: { AIGUARD_API_KEY: 'dummy-key' },
+    };
+
+    await zscalerAIGuardHandler(
+      mockContext,
+      paramsNoCloud,
+      'beforeRequestHook'
+    );
+
+    expect(mockPost).toHaveBeenCalledWith(
+      'https://api.us1.zseclipse.net/v1/detection/resolve-and-execute-policy',
+      expect.any(Object),
+      expect.any(Object),
+      expect.any(Number)
+    );
+  });
+
+  it('should send direction=IN for beforeRequestHook', async () => {
+    mockPost.mockResolvedValue({ action: 'ALLOW' });
+
+    await zscalerAIGuardHandler(mockContext, params, 'beforeRequestHook');
+
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ direction: 'IN' }),
+      expect.any(Object),
+      expect.any(Number)
+    );
+  });
+
+  it('should send direction=OUT for afterRequestHook', async () => {
+    mockPost.mockResolvedValue({ action: 'ALLOW' });
+
+    await zscalerAIGuardHandler(mockContext, params, 'afterRequestHook');
+
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ direction: 'OUT' }),
+      expect.any(Object),
+      expect.any(Number)
+    );
+  });
+
+  it('should use x-portkey-trace-id as transaction_id when available', async () => {
+    const traceId = '38d838c3-2151-4f40-9729-9607f34ea446';
+    const mockContextWithTraceId = {
+      request: {
+        text: 'Test prompt.',
+        headers: { 'x-portkey-trace-id': traceId },
+      },
+      response: { text: 'Test response.' },
+    };
+
+    mockPost.mockResolvedValue({ action: 'ALLOW' });
+
+    await zscalerAIGuardHandler(
+      mockContextWithTraceId,
+      params,
+      'beforeRequestHook'
+    );
+
+    expect(mockPost).toHaveBeenCalledWith(
+      expect.any(String),
+      expect.objectContaining({ transaction_id: traceId }),
+      expect.any(Object),
+      expect.any(Number)
+    );
+  });
+
+  it('should allow traffic when API key is missing (no HTTP call)', async () => {
+    const originalEnvKey = process.env.AIGUARD_API_KEY;
+    delete process.env.AIGUARD_API_KEY;
+
+    const paramsWithoutKey = {
+      ...params,
+      credentials: {},
+    };
+
+    const result = await zscalerAIGuardHandler(
+      mockContext,
+      paramsWithoutKey,
+      'beforeRequestHook'
+    );
+
+    if (originalEnvKey !== undefined) {
+      process.env.AIGUARD_API_KEY = originalEnvKey;
+    } else {
+      delete process.env.AIGUARD_API_KEY;
+    }
+
+    expect(result.verdict).toBe(true);
+    expect(result.error).toContain(
+      'AIGUARD_API_KEY is required but not configured'
+    );
+    expect(result.data).toBeNull();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('should allow traffic when API key is whitespace only (no HTTP call)', async () => {
+    const originalEnvKey = process.env.AIGUARD_API_KEY;
+    delete process.env.AIGUARD_API_KEY;
+
+    const paramsWithEmptyKey = {
+      ...params,
+      credentials: { AIGUARD_API_KEY: '   ' },
+    };
+
+    const result = await zscalerAIGuardHandler(
+      mockContext,
+      paramsWithEmptyKey,
+      'beforeRequestHook'
+    );
+
+    if (originalEnvKey !== undefined) {
+      process.env.AIGUARD_API_KEY = originalEnvKey;
+    } else {
+      delete process.env.AIGUARD_API_KEY;
+    }
+
+    expect(result.verdict).toBe(true);
+    expect(result.error).toContain(
+      'AIGUARD_API_KEY is required but not configured'
+    );
+    expect(result.data).toBeNull();
+    expect(mockPost).not.toHaveBeenCalled();
+  });
+
+  it('should handle malformed AI Guard response', async () => {
+    mockPost.mockResolvedValue({ invalid: 'response' });
+
+    const result = await zscalerAIGuardHandler(
+      mockContext,
+      params,
+      'beforeRequestHook'
+    );
+
+    expect(result.verdict).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.error.message).toContain('Malformed AI Guard response');
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+
+  it('should handle network errors', async () => {
+    const networkError = new Error('Network timeout');
+    mockPost.mockRejectedValue(networkError);
+
+    const result = await zscalerAIGuardHandler(
+      mockContext,
+      params,
+      'beforeRequestHook'
+    );
+
+    expect(result.verdict).toBe(false);
+    expect(result.error).toBe(networkError);
+    expect(result.data).toBeNull();
+    expect(mockPost).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

- Adds a new **Zscaler AI Guard** guardrail plugin that scans prompts and LLM responses in real time for security threats including prompt injections, PII leakage, secrets exposure, toxicity, and policy violations
- Uses the AI Guard DAS API (`resolve-and-execute-policy`) with automatic policy resolution — no profile or policy ID needed at the gateway level
- Supports configurable cloud regions (us1, us2, eu1, etc.) and both `beforeRequestHook` (input) and `afterRequestHook` (output) hook types

## Files

| File | Description |
|------|-------------|
| `plugins/zscaler-aiguard/manifest.json` | Plugin metadata, credentials schema (encrypted API key), cloud region parameter |
| `plugins/zscaler-aiguard/intercept.ts` | Handler implementation — builds API URL from cloud region, sends content with direction (IN/OUT), uses Portkey trace ID as transaction ID |
| `plugins/zscaler-aiguard/zscaler.aiguard.test.ts` | 12 unit tests covering allow/block, cloud region routing, direction mapping, trace ID propagation, missing API key, malformed response, and network errors |
| `plugins/index.ts` | Registers the new plugin |

## How it works

1. Extracts text from the request/response context via `getText()` utility
2. Determines direction: `IN` for `beforeRequestHook`, `OUT` for `afterRequestHook`
3. Calls `https://api.{cloud}.zseclipse.net/v1/detection/resolve-and-execute-policy` with Bearer token auth
4. If AI Guard returns `action: "BLOCK"`, sets `verdict: false` to block the request
5. On API errors or malformed responses, blocks by default (fail-closed)

## Configuration

Users configure the plugin in the Portkey dashboard:
- **AIGUARD_API_KEY** (required, encrypted) — Zscaler AI Guard API key
- **cloud** (optional, default: `us1`) — Cloud region

## Test plan

- [x] All 12 unit tests pass (`npm test -- --testPathPattern=zscaler`)
- [x] Prettier formatting check passes
- [x] Build succeeds
- [x] Gateway starts successfully
- [ ] Portkey team review

## References

- [Zscaler AI Guard](https://www.zscaler.com/products/ai-guard)
- Similar to the existing `panw-prisma-airs` plugin pattern


Made with [Cursor](https://cursor.com)