### PR TITLE
provider: add Avian as a new LLM provider

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -113,6 +113,7 @@ export const ORACLE: string = 'oracle';
 export const IO_INTELLIGENCE: string = 'iointelligence';
 export const AIBADGR: string = 'aibadgr';
 export const OVHCLOUD: string = 'ovhcloud';
+export const AVIAN: string = 'avian';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -189,6 +190,7 @@ export const VALID_PROVIDERS = [
   IO_INTELLIGENCE,
   AIBADGR,
   OVHCLOUD,
+  AVIAN,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/avian/api.ts
+++ b/src/providers/avian/api.ts
@@ -1,0 +1,20 @@
+import { ProviderAPIConfig } from '../types';
+
+const AvianAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://api.avian.io/v1',
+  headers: ({ providerOptions }) => {
+    return {
+      Authorization: `Bearer ${providerOptions.apiKey}`,
+    };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      default:
+        return '';
+    }
+  },
+};
+
+export default AvianAPIConfig;

--- a/src/providers/avian/chatComplete.ts
+++ b/src/providers/avian/chatComplete.ts
@@ -1,0 +1,65 @@
+import { AVIAN } from '../../globals';
+
+interface AvianStreamChunk {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: {
+    index: number;
+    delta: {
+      role?: string | null;
+      content?: string;
+      tool_calls?: {
+        index: number;
+        id?: string;
+        type?: string;
+        function?: {
+          name?: string;
+          arguments?: string;
+        };
+      }[];
+    };
+    finish_reason: string | null;
+  }[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export const AvianChatCompleteStreamChunkTransform: (
+  responseChunk: string
+) => string = (responseChunk) => {
+  let chunk = responseChunk.trim();
+  chunk = chunk.replace(/^data: /, '');
+  chunk = chunk.trim();
+
+  if (chunk === '[DONE]') {
+    return `data: ${chunk}\n\n`;
+  }
+
+  const parsedChunk: AvianStreamChunk = JSON.parse(chunk);
+  return (
+    `data: ${JSON.stringify({
+      id: parsedChunk.id,
+      object: parsedChunk.object,
+      created: parsedChunk.created,
+      model: parsedChunk.model,
+      provider: AVIAN,
+      choices: parsedChunk.choices.map((choice) => ({
+        index: choice.index,
+        delta: choice.delta,
+        finish_reason: choice.finish_reason,
+      })),
+      usage: parsedChunk.usage
+        ? {
+            prompt_tokens: parsedChunk.usage.prompt_tokens,
+            completion_tokens: parsedChunk.usage.completion_tokens,
+            total_tokens: parsedChunk.usage.total_tokens,
+          }
+        : undefined,
+    })}` + '\n\n'
+  );
+};

--- a/src/providers/avian/index.ts
+++ b/src/providers/avian/index.ts
@@ -1,0 +1,20 @@
+import { AVIAN } from '../../globals';
+import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import AvianAPIConfig from './api';
+import { AvianChatCompleteStreamChunkTransform } from './chatComplete';
+
+const AvianConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams([], {
+    model: 'deepseek/deepseek-v3.2',
+  }),
+  api: AvianAPIConfig,
+  responseTransforms: {
+    ...responseTransformers(AVIAN, {
+      chatComplete: true,
+    }),
+    'stream-chatComplete': AvianChatCompleteStreamChunkTransform,
+  },
+};
+
+export default AvianConfig;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,6 +74,7 @@ import OracleConfig from './oracle';
 import IOIntelligenceConfig from './iointelligence';
 import AIBadgrConfig from './aibadgr';
 import OVHcloudConfig from './ovhcloud';
+import AvianConfig from './avian';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -148,6 +149,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   iointelligence: IOIntelligenceConfig,
   aibadgr: AIBadgrConfig,
   ovhcloud: OVHcloudConfig,
+  avian: AvianConfig,
 };
 
 export default Providers;


### PR DESCRIPTION
**Description:**
- Add [Avian](https://avian.io) as a new OpenAI-compatible LLM provider
- Avian provides access to multiple LLM models through a unified API at `https://api.avian.io/v1`
- Supports chat completions, streaming, and function calling
- Auth via Bearer token (`AVIAN_API_KEY`)
- Available models:
  - `deepseek/deepseek-v3.2` — 164K context, 65K max output
  - `moonshotai/kimi-k2.5` — 131K context, 8K max output
  - `z-ai/glm-5` — 131K context, 16K max output
  - `minimax/minimax-m2.5` — 1M context, 1M max output

**Files changed:**
- `src/providers/avian/api.ts` — API config (base URL, auth headers, endpoint routing)
- `src/providers/avian/chatComplete.ts` — Stream chunk transform for SSE streaming
- `src/providers/avian/index.ts` — Provider config using `open-ai-base` helpers
- `src/globals.ts` — Added `AVIAN` constant and registered in `VALID_PROVIDERS`
- `src/providers/index.ts` — Registered `AvianConfig` in the providers map

**Tests Run/Test cases added:**
- [x] TypeScript compilation passes (`npx tsc --noEmit` — no avian-related errors)
- [x] Build succeeds (`npm run build`)
- [x] Gateway starts successfully (`node start-test.js`)
- [x] Prettier formatting verified on all new files

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)