### PR TITLE
feat: propagate strict parameter for Anthropic tool definitions

### DIFF
--- a/src/providers/anthropic/__tests__/tool-transform.test.ts
+++ b/src/providers/anthropic/__tests__/tool-transform.test.ts
@@ -1,0 +1,68 @@
+import { AnthropicChatCompleteConfig } from '../chatComplete';
+
+jest.mock('../../../data-stores/redis', () => ({
+  redisClient: null,
+  redisReaderClient: null,
+}));
+
+jest.mock('../../../utils/awsAuth', () => ({}));
+
+jest.mock('../../..', () => ({}));
+
+const toolsTransform = (AnthropicChatCompleteConfig.tools as any).transform;
+
+function makeOpenAITool(overrides: Record<string, any> = {}) {
+  return {
+    type: 'function',
+    function: {
+      name: 'get_weather',
+      description: 'Get weather for a location',
+      parameters: {
+        type: 'object',
+        properties: {
+          location: { type: 'string', description: 'City name' },
+        },
+        required: ['location'],
+      },
+      ...overrides,
+    },
+  };
+}
+
+describe('Anthropic tool transform - strict parameter', () => {
+  it('forwards strict: true to the Anthropic tool definition', () => {
+    const result = toolsTransform({
+      tools: [makeOpenAITool({ strict: true })],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].strict).toBe(true);
+  });
+
+  it('forwards strict: false to the Anthropic tool definition', () => {
+    const result = toolsTransform({
+      tools: [makeOpenAITool({ strict: false })],
+    });
+    expect(result).toHaveLength(1);
+    expect(result[0].strict).toBe(false);
+  });
+
+  it('omits strict when not provided in the OpenAI tool', () => {
+    const result = toolsTransform({ tools: [makeOpenAITool()] });
+    expect(result).toHaveLength(1);
+    expect(result[0]).not.toHaveProperty('strict');
+  });
+
+  it('handles multiple tools with mixed strict settings', () => {
+    const result = toolsTransform({
+      tools: [
+        makeOpenAITool({ name: 'tool_a', strict: true }),
+        makeOpenAITool({ name: 'tool_b', strict: false }),
+        makeOpenAITool({ name: 'tool_c' }),
+      ],
+    });
+    expect(result).toHaveLength(3);
+    expect(result[0].strict).toBe(true);
+    expect(result[1].strict).toBe(false);
+    expect(result[2]).not.toHaveProperty('strict');
+  });
+});

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -59,6 +59,11 @@ interface AnthropicTool extends PromptCache {
    * Example inputs demonstrating how to use this tool.
    */
   input_examples?: Record<string, any>[];
+  /**
+   * When true, Anthropic uses constrained decoding to guarantee
+   * tool call arguments conform to the input_schema.
+   */
+  strict?: boolean;
 }
 
 interface AnthropicToolResultContentItem {
@@ -418,6 +423,9 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
               }),
               ...(tool.function.input_examples && {
                 input_examples: tool.function.input_examples,
+              }),
+              ...(tool.function.strict !== undefined && {
+                strict: tool.function.strict,
               }),
             });
           } else if (tool.type) {


### PR DESCRIPTION
When using the OpenAI chat completions interface with an underlying Anthropic model, the strict field on tool definitions was being dropped during the OpenAI-to-Anthropic transformation. This adds support for forwarding strict to Anthropic's native tool format, enabling constrained decoding for tool call arguments.

**Description:** (required)
- Added `strict` field to the `AnthropicTool` interface to match Anthropic's native tool definition schema
- Updated the OpenAI-to-Anthropic tool transformation logic to propagate `tool.function.strict` when present, using the same conditional spread pattern as other optional fields like `input_examples`

**Tests Run/Test cases added:** (required)
- [x] Ran full gateway test suite (`npm run test:gateway`). 2/10 suites pass (47 tests), matching `main` exactly. The 8 failing suites are pre-existing upstream issues (broken imports from a prior refactor, missing integration credentials) unrelated to this change.
- [x] Build and startup smoke test passed via pre-push hook

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)