### PR TITLE
feat: add streaming transformer for ai21

### DIFF
--- a/src/providers/ai21/chatComplete.test.ts
+++ b/src/providers/ai21/chatComplete.test.ts
@@ -1,0 +1,182 @@
+import { AI21ChatCompleteStreamChunkTransform } from './chatComplete';
+
+describe('AI21ChatCompleteStreamChunkTransform', () => {
+  const fallbackId = 'ai21-fallback-id';
+  const streamState = {};
+
+  it('should transform a role-only first chunk', () => {
+    const rawChunk = `data: ${JSON.stringify({
+      id: 'req-123',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'jamba-1.5-mini',
+      choices: [
+        { index: 0, delta: { role: 'assistant' }, finish_reason: null },
+      ],
+      usage: null,
+    })}`;
+
+    const result = AI21ChatCompleteStreamChunkTransform(
+      rawChunk,
+      fallbackId,
+      streamState,
+      true
+    );
+
+    const parsed = JSON.parse(result.replace('data: ', '').trim());
+    expect(parsed.id).toBe('req-123');
+    expect(parsed.object).toBe('chat.completion.chunk');
+    expect(parsed.model).toBe('jamba-1.5-mini');
+    expect(parsed.provider).toBe('ai21');
+    expect(parsed.choices[0].delta.role).toBe('assistant');
+    expect(parsed.choices[0].finish_reason).toBeNull();
+    expect(parsed.usage).toBeNull();
+  });
+
+  it('should transform a content delta chunk', () => {
+    const rawChunk = `data: ${JSON.stringify({
+      id: 'req-123',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'jamba-1.5-mini',
+      choices: [{ index: 0, delta: { content: 'Hello' }, finish_reason: null }],
+      usage: null,
+    })}`;
+
+    const result = AI21ChatCompleteStreamChunkTransform(
+      rawChunk,
+      fallbackId,
+      streamState,
+      true
+    );
+
+    const parsed = JSON.parse(result.replace('data: ', '').trim());
+    expect(parsed.choices[0].delta.content).toBe('Hello');
+    expect(parsed.choices[0].finish_reason).toBeNull();
+  });
+
+  it('should transform a final chunk with finish_reason and usage', () => {
+    const rawChunk = `data: ${JSON.stringify({
+      id: 'req-123',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'jamba-1.5-mini',
+      choices: [{ index: 0, delta: {}, finish_reason: 'stop' }],
+      usage: {
+        prompt_tokens: 10,
+        completion_tokens: 45,
+        total_tokens: 55,
+      },
+    })}`;
+
+    const result = AI21ChatCompleteStreamChunkTransform(
+      rawChunk,
+      fallbackId,
+      streamState,
+      true
+    );
+
+    const parsed = JSON.parse(result.replace('data: ', '').trim());
+    expect(parsed.choices[0].finish_reason).toBe('stop');
+    expect(parsed.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 45,
+      total_tokens: 55,
+    });
+  });
+
+  it('should handle [DONE] marker', () => {
+    const rawChunk = 'data: [DONE]';
+
+    const result = AI21ChatCompleteStreamChunkTransform(
+      rawChunk,
+      fallbackId,
+      streamState,
+      true
+    );
+
+    expect(result).toBe('data: [DONE]\n\n');
+  });
+
+  it('should use fallbackId when chunk has no id', () => {
+    const rawChunk = `data: ${JSON.stringify({
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'jamba-1.5-mini',
+      choices: [{ index: 0, delta: { content: 'test' }, finish_reason: null }],
+    })}`;
+
+    const result = AI21ChatCompleteStreamChunkTransform(
+      rawChunk,
+      fallbackId,
+      streamState,
+      true
+    );
+
+    const parsed = JSON.parse(result.replace('data: ', '').trim());
+    expect(parsed.id).toBe(fallbackId);
+  });
+
+  it('should handle chunk without data: prefix', () => {
+    const rawChunk = JSON.stringify({
+      id: 'req-456',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'jamba-1.5-mini',
+      choices: [{ index: 0, delta: { content: 'world' }, finish_reason: null }],
+      usage: null,
+    });
+
+    const result = AI21ChatCompleteStreamChunkTransform(
+      rawChunk,
+      fallbackId,
+      streamState,
+      true
+    );
+
+    const parsed = JSON.parse(result.replace('data: ', '').trim());
+    expect(parsed.id).toBe('req-456');
+    expect(parsed.choices[0].delta.content).toBe('world');
+  });
+
+  it('should output in SSE format with trailing newlines', () => {
+    const rawChunk = `data: ${JSON.stringify({
+      id: 'req-123',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'jamba-1.5-mini',
+      choices: [{ index: 0, delta: { content: 'hi' }, finish_reason: null }],
+      usage: null,
+    })}`;
+
+    const result = AI21ChatCompleteStreamChunkTransform(
+      rawChunk,
+      fallbackId,
+      streamState,
+      true
+    );
+
+    expect(result).toMatch(/^data: \{.*\}\n\n$/);
+  });
+
+  it('should transform length finish_reason with strict compliance', () => {
+    const rawChunk = `data: ${JSON.stringify({
+      id: 'req-123',
+      object: 'chat.completion.chunk',
+      created: 1700000000,
+      model: 'jamba-1.5-mini',
+      choices: [{ index: 0, delta: {}, finish_reason: 'length' }],
+      usage: null,
+    })}`;
+
+    const result = AI21ChatCompleteStreamChunkTransform(
+      rawChunk,
+      fallbackId,
+      streamState,
+      true
+    );
+
+    const parsed = JSON.parse(result.replace('data: ', '').trim());
+    expect(parsed.choices[0].finish_reason).toBe('length');
+  });
+});

--- a/src/providers/ai21/chatComplete.test.ts
+++ b/src/providers/ai21/chatComplete.test.ts
@@ -159,6 +159,36 @@ describe('AI21ChatCompleteStreamChunkTransform', () => {
     expect(result).toMatch(/^data: \{.*\}\n\n$/);
   });
 
+  it('should return empty string for empty chunks', () => {
+    const result = AI21ChatCompleteStreamChunkTransform(
+      '',
+      fallbackId,
+      streamState,
+      true
+    );
+    expect(result).toBe('');
+  });
+
+  it('should return empty string for malformed JSON', () => {
+    const result = AI21ChatCompleteStreamChunkTransform(
+      'data: {invalid json}',
+      fallbackId,
+      streamState,
+      true
+    );
+    expect(result).toBe('');
+  });
+
+  it('should return empty string for SSE comment frames', () => {
+    const result = AI21ChatCompleteStreamChunkTransform(
+      ': ping',
+      fallbackId,
+      streamState,
+      true
+    );
+    expect(result).toBe('');
+  });
+
   it('should transform length finish_reason with strict compliance', () => {
     const rawChunk = `data: ${JSON.stringify({
       id: 'req-123',

--- a/src/providers/ai21/chatComplete.ts
+++ b/src/providers/ai21/chatComplete.ts
@@ -208,7 +208,15 @@ export const AI21ChatCompleteStreamChunkTransform: (
   if (chunk === '[DONE]') {
     return `data: ${chunk}\n\n`;
   }
-  const parsedChunk: AI21ChatCompleteStreamChunk = JSON.parse(chunk);
+  if (!chunk) {
+    return '';
+  }
+  let parsedChunk: AI21ChatCompleteStreamChunk;
+  try {
+    parsedChunk = JSON.parse(chunk);
+  } catch {
+    return '';
+  }
   return (
     `data: ${JSON.stringify({
       id: parsedChunk.id ?? fallbackId,
@@ -222,7 +230,9 @@ export const AI21ChatCompleteStreamChunkTransform: (
           delta: parsedChunk.choices[0]?.delta ?? {},
           finish_reason: parsedChunk.choices[0]?.finish_reason
             ? transformFinishReason(
-                parsedChunk.choices[0].finish_reason as any,
+                parsedChunk.choices[0].finish_reason as unknown as Parameters<
+                  typeof transformFinishReason
+                >[0],
                 strictOpenAiCompliance
               )
             : null,

--- a/src/providers/ai21/chatComplete.ts
+++ b/src/providers/ai21/chatComplete.ts
@@ -8,6 +8,7 @@ import {
 import {
   generateErrorResponse,
   generateInvalidProviderResponseError,
+  transformFinishReason,
 } from '../utils';
 import { AI21ErrorResponse } from './complete';
 
@@ -96,6 +97,10 @@ export const AI21ChatCompleteConfig: ProviderConfig = {
       };
     },
   },
+  stream: {
+    param: 'stream',
+    default: false,
+  },
   countPenalty: {
     param: 'countPenalty',
   },
@@ -164,4 +169,66 @@ export const AI21ChatCompleteResponseTransform: (
   }
 
   return generateInvalidProviderResponseError(response, AI21);
+};
+
+interface AI21ChatCompleteStreamChunk {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: {
+    index: number;
+    delta: {
+      role?: string;
+      content?: string;
+    };
+    finish_reason: string | null | undefined;
+  }[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  } | null;
+}
+
+export const AI21ChatCompleteStreamChunkTransform: (
+  response: string,
+  fallbackId: string,
+  streamState: Record<string, unknown>,
+  strictOpenAiCompliance: boolean
+) => string = (
+  responseChunk,
+  fallbackId,
+  _streamState,
+  strictOpenAiCompliance
+) => {
+  let chunk = responseChunk.trim();
+  chunk = chunk.replace(/^data: /, '');
+  chunk = chunk.trim();
+  if (chunk === '[DONE]') {
+    return `data: ${chunk}\n\n`;
+  }
+  const parsedChunk: AI21ChatCompleteStreamChunk = JSON.parse(chunk);
+  return (
+    `data: ${JSON.stringify({
+      id: parsedChunk.id ?? fallbackId,
+      object: parsedChunk.object ?? 'chat.completion.chunk',
+      created: parsedChunk.created ?? Math.floor(Date.now() / 1000),
+      model: parsedChunk.model ?? '',
+      provider: AI21,
+      choices: [
+        {
+          index: parsedChunk.choices[0]?.index ?? 0,
+          delta: parsedChunk.choices[0]?.delta ?? {},
+          finish_reason: parsedChunk.choices[0]?.finish_reason
+            ? transformFinishReason(
+                parsedChunk.choices[0].finish_reason as any,
+                strictOpenAiCompliance
+              )
+            : null,
+        },
+      ],
+      usage: parsedChunk.usage ?? null,
+    })}` + '\n\n'
+  );
 };

--- a/src/providers/ai21/index.ts
+++ b/src/providers/ai21/index.ts
@@ -3,6 +3,7 @@ import AI21APIConfig from './api';
 import {
   AI21ChatCompleteConfig,
   AI21ChatCompleteResponseTransform,
+  AI21ChatCompleteStreamChunkTransform,
 } from './chatComplete';
 import { AI21CompleteConfig, AI21CompleteResponseTransform } from './complete';
 import { AI21EmbedConfig, AI21EmbedResponseTransform } from './embed';
@@ -15,6 +16,7 @@ const AI21Config: ProviderConfigs = {
   responseTransforms: {
     complete: AI21CompleteResponseTransform,
     chatComplete: AI21ChatCompleteResponseTransform,
+    'stream-chatComplete': AI21ChatCompleteStreamChunkTransform,
     embed: AI21EmbedResponseTransform,
   },
 };


### PR DESCRIPTION
**Description:** (required)
 - Added streaming chunk transformer (`AI21ChatCompleteStreamChunkTransform`) for the ai21 provider to support streaming chat completions
- Added `stream` parameter to `AI21ChatCompleteConfig`
- Registered `stream-chatComplete` transform in AI21 provider config


**Tests Run/Test cases added:** (required)
- [ ] Description of test case

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)

Closes #831