### PR TITLE
provider: Add EmberCloud integration

### DIFF
--- a/src/data/providers.json
+++ b/src/data/providers.json
@@ -323,6 +323,13 @@
       "object": "provider",
       "description": "Dashscope provides intelligent analytics solutions designed to help businesses visualize and interpret complex data effectively. Their platform integrates advanced machine learning algorithms to generate real-time insights from diverse datasets, enabling organizations to make informed decisions quickly. Dashscope focuses on enhancing data accessibility and usability, empowering teams to leverage analytics for strategic planning and operational efficiency.",
       "base_url": "https://dashscope.aliyuncs.com/compatible-mode/v1"
+    },
+    {
+      "id": "embercloud",
+      "name": "EmberCloud",
+      "object": "provider",
+      "description": "EmberCloud provides access to GLM and MiniMax AI models through an OpenAI-compatible API with system-prompt affinity routing for optimized KV-cache performance.",
+      "base_url": "https://api.embercloud.ai/v1"
     }
   ]
 }

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -113,6 +113,7 @@ export const ORACLE: string = 'oracle';
 export const IO_INTELLIGENCE: string = 'iointelligence';
 export const AIBADGR: string = 'aibadgr';
 export const OVHCLOUD: string = 'ovhcloud';
+export const EMBER_CLOUD: string = 'embercloud';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -189,6 +190,7 @@ export const VALID_PROVIDERS = [
   IO_INTELLIGENCE,
   AIBADGR,
   OVHCLOUD,
+  EMBER_CLOUD,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/embercloud/api.ts
+++ b/src/providers/embercloud/api.ts
@@ -1,0 +1,22 @@
+import { ProviderAPIConfig } from '../types';
+
+const EmberCloudAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://api.embercloud.ai/v1',
+  headers: ({ providerOptions }) => {
+    return {
+      Authorization: `Bearer ${providerOptions.apiKey}`,
+    };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      case 'stream-chatComplete':
+        return '/chat/completions';
+      default:
+        return '';
+    }
+  },
+};
+
+export default EmberCloudAPIConfig;

--- a/src/providers/embercloud/chatComplete.ts
+++ b/src/providers/embercloud/chatComplete.ts
@@ -1,0 +1,62 @@
+import { EMBER_CLOUD } from '../../globals';
+import { ParameterConfig, ProviderConfig } from '../types';
+import { OpenAIChatCompleteConfig } from '../openai/chatComplete';
+
+const emberCloudModelConfig = OpenAIChatCompleteConfig.model as ParameterConfig;
+
+export const EmberCloudChatCompleteConfig: ProviderConfig = {
+  ...OpenAIChatCompleteConfig,
+  model: {
+    ...emberCloudModelConfig,
+    default: 'glm-4.7',
+  },
+};
+
+interface EmberCloudStreamChunk {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: {
+    delta?: Record<string, unknown>;
+    message?: Record<string, unknown>;
+    index: number;
+    finish_reason: string | null;
+  }[];
+  usage?: Record<string, unknown>;
+}
+
+export const EmberCloudChatCompleteStreamChunkTransform: (
+  responseChunk: string
+) => string = (responseChunk) => {
+  let chunk = responseChunk.trim();
+
+  if (!chunk) {
+    return '';
+  }
+
+  if (chunk.startsWith('data:')) {
+    chunk = chunk.slice(5).trim();
+  }
+
+  if (!chunk) {
+    return '';
+  }
+
+  if (chunk === '[DONE]') {
+    return `data: ${chunk}\n\n`;
+  }
+
+  const parsedChunk: EmberCloudStreamChunk = JSON.parse(chunk);
+
+  if (!parsedChunk?.choices?.length) {
+    return `data: ${chunk}\n\n`;
+  }
+
+  return (
+    `data: ${JSON.stringify({
+      ...parsedChunk,
+      provider: EMBER_CLOUD,
+    })}` + '\n\n'
+  );
+};

--- a/src/providers/embercloud/index.ts
+++ b/src/providers/embercloud/index.ts
@@ -1,0 +1,20 @@
+import { EMBER_CLOUD } from '../../globals';
+import { responseTransformers } from '../open-ai-base';
+import EmberCloudAPIConfig from './api';
+import {
+  EmberCloudChatCompleteConfig,
+  EmberCloudChatCompleteStreamChunkTransform,
+} from './chatComplete';
+
+const EmberCloudConfig = {
+  api: EmberCloudAPIConfig,
+  chatComplete: EmberCloudChatCompleteConfig,
+  responseTransforms: {
+    ...responseTransformers(EMBER_CLOUD, {
+      chatComplete: true,
+    }),
+    'stream-chatComplete': EmberCloudChatCompleteStreamChunkTransform,
+  },
+};
+
+export default EmberCloudConfig;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,6 +74,7 @@ import OracleConfig from './oracle';
 import IOIntelligenceConfig from './iointelligence';
 import AIBadgrConfig from './aibadgr';
 import OVHcloudConfig from './ovhcloud';
+import EmberCloudConfig from './embercloud';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -148,6 +149,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   iointelligence: IOIntelligenceConfig,
   aibadgr: AIBadgrConfig,
   ovhcloud: OVHcloudConfig,
+  embercloud: EmberCloudConfig,
 };
 
 export default Providers;


### PR DESCRIPTION
Add EmberCloud as a new provider to the gateway, enabling access to GLM and MiniMax AI models through EmberCloud's OpenAI-compatible API.

Supported models: glm-5, glm-4.7, glm-4.7-flash, glm-4.6, glm-4.5, glm-4.5-air, minimax-m2.5.

**Description:** (required)
- Add EmberCloud as a new provider to the gateway, enabling access to GLM and MiniMax AI models through EmberCloud's OpenAI-compatible API
  (https://api.embercloud.ai/v1)                                                                                                                                    
- Supported models: glm-5, glm-4.7, glm-4.7-flash, glm-4.6, glm-4.5, glm-4.5-air, minimax-m2.5
- Implements standard OpenAI-compatible provider pattern (same as OVHCloud, Groq): api.ts for API config, chatComplete.ts for chat params and stream transforms,
  index.ts for provider config export
- Registers provider constant EMBER_CLOUD in globals.ts and adds to VALID_PROVIDERS
- Adds provider metadata entry in providers.json

**Tests Run/Test cases added:** (required)
- Ran npm run test:gateway — all 47 passing tests continue to pass; 8 pre-existing test suite failures (unrelated to this PR: broken mock paths, missing
  .creds.json, TS errors in bytez/api.ts)
- Build succeeds via rollup -c (verified through pre-push hook)
- Gateway starts successfully and is ready for connections at localhost:8787

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)