### PR TITLE
improvement: Map response_format to Bedrock Converse outputConfig

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -842,7 +842,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.7.1.tgz",
       "integrity": "sha512-o1uhUASyo921r2XtHYOHy7gdkGLge8ghBEQHMWmyJFoXlpU58kIrhhN3w26lpQb6dspetweapMn2CSNwQ8I4wg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "@emnapi/wasi-threads": "1.1.0",
@@ -853,7 +852,6 @@
       "version": "1.7.1",
       "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.7.1.tgz",
       "integrity": "sha512-PVtJr5CmLwYAU9PZDMITZoR5iAOShYREoR45EyyLrbntV50mdePTgUn4AmOw90Ifcj+x2kRjdzr1HP3RrNiHGA==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -863,7 +861,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.1.0.tgz",
       "integrity": "sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -2763,6 +2760,310 @@
         "win32"
       ]
     },
+    "node_modules/@napi-rs/snappy-android-arm-eabi": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm-eabi/-/snappy-android-arm-eabi-7.3.3.tgz",
+      "integrity": "sha512-d4vUFFzNBvazGfB/KU8MnEax6itTIgRWXodPdZDnWKHy9HwVBndpCiedQDcSNHcZNYV36rx034rpn7SAuTL2NA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-android-arm64": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-android-arm64/-/snappy-android-arm64-7.3.3.tgz",
+      "integrity": "sha512-Uh+w18dhzjVl85MGhRnojb7OLlX2ErvMsYIunO/7l3Frvc2zQvfqsWsFJanu2dwqlE2YDooeNP84S+ywgN9sxg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-darwin-arm64": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-arm64/-/snappy-darwin-arm64-7.3.3.tgz",
+      "integrity": "sha512-AmJn+6yOu/0V0YNHLKmRUNYkn93iv/1wtPayC7O1OHtfY6YqHQ31/MVeeRBiEYtQW9TwVZxXrDirxSB1PxRdtw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-darwin-x64": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-darwin-x64/-/snappy-darwin-x64-7.3.3.tgz",
+      "integrity": "sha512-biLTXBmPjPmO7HIpv+5BaV9Gy/4+QJSUNJW8Pjx1UlWAVnocPy7um+zbvAWStZssTI5sfn/jOClrAegD4w09UA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-freebsd-x64": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-freebsd-x64/-/snappy-freebsd-x64-7.3.3.tgz",
+      "integrity": "sha512-E3R3ewm8Mrjm0yL2TC3VgnphDsQaCPixNJqBbGiz3NTshVDhlPlOgPKF0NGYqKiKaDGdD9PKtUgOR4vagUtn7g==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-arm-gnueabihf": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm-gnueabihf/-/snappy-linux-arm-gnueabihf-7.3.3.tgz",
+      "integrity": "sha512-ZuNgtmk9j0KyT7TfLyEnvZJxOhbkyNR761nk04F0Q4NTHMICP28wQj0xgEsnCHUsEeA9OXrRL4R7waiLn+rOQA==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-arm64-gnu": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-gnu/-/snappy-linux-arm64-gnu-7.3.3.tgz",
+      "integrity": "sha512-KIzwtq0dAzshzpqZWjg0Q9lUx93iZN7wCCUzCdLYIQ+mvJZKM10VCdn0RcuQze1R3UJTPwpPLXQIVskNMBYyPA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-arm64-musl": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-arm64-musl/-/snappy-linux-arm64-musl-7.3.3.tgz",
+      "integrity": "sha512-AAED4cQS74xPvktsyVmz5sy8vSxG/+3d7Rq2FDBZzj3Fv6v5vux6uZnECPCAqpALCdTtJ61unqpOyqO7hZCt1Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-ppc64-gnu": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-ppc64-gnu/-/snappy-linux-ppc64-gnu-7.3.3.tgz",
+      "integrity": "sha512-pofO5eSLg8ZTBwVae4WHHwJxJGZI8NEb4r5Mppvq12J/1/Hq1HecClXmfY3A7bdT2fsS2Td+Q7CI9VdBOj2sbA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-riscv64-gnu": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-riscv64-gnu/-/snappy-linux-riscv64-gnu-7.3.3.tgz",
+      "integrity": "sha512-OiHYdeuwj0TVBXADUmmQDQ4lL1TB+8EwmXnFgOutoDVXHaUl0CJFyXLa6tYUXe+gRY8hs1v7eb0vyE97LKY06Q==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-s390x-gnu": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-s390x-gnu/-/snappy-linux-s390x-gnu-7.3.3.tgz",
+      "integrity": "sha512-66QdmuV9CTq/S/xifZXlMy3PsZTviAgkqqpZ+7vPCmLtuP+nqhaeupShOFf/sIDsS0gZePazPosPTeTBbhkLHg==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-x64-gnu": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-gnu/-/snappy-linux-x64-gnu-7.3.3.tgz",
+      "integrity": "sha512-g6KURjOxrgb8yXDEZMuIcHkUr/7TKlDwSiydEQtMtP3n4iI4sNjkcE/WNKlR3+t9bZh1pFGAq7NFRBtouQGHpQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-linux-x64-musl": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-linux-x64-musl/-/snappy-linux-x64-musl-7.3.3.tgz",
+      "integrity": "sha512-6UvOyczHknpaKjrlKKSlX3rwpOrfJwiMG6qA0NRKJFgbcCAEUxmN9A8JvW4inP46DKdQ0bekdOxwRtAhFiTDfg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-openharmony-arm64": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-openharmony-arm64/-/snappy-openharmony-arm64-7.3.3.tgz",
+      "integrity": "sha512-I5mak/5rTprobf7wMCk0vFhClmWOL/QiIJM4XontysnadmP/R9hAcmuFmoMV2GaxC9MblqLA7Z++gy8ou5hJVw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-wasm32-wasi": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-wasm32-wasi/-/snappy-wasm32-wasi-7.3.3.tgz",
+      "integrity": "sha512-+EroeygVYo9RksOchjF206frhMkfD2PaIun3yH4Zp5j/Y0oIEgs/+VhAYx/f+zHRylQYUIdLzDRclcoepvlR8Q==",
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "^1.0.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@napi-rs/snappy-wasm32-wasi/node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.1.tgz",
+      "integrity": "sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1",
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      }
+    },
+    "node_modules/@napi-rs/snappy-win32-arm64-msvc": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-arm64-msvc/-/snappy-win32-arm64-msvc-7.3.3.tgz",
+      "integrity": "sha512-rxqfntBsCfzgOha/OlG8ld2hs6YSMGhpMUbFjeQLyVDbooY041fRXv3S7yk52DfO6H4QQhLT5+p7cW0mYdhyiQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-win32-ia32-msvc": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-ia32-msvc/-/snappy-win32-ia32-msvc-7.3.3.tgz",
+      "integrity": "sha512-joRV16DsRtqjGt0CdSpxGCkO0UlHGeTZ/GqvdscoALpRKbikR2Top4C61dxEchmOd3lSYsXutuwWWGg3Nr++WA==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@napi-rs/snappy-win32-x64-msvc": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/@napi-rs/snappy-win32-x64-msvc/-/snappy-win32-x64-msvc-7.3.3.tgz",
+      "integrity": "sha512-cEnQwcsdJyOU7HSZODWsHpKuQoSYM4jaqw/hn9pOXYbRN1+02WxYppD3fdMuKN6TOA6YG5KA5PHRNeVilNX86Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 10"
+      }
+    },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.12",
       "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-0.2.12.tgz",
@@ -3507,7 +3808,6 @@
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
       "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
-      "dev": true,
       "optional": true,
       "dependencies": {
         "tslib": "^2.4.0"
@@ -10085,6 +10385,40 @@
       "resolved": "https://registry.npmjs.org/smob/-/smob-1.4.1.tgz",
       "integrity": "sha512-9LK+E7Hv5R9u4g4C3p+jjLstaLe11MDsL21UpYaCNmapvMkYhqCV4A/f/3gyH8QjMyh6l68q9xC85vihY9ahMQ==",
       "dev": true
+    },
+    "node_modules/snappy": {
+      "version": "7.3.3",
+      "resolved": "https://registry.npmjs.org/snappy/-/snappy-7.3.3.tgz",
+      "integrity": "sha512-UDJVCunvgblRpfTOjo/uT7pQzfrTsSICJ4yVS4aq7SsGBaUSpJwaVP15nF//jqinSLpN7boe/BqbUmtWMTQ5MQ==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "optionalDependencies": {
+        "@napi-rs/snappy-android-arm-eabi": "7.3.3",
+        "@napi-rs/snappy-android-arm64": "7.3.3",
+        "@napi-rs/snappy-darwin-arm64": "7.3.3",
+        "@napi-rs/snappy-darwin-x64": "7.3.3",
+        "@napi-rs/snappy-freebsd-x64": "7.3.3",
+        "@napi-rs/snappy-linux-arm-gnueabihf": "7.3.3",
+        "@napi-rs/snappy-linux-arm64-gnu": "7.3.3",
+        "@napi-rs/snappy-linux-arm64-musl": "7.3.3",
+        "@napi-rs/snappy-linux-ppc64-gnu": "7.3.3",
+        "@napi-rs/snappy-linux-riscv64-gnu": "7.3.3",
+        "@napi-rs/snappy-linux-s390x-gnu": "7.3.3",
+        "@napi-rs/snappy-linux-x64-gnu": "7.3.3",
+        "@napi-rs/snappy-linux-x64-musl": "7.3.3",
+        "@napi-rs/snappy-openharmony-arm64": "7.3.3",
+        "@napi-rs/snappy-wasm32-wasi": "7.3.3",
+        "@napi-rs/snappy-win32-arm64-msvc": "7.3.3",
+        "@napi-rs/snappy-win32-ia32-msvc": "7.3.3",
+        "@napi-rs/snappy-win32-x64-msvc": "7.3.3"
+      }
     },
     "node_modules/snappyjs": {
       "version": "0.7.0",

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -43,6 +43,7 @@ import {
   transformAnthropicAdditionalModelRequestFields,
   transformCohereAdditionalModelRequestFields,
   transformInferenceConfig,
+  transformOutputConfig,
 } from './utils';
 
 export interface BedrockChatCompletionsParams extends Params {
@@ -452,6 +453,11 @@ export const BedrockConverseChatCompleteConfig: ProviderConfig = {
     param: 'inferenceConfig',
     transform: (params: BedrockChatCompletionsParams) =>
       transformInferenceConfig(params),
+  },
+  response_format: {
+    param: 'outputConfig',
+    transform: (params: BedrockChatCompletionsParams) =>
+      transformOutputConfig(params),
   },
   additionalModelRequestFields: {
     param: 'additionalModelRequestFields',

--- a/src/providers/bedrock/utils.test.ts
+++ b/src/providers/bedrock/utils.test.ts
@@ -1,22 +1,46 @@
-// Mock modules with top-level await that break jest's ts-jest transform
+// Mock modules that have runtime dependencies incompatible with jest
+jest.mock('../../apm', () => ({
+  logger: {
+    info: jest.fn(),
+    error: jest.fn(),
+    debug: jest.fn(),
+  },
+}));
+
 jest.mock('../../utils/env', () => ({
   Environment: jest.fn(() => ({})),
 }));
 
-jest.mock('@smithy/signature-v4', () => ({
-  SignatureV4: jest.fn(),
+jest.mock('../../utils/fetch', () => ({
+  externalServiceFetch: jest.fn(),
 }));
 
-jest.mock('@aws-crypto/sha256-js', () => ({
-  Sha256: jest.fn(),
+jest.mock('../../utils/awsAuth', () => ({
+  awsEndpointDomain: 'amazonaws.com',
+  generateAWSHeaders: jest.fn(),
+  getRegionFromEnv: jest.fn(),
+  fetchECSContainerCredentials: jest.fn(),
+  fetchECSRegionFromMetadata: jest.fn(),
+  fetchECSTaskRoleArnFromMetadata: jest.fn(),
+  fetchIMDSAllCredentials: jest.fn(),
+  fetchPodIdentityCredentials: jest.fn(),
+  fetchSTSAssumeRoleCredentials: jest.fn(),
+  fetchWebIdentityCredentials: jest.fn(),
+  getCredentialsFromAwsConfigFile: jest.fn(),
+  getCredentialsFromEnvironment: jest.fn(),
+  getCredentialsFromSharedCredentialsFile: jest.fn(),
 }));
 
-jest.mock('hono', () => ({
-  Hono: jest.fn(),
+jest.mock('../../services/cache/cacheService', () => ({
+  requestCache: jest.fn(() => ({
+    get: jest.fn(),
+    set: jest.fn(),
+  })),
 }));
 
 jest.mock('hono/adapter', () => ({
   env: jest.fn(),
+  getRuntimeKey: jest.fn(() => 'node'),
 }));
 
 import {

--- a/src/providers/bedrock/utils.test.ts
+++ b/src/providers/bedrock/utils.test.ts
@@ -1,0 +1,195 @@
+// Mock modules with top-level await that break jest's ts-jest transform
+jest.mock('../../utils/env', () => ({
+  Environment: jest.fn(() => ({})),
+}));
+
+jest.mock('@smithy/signature-v4', () => ({
+  SignatureV4: jest.fn(),
+}));
+
+jest.mock('@aws-crypto/sha256-js', () => ({
+  Sha256: jest.fn(),
+}));
+
+jest.mock('hono', () => ({
+  Hono: jest.fn(),
+}));
+
+jest.mock('hono/adapter', () => ({
+  env: jest.fn(),
+}));
+
+import {
+  transformAdditionalModelRequestFields,
+  transformOutputConfig,
+} from './utils';
+import { BedrockChatCompletionsParams } from './chatComplete';
+
+describe('transformOutputConfig', () => {
+  it('maps json_schema response_format to Bedrock outputConfig', () => {
+    const params = {
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'MySchema',
+          strict: true,
+          schema: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              age: { type: 'integer' },
+            },
+            required: ['name', 'age'],
+          },
+        },
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformOutputConfig(params);
+
+    expect(result).toEqual({
+      textFormat: {
+        type: 'json_schema',
+        structure: {
+          jsonSchema: {
+            schema: JSON.stringify({
+              type: 'object',
+              properties: {
+                name: { type: 'string' },
+                age: { type: 'integer' },
+              },
+              required: ['name', 'age'],
+            }),
+            name: 'MySchema',
+          },
+        },
+      },
+    });
+  });
+
+  it('stringifies schema when provided as object', () => {
+    const schemaObj = {
+      type: 'object',
+      properties: { x: { type: 'number' } },
+    };
+    const params = {
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'Test',
+          schema: schemaObj,
+        },
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformOutputConfig(params);
+    expect(typeof result?.textFormat.structure.jsonSchema.schema).toBe(
+      'string'
+    );
+    expect(JSON.parse(result!.textFormat.structure.jsonSchema.schema)).toEqual(
+      schemaObj
+    );
+  });
+
+  it('passes through schema when already a string', () => {
+    const schemaStr = '{"type":"object"}';
+    const params = {
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'Test',
+          schema: schemaStr,
+        },
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformOutputConfig(params);
+    expect(result?.textFormat.structure.jsonSchema.schema).toBe(schemaStr);
+  });
+
+  it('defaults name to "response" when not provided', () => {
+    const params = {
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          schema: { type: 'object' },
+        },
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformOutputConfig(params);
+    expect(result?.textFormat.structure.jsonSchema.name).toBe('response');
+  });
+
+  it('returns undefined for json_object type (not supported by Bedrock)', () => {
+    const params = {
+      response_format: {
+        type: 'json_object',
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    expect(transformOutputConfig(params)).toBeUndefined();
+  });
+
+  it('returns undefined for text type', () => {
+    const params = {
+      response_format: {
+        type: 'text',
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    expect(transformOutputConfig(params)).toBeUndefined();
+  });
+
+  it('returns undefined when response_format is not present', () => {
+    const params = {} as unknown as BedrockChatCompletionsParams;
+    expect(transformOutputConfig(params)).toBeUndefined();
+  });
+
+  it('returns undefined when json_schema property is missing', () => {
+    const params = {
+      response_format: {
+        type: 'json_schema',
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    expect(transformOutputConfig(params)).toBeUndefined();
+  });
+});
+
+describe('transformAdditionalModelRequestFields', () => {
+  it('does not include response_format in additionalModelRequestFields', () => {
+    const params = {
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'Test',
+          schema: { type: 'object' },
+        },
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformAdditionalModelRequestFields(params);
+    expect(result['response_format']).toBeUndefined();
+  });
+
+  it('still passes through top_k', () => {
+    const params = {
+      top_k: 50,
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformAdditionalModelRequestFields(params);
+    expect(result['top_k']).toBe(50);
+  });
+
+  it('preserves user-provided additionalModelRequestFields', () => {
+    const params = {
+      additionalModelRequestFields: {
+        custom_param: 'value',
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformAdditionalModelRequestFields(params);
+    expect(result['custom_param']).toBe('value');
+  });
+});

--- a/src/providers/bedrock/utils.test.ts
+++ b/src/providers/bedrock/utils.test.ts
@@ -121,6 +121,54 @@ describe('transformOutputConfig', () => {
     expect(result?.textFormat.structure.jsonSchema.name).toBe('response');
   });
 
+  it('passes through description when provided', () => {
+    const params = {
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'MySchema',
+          description: 'A schema for structured review output',
+          schema: { type: 'object' },
+        },
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformOutputConfig(params);
+    expect(result?.textFormat.structure.jsonSchema.description).toBe(
+      'A schema for structured review output'
+    );
+  });
+
+  it('omits description when not provided', () => {
+    const params = {
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'Test',
+          schema: { type: 'object' },
+        },
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    const result = transformOutputConfig(params);
+    expect(result?.textFormat.structure.jsonSchema).not.toHaveProperty(
+      'description'
+    );
+  });
+
+  it('returns undefined when schema is missing from json_schema', () => {
+    const params = {
+      response_format: {
+        type: 'json_schema',
+        json_schema: {
+          name: 'Test',
+        },
+      },
+    } as unknown as BedrockChatCompletionsParams;
+
+    expect(transformOutputConfig(params)).toBeUndefined();
+  });
+
   it('returns undefined for json_object type (not supported by Bedrock)', () => {
     const params = {
       response_format: {

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -437,6 +437,7 @@ export const transformAdditionalModelRequestFields = (
  * Returns undefined for unsupported types so no outputConfig is set.
  *
  * Note: Bedrock expects the schema as a JSON string, while OpenAI sends it as an object.
+ * Note: OpenAI's `strict` field is intentionally dropped — Bedrock has no equivalent.
  *
  * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
  * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_OutputConfig.html
@@ -448,7 +449,7 @@ export const transformOutputConfig = (params: BedrockChatCompletionsParams) => {
   }
 
   const jsonSchema = responseFormat.json_schema;
-  if (!jsonSchema) {
+  if (!jsonSchema || !jsonSchema.schema) {
     return undefined;
   }
 
@@ -462,6 +463,9 @@ export const transformOutputConfig = (params: BedrockChatCompletionsParams) => {
         jsonSchema: {
           schema: typeof schema === 'string' ? schema : JSON.stringify(schema),
           name,
+          ...(jsonSchema.description && {
+            description: jsonSchema.description,
+          }),
         },
       },
     },

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -422,10 +422,50 @@ export const transformAdditionalModelRequestFields = (
   if (params['top_k'] !== undefined && params['top_k'] !== null) {
     additionalModelRequestFields['top_k'] = params['top_k'];
   }
-  if (params['response_format']) {
-    additionalModelRequestFields['response_format'] = params['response_format'];
-  }
   return additionalModelRequestFields;
+};
+
+/**
+ * Transform OpenAI-format response_format to Bedrock Converse outputConfig.
+ *
+ * Maps:
+ *   { type: "json_schema", json_schema: { schema: {...}, name: "N", strict: true } }
+ * to:
+ *   { textFormat: { type: "json_schema", structure: { jsonSchema: { schema: "...", name: "N" } } } }
+ *
+ * Only handles type=json_schema — Bedrock Converse does not support json_object.
+ * Returns undefined for unsupported types so no outputConfig is set.
+ *
+ * Note: Bedrock expects the schema as a JSON string, while OpenAI sends it as an object.
+ *
+ * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html
+ * @see https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_OutputConfig.html
+ */
+export const transformOutputConfig = (params: BedrockChatCompletionsParams) => {
+  const responseFormat = params['response_format'];
+  if (!responseFormat || responseFormat.type !== 'json_schema') {
+    return undefined;
+  }
+
+  const jsonSchema = responseFormat.json_schema;
+  if (!jsonSchema) {
+    return undefined;
+  }
+
+  const schema = jsonSchema.schema;
+  const name = jsonSchema.name || 'response';
+
+  return {
+    textFormat: {
+      type: 'json_schema',
+      structure: {
+        jsonSchema: {
+          schema: typeof schema === 'string' ? schema : JSON.stringify(schema),
+          name,
+        },
+      },
+    },
+  };
 };
 
 export const transformAnthropicAdditionalModelRequestFields = (


### PR DESCRIPTION
## Summary

Bedrock's Converse API supports native structured JSON output via [`outputConfig.textFormat`](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_OutputConfig.html) (launched February 2025 for Claude 3.5+, Llama, Mistral, and others). However, the gateway currently places `response_format` into `additionalModelRequestFields` on the base `BedrockConverseChatCompleteConfig`, where Bedrock silently ignores it — structured output never actually takes effect for non-Anthropic models.

This PR adds proper mapping from OpenAI's `response_format: { type: "json_schema", ... }` to Bedrock's native Converse API `outputConfig.textFormat` parameter on the **base config**.

> **Note:** The `2.0.0` branch already adds `response_format` handling for the Anthropic variant via `additionalModelRequestFields.output_config` (Anthropic's proprietary path). That override takes precedence for Anthropic models. This PR complements that by adding Converse-native `outputConfig` support for all other Bedrock models (Meta, Cohere, AI21, Amazon, Mistral, etc.) via the base config.

### What changed

- **`src/providers/bedrock/utils.ts`**
  - Removed `response_format` from `transformAdditionalModelRequestFields()` (was a no-op — Bedrock ignores unknown keys in `additionalModelRequestFields`)
  - Added `transformOutputConfig()` function that maps:
    ```
    // OpenAI format (input)
    { type: "json_schema", json_schema: { schema: {...}, name: "N", description: "D", strict: true } }
    
    // Bedrock Converse format (output)  
    { textFormat: { type: "json_schema", structure: { jsonSchema: { schema: "...", name: "N", description: "D" } } } }
    ```
  - Handles schema stringification: OpenAI sends `schema` as a JSON object, Bedrock expects a JSON **string**
  - Passes through `name` (defaults to `"response"`) and `description` (omitted when not provided)
  - Guards against missing `schema` to prevent malformed requests
  - `strict` is intentionally dropped — Bedrock has no equivalent

- **`src/providers/bedrock/chatComplete.ts`**
  - Added `response_format` → `outputConfig` entry to `BedrockConverseChatCompleteConfig`
  - Imported `transformOutputConfig` from utils

- **`src/providers/bedrock/utils.test.ts`** (new)
  - 14 unit tests covering: json_schema mapping, schema stringification (object and string), name defaults, description pass-through and omission, missing schema guard, json_object/text/absent response_format, and verification that response_format is no longer in additionalModelRequestFields

### How it interacts with the Anthropic variant

The `BedrockConverseAnthropicChatCompleteConfig` in `2.0.0` already overrides `response_format` to route through `transformAnthropicAdditionalModelRequestFields`, which maps it to `additionalModelRequestFields.output_config`. Since the spread + override pattern means the Anthropic-specific entry takes precedence, **Anthropic models are unaffected by this change**. This PR only affects the base Converse config used by non-Anthropic models.

| Model provider | response_format path | Source |
|---|---|---|
| Anthropic (Claude) | `additionalModelRequestFields.output_config` | Existing 2.0.0 code |
| All others (Meta, Cohere, AI21, etc.) | `outputConfig.textFormat` | **This PR** |

### Design decisions

1. **Only `json_schema` type is mapped** — Bedrock Converse does not support `json_object`. For `json_object` and `text` types, `transformOutputConfig` returns `undefined` so no `outputConfig` is set (same behavior as before).

2. **`strict` is intentionally dropped** — OpenAI's `strict` field has no Bedrock equivalent. Documented in the JSDoc.

3. **No model filtering** — Rather than maintaining a list of which Bedrock models support structured output, we let Bedrock return a `400 ValidationException` for unsupported models. This matches how other unsupported features (e.g., tool use on models without it) are handled.

4. **No streaming changes needed** — The same `chatComplete` config is used for both `Converse` and `ConverseStream` API calls, so structured output works for both.

5. **Scoped to Bedrock only** — All changes are within `src/providers/bedrock/`. Zero impact on any other provider.

### Context

We discovered this issue while building a Terraform PR review agent that uses Portkey to route structured output calls to Bedrock (Claude Sonnet via Converse API). The model returned correct decisions but empty arrays in the structured response — because without `outputConfig`, Bedrock has no schema to enforce and the model was free to minimize output. Switching to tool-use (`tools` + `tool_choice`) as a workaround confirmed the model was capable; the gateway translation was the gap.

### Bedrock API Reference

- [Converse API](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_Converse.html) — `outputConfig` parameter
- [OutputConfig](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_OutputConfig.html) — `textFormat` structure
- [TextFormat](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_TextFormat.html) — `json_schema` type with `JsonSchemaFormat`
- [JsonSchemaDefinition](https://docs.aws.amazon.com/bedrock/latest/APIReference/API_runtime_JsonSchemaDefinition.html) — `schema` (string), `name`, `description`

### Test plan

- [x] 14 unit tests pass (`npx jest src/providers/bedrock/utils.test.ts`)
- [x] Prettier + lint-staged checks pass
- [x] Rollup build succeeds
- [x] Rebased onto `2.0.0` — no conflicts
- [ ] Integration test with Bedrock Converse + non-Anthropic model using `response_format: { type: "json_schema" }`