### PR TITLE
fix: avoid immutable header mutation for mapped streaming responses on node

### DIFF
--- a/src/handlers/services/responseService.ts
+++ b/src/handlers/services/responseService.ts
@@ -61,6 +61,18 @@ export class ResponseService {
       ));
     }
 
+    if (
+      isResponseAlreadyMapped &&
+      this.context.isStreaming &&
+      getRuntimeKey() == 'node'
+    ) {
+      finalMappedResponse = new Response(finalMappedResponse.body, {
+        status: finalMappedResponse.status,
+        statusText: finalMappedResponse.statusText,
+        headers: new Headers(finalMappedResponse.headers),
+      });
+    }
+
     this.updateHeaders(finalMappedResponse, cache.cacheStatus, retryAttempt);
 
     return {


### PR DESCRIPTION
**Description:** (required)
- Fixes a `TypeError: immutable` failure in Node runtime when `/v1/responses` streaming output goes through the mapped response path.
- Clones mapped streaming responses (`isResponseAlreadyMapped && isStreaming && node`) into a new `Response` with copied status, statusText, body, and headers before `updateHeaders()` mutates headers.
- Preserves existing behavior for non-streaming and non-Node paths while keeping `x-portkey-*` response headers.
- Fixes #1550.

**Tests Run/Test cases added:** (required)
- [x] `pnpm run build`
- [x] Manual check: `POST /v1/responses` with `"stream": true` returns SSE successfully and does not throw `TypeError: immutable`.

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
