### PR TITLE
feat: add passthrough target type for config routing

### DIFF
--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -31,6 +31,7 @@ import {
   adaptResponse,
   AdapterContext,
 } from './adapterUtils';
+import { constructConfigFromRequestHeaders } from '../utils/request';
 
 /**
  * Constructs the request options for the API call.
@@ -725,6 +726,10 @@ export async function tryTargetsRecursively(
 
   const cEnv = env(c);
   // start: merge inherited config with current target config (preference given to current)
+  const passthroughConfig =
+    inheritedConfig.passthroughConfig ??
+    constructConfigFromRequestHeaders(requestHeaders);
+
   const currentInheritedConfig: Record<string, any> = {
     id: inheritedConfig.id || currentTarget.id,
     overrideParams: {
@@ -740,6 +745,7 @@ export async function tryTargetsRecursively(
     requestTimeout: null,
     defaultInputGuardrails: inheritedConfig.defaultInputGuardrails,
     defaultOutputGuardrails: inheritedConfig.defaultOutputGuardrails,
+    passthroughConfig,
   };
 
   // Inherited config can be empty only for the base case of recursive call.
@@ -1083,9 +1089,18 @@ export async function tryTargetsRecursively(
 
     default:
       try {
+        let targetToUse = currentTarget;
+
+        if (currentTarget.passthrough === true) {
+          targetToUse = {
+            ...currentTarget,
+            ...passthroughConfig,
+          };
+        }
+
         response = await tryPost(
           c,
-          currentTarget,
+          targetToUse,
           request,
           requestHeaders,
           fn,

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -216,6 +216,7 @@ export const configSchema: any = z
     azure_ad_token: z.string().optional(),
     azure_model_name: z.string().optional(),
     strict_open_ai_compliance: z.boolean().optional(),
+    passthrough: z.boolean().optional(),
   })
   .refine(
     (value) => {
@@ -249,12 +250,13 @@ export const configSchema: any = z
         value.after_request_hooks ||
         value.before_request_hooks ||
         value.input_guardrails ||
-        value.output_guardrails
+        value.output_guardrails ||
+        value.passthrough === true
       );
     },
     {
       message:
-        "Invalid configuration. It must have either 'provider' and 'api_key', or 'strategy' and 'targets', or 'cache', or 'retry', or 'request_timeout'",
+        "Invalid configuration. It must have either 'provider' and 'api_key', or 'strategy' and 'targets', or 'cache', or 'retry', or 'request_timeout', or 'passthrough'",
     }
   )
   .refine(

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -196,6 +196,10 @@ export interface Options {
 export interface Targets {
   name?: string;
   strategy?: Strategy;
+  /** When true, uses the provider and model from the original request headers/body instead of this target's config.
+   * Useful for conditional routing where unmatched requests should pass through unchanged,
+   * or for fallback strategies where the original request should be tried first. */
+  passthrough?: boolean;
   /** The name of the provider. */
   provider?: string | undefined;
   /** The name of the API key for the provider. */


### PR DESCRIPTION
## Summary
- Adds `passthrough: true` option for targets that use the original request's provider/model instead of defining them in the config
- Useful for conditional routing where unmatched requests should pass through unchanged
- Works with fallback, loadbalance, and conditional strategies

## Example Usage
```json
{
  "strategy": { "mode": "conditional" },
  "targets": [
    {
      "name": "openai-target",
      "provider": "openai",
      "api_key": "...",
      "override_params": { "model": "gpt-4o" }
    },
    {
      "name": "default",
      "passthrough": true
    }
  ]
}
```

## Changes
- `src/types/requestBody.ts`: Added `passthrough?: boolean` to Targets interface
- `src/middlewares/requestValidator/schema/config.ts`: Added schema validation for passthrough
- `src/handlers/handlerUtils.ts`: Handle passthrough in `tryTargetsRecursively`

## Test plan
- [ ] Test passthrough target in conditional routing
- [ ] Test passthrough target in fallback strategy
- [ ] Verify original request provider/model are used when passthrough is true


Made with [Cursor](https://cursor.com)