### PR TITLE
bug: normalize prompt_tokens across Anthropic providers

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -610,7 +610,10 @@ export const getAnthropicChatCompleteResponseTransform = (provider: string) => {
           },
         ],
         usage: {
-          prompt_tokens: input_tokens,
+          prompt_tokens:
+            input_tokens +
+            (cache_creation_input_tokens ?? 0) +
+            (cache_read_input_tokens ?? 0),
           completion_tokens: output_tokens,
           total_tokens:
             input_tokens +

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -896,7 +896,8 @@ export const VertexAnthropicChatCompleteResponseTransform: (
         },
       ],
       usage: {
-        prompt_tokens: input_tokens,
+        prompt_tokens:
+          input_tokens + cache_creation_input_tokens + cache_read_input_tokens,
         completion_tokens: output_tokens,
         total_tokens: totalTokens,
         prompt_tokens_details: {


### PR DESCRIPTION
**Description:**
- Fixed inconsistent prompt_tokens normalization between Anthropic direct API, Vertex AI, and Bedrock providers
- All three providers now include cache tokens in prompt_tokens, matching the OpenAI convention where prompt_tokens_details.cached_tokens provides the breakdown

**Changes:**
- Anthropic direct API: prompt_tokens now includes input_tokens + cache_creation_input_tokens + cache_read_input_tokens
- Vertex AI: prompt_tokens now includes input_tokens + cache_creation_input_tokens + cache_read_input_tokens  
- Bedrock: already correct (no changes needed)

**Tests:**
- Added unit tests verifying consistent token counting across all three providers
- Tests confirm prompt_tokens includes cache tokens while prompt_tokens_details.cached_tokens provides the breakdown

Fixes #1564