### PR TITLE
bug: fix inconsistent prompt_tokens normalization across Anthropic providers

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -610,7 +610,10 @@ export const getAnthropicChatCompleteResponseTransform = (provider: string) => {
           },
         ],
         usage: {
-          prompt_tokens: input_tokens,
+          prompt_tokens:
+            input_tokens +
+            (cache_creation_input_tokens ?? 0) +
+            (cache_read_input_tokens ?? 0),
           completion_tokens: output_tokens,
           total_tokens:
             input_tokens +
@@ -697,14 +700,18 @@ export const getAnthropicStreamChunkTransform = (provider: string) => {
       parsedChunk.message?.usage?.cache_creation_input_tokens;
 
     if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
+      const inputTokens = parsedChunk.message?.usage?.input_tokens ?? 0;
+      const cacheReadTokens =
+        parsedChunk.message?.usage?.cache_read_input_tokens ?? 0;
+      const cacheCreationTokens =
+        parsedChunk.message?.usage?.cache_creation_input_tokens ?? 0;
+
       streamState.model = parsedChunk?.message?.model ?? '';
       streamState.usage = {
-        prompt_tokens: parsedChunk.message?.usage?.input_tokens,
+        prompt_tokens: inputTokens + cacheReadTokens + cacheCreationTokens,
         ...(shouldSendCacheUsage && {
-          cache_read_input_tokens:
-            parsedChunk.message?.usage?.cache_read_input_tokens,
-          cache_creation_input_tokens:
-            parsedChunk.message?.usage?.cache_creation_input_tokens,
+          cache_read_input_tokens: cacheReadTokens,
+          cache_creation_input_tokens: cacheCreationTokens,
         }),
       };
       return (

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -896,7 +896,8 @@ export const VertexAnthropicChatCompleteResponseTransform: (
         },
       ],
       usage: {
-        prompt_tokens: input_tokens,
+        prompt_tokens:
+          input_tokens + cache_creation_input_tokens + cache_read_input_tokens,
         completion_tokens: output_tokens,
         total_tokens: totalTokens,
         prompt_tokens_details: {
@@ -980,13 +981,17 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
 
     streamState.model = parsedChunk?.message?.model ?? '';
 
+    const inputTokens = parsedChunk.message.usage?.input_tokens ?? 0;
+    const cacheReadTokens =
+      parsedChunk.message?.usage?.cache_read_input_tokens ?? 0;
+    const cacheCreationTokens =
+      parsedChunk.message?.usage?.cache_creation_input_tokens ?? 0;
+
     streamState.usage = {
-      prompt_tokens: parsedChunk.message.usage?.input_tokens,
+      prompt_tokens: inputTokens + cacheReadTokens + cacheCreationTokens,
       ...(shouldSendCacheUsage && {
-        cache_read_input_tokens:
-          parsedChunk.message?.usage?.cache_read_input_tokens,
-        cache_creation_input_tokens:
-          parsedChunk.message?.usage?.cache_creation_input_tokens,
+        cache_read_input_tokens: cacheReadTokens,
+        cache_creation_input_tokens: cacheCreationTokens,
       }),
     };
     return (


### PR DESCRIPTION
## Issue
Fixes #1564

The `prompt_tokens` count was inconsistent across Anthropic providers:
- **Bedrock**: Included cache tokens in `prompt_tokens`
- **Direct Anthropic**: Did NOT include cache tokens in `prompt_tokens`
- **Vertex AI**: Did NOT include cache tokens in `prompt_tokens`

## Root Cause
The Bedrock provider correctly added `cache_creation_input_tokens` and `cache_read_input_tokens` to `prompt_tokens`, but the direct Anthropic and Vertex AI providers only used `input_tokens`.

## Fix
Updated both the Anthropic and Vertex AI providers to include cache tokens in `prompt_tokens`:

```
prompt_tokens = input_tokens + cache_creation_input_tokens + cache_read_input_tokens
```

### Changes Made:
- **Anthropic provider (non-streaming)**: Fixed `prompt_tokens` calculation in response transform
- **Anthropic provider (streaming)**: Fixed `prompt_tokens` in message_start event
- **Vertex AI provider (non-streaming)**: Fixed `prompt_tokens` calculation in response transform  
- **Vertex AI provider (streaming)**: Fixed `prompt_tokens` in message_start event

## Verification
The fix ensures consistent token counting behavior across all Anthropic provider implementations, matching the existing (correct) behavior in the Bedrock provider.

---

I have read and understood the CLA and agree to it.