### PR TITLE
fix(anthropic): normalize prompt_tokens to include cache tokens across all providers

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -610,7 +610,10 @@ export const getAnthropicChatCompleteResponseTransform = (provider: string) => {
           },
         ],
         usage: {
-          prompt_tokens: input_tokens,
+          prompt_tokens:
+            input_tokens +
+            (cache_creation_input_tokens ?? 0) +
+            (cache_read_input_tokens ?? 0),
           completion_tokens: output_tokens,
           total_tokens:
             input_tokens +
@@ -699,7 +702,10 @@ export const getAnthropicStreamChunkTransform = (provider: string) => {
     if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
       streamState.model = parsedChunk?.message?.model ?? '';
       streamState.usage = {
-        prompt_tokens: parsedChunk.message?.usage?.input_tokens,
+        prompt_tokens:
+          (parsedChunk.message?.usage?.input_tokens ?? 0) +
+          (parsedChunk.message?.usage?.cache_creation_input_tokens ?? 0) +
+          (parsedChunk.message?.usage?.cache_read_input_tokens ?? 0),
         ...(shouldSendCacheUsage && {
           cache_read_input_tokens:
             parsedChunk.message?.usage?.cache_read_input_tokens,
@@ -733,8 +739,6 @@ export const getAnthropicStreamChunkTransform = (provider: string) => {
     if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
       const totalTokens =
         (streamState?.usage?.prompt_tokens ?? 0) +
-        (streamState?.usage?.cache_creation_input_tokens ?? 0) +
-        (streamState?.usage?.cache_read_input_tokens ?? 0) +
         (parsedChunk.usage.output_tokens ?? 0);
       return (
         `data: ${JSON.stringify({

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -896,7 +896,8 @@ export const VertexAnthropicChatCompleteResponseTransform: (
         },
       ],
       usage: {
-        prompt_tokens: input_tokens,
+        prompt_tokens:
+          input_tokens + cache_creation_input_tokens + cache_read_input_tokens,
         completion_tokens: output_tokens,
         total_tokens: totalTokens,
         prompt_tokens_details: {
@@ -981,7 +982,10 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
     streamState.model = parsedChunk?.message?.model ?? '';
 
     streamState.usage = {
-      prompt_tokens: parsedChunk.message.usage?.input_tokens,
+      prompt_tokens:
+        (parsedChunk.message.usage?.input_tokens ?? 0) +
+        (parsedChunk.message?.usage?.cache_creation_input_tokens ?? 0) +
+        (parsedChunk.message?.usage?.cache_read_input_tokens ?? 0),
       ...(shouldSendCacheUsage && {
         cache_read_input_tokens:
           parsedChunk.message?.usage?.cache_read_input_tokens,
@@ -1016,8 +1020,6 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
   if (parsedChunk.type === 'message_delta' && parsedChunk.usage) {
     const totalTokens =
       (streamState?.usage?.prompt_tokens ?? 0) +
-      (streamState?.usage?.cache_creation_input_tokens ?? 0) +
-      (streamState?.usage?.cache_read_input_tokens ?? 0) +
       (parsedChunk.usage.output_tokens ?? 0);
 
     return (


### PR DESCRIPTION
prompt_tokens normalization was inconsistent across Anthropic providers. For the same model with caching enabled, Anthropic direct and Vertex AI set prompt_tokens = input_tokens (excluding cache tokens), while Bedrock included them. OpenAI convention is that prompt_tokens includes cached tokens with breakdown in prompt_tokens_details.cached_tokens.

Updated prompt_tokens in both non-streaming and streaming response transforms for Anthropic direct and Vertex AI to include cache_creation_input_tokens and cache_read_input_tokens, matching Bedrock. Also fixed the streaming totalTokens calculation to avoid double-counting now that prompt_tokens includes cache tokens.

Files changed:
- src/providers/anthropic/chatComplete.ts (non-streaming + streaming)
- src/providers/google-vertex-ai/chatComplete.ts (non-streaming + streaming)

Fixes #1564