### PR TITLE
fix: normalize prompt_tokens to include cache tokens across Anthropic providers

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -610,7 +610,10 @@ export const getAnthropicChatCompleteResponseTransform = (provider: string) => {
           },
         ],
         usage: {
-          prompt_tokens: input_tokens,
+          prompt_tokens:
+            input_tokens +
+            (cache_creation_input_tokens ?? 0) +
+            (cache_read_input_tokens ?? 0),
           completion_tokens: output_tokens,
           total_tokens:
             input_tokens +
@@ -698,13 +701,18 @@ export const getAnthropicStreamChunkTransform = (provider: string) => {
 
     if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
       streamState.model = parsedChunk?.message?.model ?? '';
+      const streamCacheRead =
+        parsedChunk.message?.usage?.cache_read_input_tokens ?? 0;
+      const streamCacheCreate =
+        parsedChunk.message?.usage?.cache_creation_input_tokens ?? 0;
       streamState.usage = {
-        prompt_tokens: parsedChunk.message?.usage?.input_tokens,
+        prompt_tokens:
+          (parsedChunk.message?.usage?.input_tokens ?? 0) +
+          streamCacheRead +
+          streamCacheCreate,
         ...(shouldSendCacheUsage && {
-          cache_read_input_tokens:
-            parsedChunk.message?.usage?.cache_read_input_tokens,
-          cache_creation_input_tokens:
-            parsedChunk.message?.usage?.cache_creation_input_tokens,
+          cache_read_input_tokens: streamCacheRead,
+          cache_creation_input_tokens: streamCacheCreate,
         }),
       };
       return (

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -896,7 +896,8 @@ export const VertexAnthropicChatCompleteResponseTransform: (
         },
       ],
       usage: {
-        prompt_tokens: input_tokens,
+        prompt_tokens:
+          input_tokens + cache_creation_input_tokens + cache_read_input_tokens,
         completion_tokens: output_tokens,
         total_tokens: totalTokens,
         prompt_tokens_details: {
@@ -980,13 +981,18 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
 
     streamState.model = parsedChunk?.message?.model ?? '';
 
+    const vertexStreamCacheRead =
+      parsedChunk.message?.usage?.cache_read_input_tokens ?? 0;
+    const vertexStreamCacheCreate =
+      parsedChunk.message?.usage?.cache_creation_input_tokens ?? 0;
     streamState.usage = {
-      prompt_tokens: parsedChunk.message.usage?.input_tokens,
+      prompt_tokens:
+        (parsedChunk.message.usage?.input_tokens ?? 0) +
+        vertexStreamCacheRead +
+        vertexStreamCacheCreate,
       ...(shouldSendCacheUsage && {
-        cache_read_input_tokens:
-          parsedChunk.message?.usage?.cache_read_input_tokens,
-        cache_creation_input_tokens:
-          parsedChunk.message?.usage?.cache_creation_input_tokens,
+        cache_read_input_tokens: vertexStreamCacheRead,
+        cache_creation_input_tokens: vertexStreamCacheCreate,
       }),
     };
     return (


### PR DESCRIPTION
## Problem

When Portkey normalizes Anthropic model responses to OpenAI schema, `prompt_tokens` has inconsistent semantics depending on which provider is used:

| Provider | `prompt_tokens` includes cache tokens? |
|----------|----------------------------------------|
| `anthropic` (direct) | ❌ No |
| `vertex-ai` (Anthropic) | ❌ No |
| `bedrock` (Anthropic) | ✅ Yes |

The OpenAI convention (which Portkey normalizes to) is that `prompt_tokens` includes cached tokens, with the breakdown available in `prompt_tokens_details.cached_tokens`.

This inconsistency means the same Anthropic model accessed through different providers reports different `prompt_tokens` values, breaking billing and usage tracking.

Fixes #1564

## Solution

Normalize `prompt_tokens` to always include `cache_read_input_tokens + cache_creation_input_tokens`, matching Bedrock's (correct) behavior and the OpenAI convention.

### Changes

1. **Anthropic direct (non-stream)** — `src/providers/anthropic/chatComplete.ts:613`
   - `prompt_tokens` now includes cache creation and read tokens
2. **Anthropic direct (streaming)** — same file, `message_start` handler
   - Same fix applied to streaming chunk
3. **Vertex AI Anthropic (non-stream)** — `src/providers/google-vertex-ai/chatComplete.ts:899`
   - Same fix
4. **Vertex AI Anthropic (streaming)** — same file
   - Same fix

### Before
```ts
prompt_tokens: input_tokens,  // excludes cache tokens
```

### After  
```ts
prompt_tokens: input_tokens + cache_creation_input_tokens + cache_read_input_tokens,
```

## Testing

Verified the change matches Bedrock's existing behavior at `src/providers/bedrock/chatComplete.ts:551-554`:
```ts
prompt_tokens:
  response.usage.inputTokens +
  cacheReadInputTokens +
  cacheWriteInputTokens,
```