### PR TITLE
feat(plugins): add DeepKeep content moderation guardrail plugin

### DIFF
--- a/plugins/deepkeep/globals.ts
+++ b/plugins/deepkeep/globals.ts
@@ -1,0 +1,31 @@
+import { post } from '../utils';
+
+export const DEEPKEEP_BASE_URL = 'https://api.prod.deepkeep.ai/api/v2';
+
+export async function createConversation(
+  firewallId: string,
+  apiKey: string
+): Promise<string> {
+  const resp = await post<{ conversation_id: string }>(
+    `${DEEPKEEP_BASE_URL}/firewalls/${firewallId}/conversation`,
+    { title: 'portkey-guardrail' },
+    { headers: { 'X-API-Key': apiKey, 'Content-Type': 'application/json' } },
+    8000
+  );
+  if (!resp.conversation_id) throw new Error('No conversation_id returned');
+  return resp.conversation_id;
+}
+
+export async function checkUserInput(
+  firewallId: string,
+  conversationId: string,
+  content: string,
+  apiKey: string
+): Promise<{ violate_policy: boolean; content: string; message_id: string }> {
+  return post(
+    `${DEEPKEEP_BASE_URL}/firewalls/${firewallId}/conversation/${conversationId}/check_user_input`,
+    { content, logs: false },
+    { headers: { 'X-API-Key': apiKey, 'Content-Type': 'application/json' } },
+    8000
+  );
+}

--- a/plugins/deepkeep/moderateContent.ts
+++ b/plugins/deepkeep/moderateContent.ts
@@ -1,0 +1,55 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { getText } from '../utils';
+import { createConversation, checkUserInput } from './globals';
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let error = null;
+  let verdict = false;
+  let data: any = null;
+
+  try {
+    const apiKey: string = parameters?.credentials?.apiKey;
+    const firewallId: string = parameters?.firewallId;
+
+    if (!apiKey) throw new Error('Missing credentials.apiKey parameter');
+    if (!firewallId) throw new Error('Missing firewallId parameter');
+
+    // Extract text from request or response depending on hook type
+    const content = getText(context, eventType);
+    if (!content) {
+      return { error: null, verdict: true, data: { skipped: true, reason: 'empty content' } };
+    }
+
+    // Step 1 — create a fresh conversation
+    const conversationId = await createConversation(firewallId, apiKey);
+
+    // Step 2 — check the content
+    const result = await checkUserInput(firewallId, conversationId, content, apiKey);
+
+    verdict = !result.violate_policy;   // true = pass, false = block
+    data = {
+      violate_policy: result.violate_policy,
+      message_id: result.message_id,
+      conversation_id: conversationId,
+      firewall_id: firewallId,
+      checked_text: content.slice(0, 200),
+    };
+
+  } catch (e: any) {
+    delete e.stack;
+    error = e;
+    verdict = true;   // fail open — don't block on error
+    data = { error: e.message };
+  }
+
+  return { error, verdict, data };
+};

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -66,6 +66,8 @@ import { handler as javelinguardrails } from './javelin/guardrails';
 import { handler as f5GuardrailsScan } from './f5-guardrails/scan';
 import { handler as azureShieldPrompt } from './azure/shieldPrompt';
 import { handler as azureProtectedMaterial } from './azure/protectedMaterial';
+import { handler as deepkeepModerateContent } from './deepkeep/moderateContent';
+
 
 export const plugins = {
   default: {
@@ -175,5 +177,8 @@ export const plugins = {
   },
   'f5-guardrails': {
     scan: f5GuardrailsScan,
+  },
+  deepkeep: {
+    moderateContent: deepkeepModerateContent,
   },
 };


### PR DESCRIPTION
## Description

Adds DeepKeep as a native guardrail plugin for AI content moderation and toxicity filtering.

DeepKeep is an AI firewall that detects harmful, toxic, and policy-violating content in LLM inputs. This plugin integrates DeepKeep's v2 API as a first-class guardrail in the Portkey gateway.

**Changes:**
- `plugins/deepkeep/globals.ts` — API helpers for DeepKeep's two-step flow (create conversation + check user input)
- `plugins/deepkeep/moderateContent.ts` — Plugin handler implementing the `PluginHandler` interface
- `plugins/index.ts` — Registered as `deepkeep.moderateContent`

## Usage

```json
{
  "before_request_hooks": [{
    "id": "deepkeep-moderation",
    "type": "guardrail",
    "deny": true,
    "checks": [{
      "id": "deepkeep.moderateContent",
      "parameters": {
        "firewallId": "your-firewall-id",
        "credentials": {
          "apiKey": "your-deepkeep-api-key"
        }
      }
    }]
  }]
}
```

## Tests

- Verified `violate_policy: true` → `verdict: false` (request blocked)
- Verified `violate_policy: false` → `verdict: true` (request passed)
- Plugin fails open on DeepKeep errors (does not block traffic when unreachable)

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)