### PR TITLE
[New Plugin] Asqav - Quantum-safe audit trails

### DIFF
--- a/plugins/asqav/auditLog.test.ts
+++ b/plugins/asqav/auditLog.test.ts
@@ -1,0 +1,86 @@
+import { handler } from './auditLog';
+import { HookEventType, PluginContext, PluginParameters } from '../types';
+
+describe('asqav auditLog handler', () => {
+  const mockContext: PluginContext = {
+    request: {
+      json: {
+        model: 'gpt-4',
+        messages: [{ role: 'user', content: 'Hello' }],
+      },
+      text: 'Hello',
+    },
+    response: {
+      json: {
+        choices: [{ message: { content: 'Hi there' } }],
+      },
+      text: 'Hi there',
+    },
+    requestType: 'chatComplete',
+    provider: 'openai',
+    metadata: {},
+  };
+
+  it('should fail with missing API key', async () => {
+    const parameters: PluginParameters = {};
+    const result = await handler(
+      mockContext,
+      parameters,
+      'beforeRequestHook' as HookEventType
+    );
+
+    // failOpen defaults to true, so verdict should be true
+    expect(result.verdict).toBe(true);
+    expect(result.data.explanation).toContain('skipped');
+  });
+
+  it('should fail closed when failOpen is false and API key is missing', async () => {
+    const parameters: PluginParameters = { failOpen: false };
+    const result = await handler(
+      mockContext,
+      parameters,
+      'beforeRequestHook' as HookEventType
+    );
+
+    expect(result.verdict).toBe(false);
+    expect(result.error).toBeTruthy();
+  });
+
+  it('should use custom agentId from parameters', async () => {
+    const parameters: PluginParameters = {
+      credentials: { apiKey: 'test-key' },
+      agentId: 'my-agent',
+      failOpen: true,
+    };
+
+    const result = await handler(
+      mockContext,
+      parameters,
+      'beforeRequestHook' as HookEventType
+    );
+
+    // Will fail due to test API key but should fail open
+    expect(result.verdict).toBe(true);
+  });
+
+  it('should handle both beforeRequest and afterRequest hooks', async () => {
+    const parameters: PluginParameters = {
+      credentials: { apiKey: 'test-key' },
+      failOpen: true,
+    };
+
+    const beforeResult = await handler(
+      mockContext,
+      parameters,
+      'beforeRequestHook' as HookEventType
+    );
+    const afterResult = await handler(
+      mockContext,
+      parameters,
+      'afterRequestHook' as HookEventType
+    );
+
+    expect(beforeResult.verdict).toBe(true);
+    expect(afterResult.verdict).toBe(true);
+  });
+});

--- a/plugins/asqav/auditLog.ts
+++ b/plugins/asqav/auditLog.ts
@@ -1,0 +1,104 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { post, getText } from '../utils';
+
+const ASQAV_API_BASE = 'https://api.asqav.com/api/v1';
+
+interface AsqavSignResponse {
+  signature_id: string;
+  verification_url: string;
+  algorithm: string;
+  timestamp: string;
+}
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let error = null;
+  let verdict = true;
+  let data: any = null;
+
+  try {
+    const apiKey = parameters.credentials?.apiKey;
+    if (!apiKey) {
+      throw new Error(
+        'Missing asqav API key. Set it in the credentials field.'
+      );
+    }
+
+    const agentId =
+      parameters.agentId || context.metadata?.agentId || 'portkey-gateway';
+
+    const text = getText(context, eventType);
+    const action =
+      eventType === 'beforeRequestHook' ? 'llm_request' : 'llm_response';
+
+    const payload: Record<string, any> = {
+      action,
+      data: {
+        provider: context.provider || 'unknown',
+        model: context.request?.json?.model || 'unknown',
+        request_type: context.requestType || 'unknown',
+        content_length: text.length,
+        content_hash: await hashContent(text),
+      },
+    };
+
+    if (parameters.includeContent) {
+      payload.data.content = text.substring(0, 10000);
+    }
+
+    if (context.metadata) {
+      payload.data.metadata = context.metadata;
+    }
+
+    const headers = {
+      Authorization: `Bearer ${apiKey}`,
+      'X-Agent-Id': agentId,
+    };
+
+    const response = await post<AsqavSignResponse>(
+      `${ASQAV_API_BASE}/sessions/sign`,
+      payload,
+      { headers },
+      parameters.timeout || 5000
+    );
+
+    verdict = true;
+
+    data = {
+      signatureId: response.signature_id,
+      verificationUrl: response.verification_url,
+      algorithm: response.algorithm,
+      timestamp: response.timestamp,
+      action,
+      agentId,
+      explanation: `${action} signed with ${response.algorithm}. Verify: ${response.verification_url}`,
+    };
+  } catch (e: any) {
+    const failOpen = parameters.failOpen !== false;
+    error = failOpen ? null : e;
+    verdict = failOpen;
+
+    data = {
+      explanation: `Asqav signing ${failOpen ? 'skipped' : 'failed'}: ${e.message}`,
+      failOpen,
+    };
+  }
+
+  return { error, verdict, data };
+};
+
+async function hashContent(content: string): Promise<string> {
+  const encoder = new TextEncoder();
+  const data = encoder.encode(content);
+  const hashBuffer = await crypto.subtle.digest('SHA-256', data);
+  const hashArray = Array.from(new Uint8Array(hashBuffer));
+  return hashArray.map((b) => b.toString(16).padStart(2, '0')).join('');
+}

--- a/plugins/asqav/manifest.json
+++ b/plugins/asqav/manifest.json
@@ -1,0 +1,85 @@
+{
+  "id": "asqav",
+  "name": "Asqav",
+  "description": "Quantum-safe audit trails for AI traffic. Signs every request and response with ML-DSA-65 (NIST FIPS 204) for tamper-proof compliance evidence.",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "label": "API Key",
+        "description": [
+          {
+            "type": "subHeading",
+            "text": "Your asqav API key. Get one at https://asqav.com"
+          }
+        ]
+      }
+    },
+    "required": ["apiKey"]
+  },
+  "functions": [
+    {
+      "name": "Audit Log",
+      "id": "auditLog",
+      "type": "guardrail",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Signs requests and responses with quantum-safe ML-DSA-65 signatures. Creates tamper-proof audit trails with public verification URLs for compliance evidence (EU AI Act, DORA)."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "agentId": {
+            "type": "string",
+            "label": "Agent ID",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Identifier for the agent making requests. Defaults to 'portkey-gateway'."
+              }
+            ],
+            "default": "portkey-gateway"
+          },
+          "includeContent": {
+            "type": "boolean",
+            "label": "Include Content",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Include request/response content in the signed audit record. Disabled by default for privacy."
+              }
+            ],
+            "default": false
+          },
+          "failOpen": {
+            "type": "boolean",
+            "label": "Fail Open",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "If true, requests proceed even if signing fails. Set to false to block requests when audit trail cannot be created."
+              }
+            ],
+            "default": true
+          },
+          "timeout": {
+            "type": "number",
+            "label": "Timeout (ms)",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Timeout for the asqav API call in milliseconds."
+              }
+            ],
+            "default": 5000
+          }
+        },
+        "required": []
+      }
+    }
+  ]
+}

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -66,6 +66,7 @@ import { handler as javelinguardrails } from './javelin/guardrails';
 import { handler as f5GuardrailsScan } from './f5-guardrails/scan';
 import { handler as azureShieldPrompt } from './azure/shieldPrompt';
 import { handler as azureProtectedMaterial } from './azure/protectedMaterial';
+import { handler as asqavauditLog } from './asqav/auditLog';
 
 export const plugins = {
   default: {
@@ -175,5 +176,8 @@ export const plugins = {
   },
   'f5-guardrails': {
     scan: f5GuardrailsScan,
+  },
+  asqav: {
+    auditLog: asqavauditLog,
   },
 };


### PR DESCRIPTION
Closes #1577

## What this does

Adds an asqav guardrail plugin that signs every request and response with quantum-safe ML-DSA-65 signatures (NIST FIPS 204), creating tamper-proof audit trails with public verification URLs.

## How it works

- On `beforeRequestHook`: signs the outgoing request with the agent's key
- On `afterRequestHook`: signs the incoming response
- Each signed record gets a public verification URL for independent proof
- Fails open by default (configurable) so signing issues never block traffic

## Files

- `plugins/asqav/auditLog.ts` - guardrail handler
- `plugins/asqav/manifest.json` - plugin metadata
- `plugins/asqav/auditLog.test.ts` - tests
- `plugins/index.ts` - registration

## Parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `agentId` | string | `portkey-gateway` | Agent identifier for audit records |
| `includeContent` | boolean | `false` | Include request/response content in signed record |
| `failOpen` | boolean | `true` | Continue if signing fails |
| `timeout` | number | `5000` | API timeout in ms |

## Test results

```
PASS plugins/asqav/auditLog.test.ts
  asqav auditLog handler
    ✓ should fail with missing API key
    ✓ should fail closed when failOpen is false and API key is missing
    ✓ should use custom agentId from parameters
    ✓ should handle both beforeRequest and afterRequest hooks
```

- SDK: https://github.com/jagmarques/asqav-sdk (MIT)
- Docs: https://asqav.com/docs/