### PR TITLE
fix(anthropic): pass through top-level cache_control for automatic caching

### DIFF
--- a/src/providers/anthropic-base/messages.ts
+++ b/src/providers/anthropic-base/messages.ts
@@ -48,6 +48,10 @@ export const messagesBaseConfig: ProviderConfig = {
     param: 'thinking',
     required: false,
   },
+  cache_control: {
+    param: 'cache_control',
+    required: false,
+  },
   tool_choice: {
     param: 'tool_choice',
     required: false,

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -469,6 +469,10 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
     param: 'thinking',
     required: false,
   },
+  cache_control: {
+    param: 'cache_control',
+    required: false,
+  },
 };
 
 interface AnthorpicTextContentItem {


### PR DESCRIPTION
## Summary

- Anthropic supports [automatic prompt caching](https://docs.anthropic.com/en/docs/build-with-claude/prompt-caching#automatic-prompt-caching) via a top-level `cache_control` field on the request body, which automatically applies the cache breakpoint to the last cacheable block
- This field was not present in `AnthropicChatCompleteConfig`, so it was silently dropped during OpenAI→Anthropic request transformation
- Added `cache_control` as a passthrough parameter in the config