### PR TITLE
integration: Add PromptGuard AI security guardrails plugin

### DIFF
--- a/conf.example.json
+++ b/conf.example.json
@@ -9,7 +9,8 @@
     "pangea",
     "promptsecurity",
     "panw-prisma-airs",
-    "walledai"
+    "walledai",
+    "promptguard"
   ],
   "credentials": {
     "portkey": {

--- a/plugins/promptguard/manifest.json
+++ b/plugins/promptguard/manifest.json
@@ -1,0 +1,89 @@
+{
+  "id": "promptguard",
+  "description": "PromptGuard AI security firewall for scanning LLM inputs and outputs",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "label": "API Key",
+        "description": "Your PromptGuard API key. Get one at https://app.promptguard.co",
+        "encrypted": true
+      },
+      "baseUrl": {
+        "type": "string",
+        "label": "Base URL",
+        "description": "Custom base URL for self-hosted deployments. Defaults to https://api.promptguard.co/api/v1"
+      }
+    },
+    "required": ["apiKey"]
+  },
+  "functions": [
+    {
+      "name": "Security Scan",
+      "id": "scan",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "type": "guardrail",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "ML-powered detection of prompt injection, jailbreaks, and toxicity in LLM inputs and outputs."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {}
+      }
+    },
+    {
+      "name": "PII Redaction",
+      "id": "redact",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "type": "guardrail",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Detect and redact personally identifiable information (PII) from LLM inputs and outputs."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "redact": {
+            "type": "boolean",
+            "label": "Redact PII",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "If true, detected PII will be redacted from the text. If false, the request will be blocked."
+              }
+            ],
+            "default": true
+          },
+          "piiTypes": {
+            "type": "array",
+            "items": {
+              "type": "string",
+              "enum": [
+                "email",
+                "phone",
+                "ssn",
+                "credit_card",
+                "name",
+                "address",
+                "api_key",
+                "ip_address"
+              ]
+            },
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Select PII types to detect. Leave empty to detect all types."
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/plugins/promptguard/promptguard.test.ts
+++ b/plugins/promptguard/promptguard.test.ts
@@ -1,0 +1,151 @@
+import { handler as scanHandler } from './scan';
+import { handler as redactHandler } from './redact';
+import { HookEventType, PluginContext } from '../types';
+
+const options = { env: {} };
+
+describe('promptguard scan handler', () => {
+  it('should return error if no API key', async () => {
+    const context = {
+      request: { text: 'Hello world' },
+    };
+    const parameters = {};
+    const result = await scanHandler(
+      context,
+      parameters,
+      'beforeRequestHook',
+      options
+    );
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+
+  it('should return error if text is empty', async () => {
+    const context = {
+      request: { text: '' },
+    };
+    const parameters = {
+      credentials: { apiKey: 'pg_live_test_key' },
+    };
+    const result = await scanHandler(
+      context,
+      parameters,
+      'beforeRequestHook',
+      options
+    );
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+
+  it('should return error if credentials are empty object', async () => {
+    const context = {
+      request: { text: 'Hello world' },
+    };
+    const parameters = {
+      credentials: {},
+    };
+    const result = await scanHandler(
+      context,
+      parameters,
+      'beforeRequestHook',
+      options
+    );
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+});
+
+describe('promptguard redact handler', () => {
+  it('should return error if no API key', async () => {
+    const context = {
+      request: {
+        text: 'My email is test@example.com',
+        json: {
+          messages: [{ role: 'user', content: 'My email is test@example.com' }],
+        },
+      },
+      requestType: 'chatComplete',
+    } as PluginContext;
+    const parameters = {};
+    const result = await redactHandler(
+      context,
+      parameters,
+      'beforeRequestHook',
+      options
+    );
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+
+  it('should return error for embed requests with redaction', async () => {
+    const context = {
+      request: {
+        text: 'My email is test@example.com',
+        json: { input: 'My email is test@example.com' },
+      },
+      requestType: 'embed',
+    } as PluginContext;
+    const parameters = {
+      redact: true,
+      credentials: { apiKey: 'pg_live_test_key' },
+    };
+    const result = await redactHandler(
+      context,
+      parameters,
+      'beforeRequestHook',
+      options
+    );
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+
+  it('should return error if content is empty', async () => {
+    const context = {
+      request: {
+        json: null,
+      },
+      requestType: 'chatComplete',
+    } as PluginContext;
+    const parameters = {
+      credentials: { apiKey: 'pg_live_test_key' },
+    };
+    const result = await redactHandler(
+      context,
+      parameters,
+      'beforeRequestHook',
+      options
+    );
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+
+  it('should return error if credentials are empty object', async () => {
+    const context = {
+      request: {
+        text: 'My email is test@example.com',
+        json: {
+          messages: [{ role: 'user', content: 'My email is test@example.com' }],
+        },
+      },
+      requestType: 'chatComplete',
+    } as PluginContext;
+    const parameters = {
+      credentials: {},
+    };
+    const result = await redactHandler(
+      context,
+      parameters,
+      'beforeRequestHook',
+      options
+    );
+    expect(result.error).toBeDefined();
+    expect(result.verdict).toBe(true);
+    expect(result.data).toBeNull();
+  });
+});

--- a/plugins/promptguard/redact.ts
+++ b/plugins/promptguard/redact.ts
@@ -1,0 +1,140 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import {
+  getCurrentContentPart,
+  post,
+  setCurrentContentPart,
+  HttpError,
+} from '../utils';
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let transformedData: Record<string, any> = {
+    request: { json: null },
+    response: { json: null },
+  };
+  let transformed = false;
+  const shouldRedact = parameters.redact !== false;
+
+  try {
+    if (context.requestType === 'embed' && shouldRedact) {
+      return {
+        error: { message: 'PII redaction is not supported for embed requests' },
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed,
+      };
+    }
+
+    if (!parameters.credentials?.apiKey) {
+      return {
+        error: `'parameters.credentials.apiKey' must be set`,
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed,
+      };
+    }
+
+    const baseUrl =
+      parameters.credentials.baseUrl || 'https://api.promptguard.co/api/v1';
+    const url = `${baseUrl}/security/redact`;
+
+    const { content, textArray } = getCurrentContentPart(context, eventType);
+
+    if (!content) {
+      return {
+        error: { message: 'request or response json is empty' },
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed,
+      };
+    }
+
+    const requestOptions = {
+      headers: {
+        'Content-Type': 'application/json',
+        'X-API-Key': parameters.credentials.apiKey,
+      },
+    };
+
+    const redactedTextArray: (string | null)[] = [];
+    let piiDetected = false;
+    const allPiiFound: string[] = [];
+
+    for (const text of textArray) {
+      if (!text) {
+        redactedTextArray.push(null);
+        continue;
+      }
+
+      const request: Record<string, any> = { content: text };
+      if (parameters.piiTypes?.length) {
+        request.pii_types = parameters.piiTypes;
+      }
+
+      const response = await post(
+        url,
+        request,
+        requestOptions,
+        parameters.timeout
+      );
+
+      if (response.piiFound?.length > 0) {
+        piiDetected = true;
+        allPiiFound.push(...response.piiFound);
+      }
+
+      redactedTextArray.push(response.redacted || text);
+    }
+
+    let shouldBlock = piiDetected;
+    if (piiDetected && shouldRedact) {
+      setCurrentContentPart(
+        context,
+        eventType,
+        transformedData,
+        redactedTextArray
+      );
+      shouldBlock = false;
+      transformed = true;
+    }
+
+    return {
+      error: null,
+      verdict: !shouldBlock,
+      data: {
+        piiDetected,
+        piiTypes: [...new Set(allPiiFound)],
+      },
+      transformedData,
+      transformed,
+    };
+  } catch (e) {
+    if (e instanceof HttpError) {
+      return {
+        error: `${e.message}. body: ${e.response.body}`,
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed,
+      };
+    }
+    return {
+      error: e as Error,
+      verdict: true,
+      data: null,
+      transformedData,
+      transformed,
+    };
+  }
+};

--- a/plugins/promptguard/scan.ts
+++ b/plugins/promptguard/scan.ts
@@ -1,0 +1,72 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { post, getText, HttpError } from '../utils';
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let error = null;
+  let verdict = true;
+  let data = null;
+
+  if (!parameters.credentials?.apiKey) {
+    return {
+      error: `'parameters.credentials.apiKey' must be set`,
+      verdict: true,
+      data,
+    };
+  }
+
+  const baseUrl =
+    parameters.credentials.baseUrl || 'https://api.promptguard.co/api/v1';
+  const url = `${baseUrl}/security/scan`;
+
+  const text = getText(context, eventType);
+  if (!text) {
+    return {
+      error: 'request or response text is empty',
+      verdict: true,
+      data,
+    };
+  }
+
+  const requestOptions = {
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': parameters.credentials.apiKey,
+    },
+  };
+
+  const scanType = eventType === 'beforeRequestHook' ? 'prompt' : 'response';
+
+  const request = {
+    content: text,
+    type: scanType,
+  };
+
+  let response;
+  try {
+    response = await post(url, request, requestOptions, parameters.timeout);
+  } catch (e) {
+    if (e instanceof HttpError) {
+      error = `${e.message}. body: ${e.response.body}`;
+    } else {
+      error = e as Error;
+    }
+  }
+
+  if (response) {
+    data = response;
+    if (response.blocked) {
+      verdict = false;
+    }
+  }
+
+  return { error, verdict, data };
+};


### PR DESCRIPTION
## Summary

Adds [PromptGuard](https://promptguard.co) as a guardrails plugin for the Portkey AI Gateway. PromptGuard is an ML-powered AI security firewall that provides real-time threat detection and PII protection for LLM traffic.

### Plugin functions

| Function | Hook | Description |
|----------|------|-------------|
| **Security Scan** | `beforeRequestHook`, `afterRequestHook` | ML-powered detection of prompt injection, jailbreaks, and toxicity |
| **PII Redaction** | `beforeRequestHook`, `afterRequestHook` | Detect and optionally redact PII (emails, phones, SSNs, credit cards, etc.) |

### Files added/changed

- `plugins/promptguard/manifest.json` — Plugin manifest with credentials and function definitions
- `plugins/promptguard/scan.ts` — Security scan handler (prompt injection, jailbreak, toxicity detection)
- `plugins/promptguard/redact.ts` — PII detection and redaction handler with content transformation
- `plugins/promptguard/promptguard.test.ts` — 7 unit tests covering credential validation, empty input, and edge cases
- `conf.example.json` — Added `promptguard` to `plugins_enabled`

### Credentials

| Field | Required | Description |
|-------|----------|-------------|
| `apiKey` | Yes | PromptGuard API key (encrypted). Get one at https://app.promptguard.co |
| `baseUrl` | No | Custom base URL for self-hosted deployments. Defaults to `https://api.promptguard.co/api/v1` |

### Configuration example

```json
{
  "name": "promptguard-scan",
  "provider": "promptguard",
  "credentials": {
    "apiKey": "pg_live_..."
  },
  "function": "scan",
  "onSuccess": "allow",
  "onFail": "deny"
}
```

## Test plan

- [x] All 7 unit tests pass (`npx jest plugins/promptguard/ --no-coverage`)
- [x] `prettier --check` passes (pre-commit hook verified)
- [x] `eslint` passes with zero errors
- [x] Build succeeds (`rollup -c` via pre-push hook)
- [x] Gateway starts successfully (verified via pre-push hook)