### PR TITLE
fix(anthropic): forward OAuth bearer tokens via Authorization header

### DIFF
--- a/src/providers/anthropic/api.ts
+++ b/src/providers/anthropic/api.ts
@@ -6,9 +6,16 @@ const AnthropicAPIConfig: ProviderAPIConfig = {
   headers: ({ providerOptions, fn, gatewayRequestBody }) => {
     const apiKey =
       providerOptions.apiKey || providerOptions.anthropicApiKey || '';
-    const headers: Record<string, string> = {
-      'X-API-Key': apiKey,
-    };
+    const headers: Record<string, string> = {};
+
+    // Anthropic API keys start with 'sk-ant-' and must be sent as X-API-Key.
+    // OAuth bearer tokens (e.g. Claude Max / enterprise SSO) must be sent as
+    // Authorization: Bearer. Detect which scheme to use based on the key prefix.
+    if (!apiKey || apiKey.startsWith('sk-ant-')) {
+      headers['X-API-Key'] = apiKey;
+    } else {
+      headers['Authorization'] = `Bearer ${apiKey}`;
+    }
 
     // Accept anthropic_beta and anthropic_version in body to support enviroments which cannot send it in headers.
     const betaHeader =


### PR DESCRIPTION
## Summary

Fixes #1598

Anthropic uses two mutually exclusive authentication schemes:
- **API keys** (`sk-ant-*`): must be sent as `X-API-Key: <key>`
- **OAuth bearer tokens** (Claude Max / enterprise SSO): must be sent as `Authorization: Bearer <token>`

Previously, `src/providers/anthropic/api.ts` always forwarded credentials as `X-API-Key`, causing OAuth token authentication to always fail.

## Root cause

When a client sends `Authorization: Bearer <oauth_token>`, `handlerUtils.ts` strips the `Bearer ` prefix and stores the raw token as `apiKey`. The Anthropic provider then places it in `X-API-Key`, which Anthropic rejects for OAuth tokens.

## Fix

Detect the credential type by prefix in `src/providers/anthropic/api.ts` and choose the correct header:

```typescript
if (!apiKey || apiKey.startsWith('sk-ant-')) {
  headers['X-API-Key'] = apiKey;
} else {
  headers['Authorization'] = `Bearer ${apiKey}`;
}
```

## Test plan

- [ ] Requests with a standard `sk-ant-*` API key continue to use `X-API-Key` (no regression)
- [ ] Requests with an OAuth bearer token forwarded via `Authorization: Bearer` are sent to Anthropic with `Authorization: Bearer <token>`
- [ ] Claude Code configured with `ANTHROPIC_BASE_URL=https://api.portkey.ai` and no `ANTHROPIC_API_KEY` (OAuth/Max plan) authenticates successfully without mid-session failures