### PR TITLE
feat(provider): add Kyma API OpenAI-compatible provider

### DIFF
--- a/cookbook/providers/kyma.ipynb
+++ b/cookbook/providers/kyma.ipynb
@@ -1,0 +1,193 @@
+{
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "# Portkey + Kyma API\n",
+        "\n",
+        "[Portkey](https://app.portkey.ai/) is the Control Panel for AI apps. With its popular AI Gateway and Observability Suite, hundreds of teams ship reliable, cost-efficient, and fast apps."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Access 20+ Open-Source Models via Kyma API with OpenAI Compatibility!\n",
+        "\n",
+        "[Kyma API](https://kymaapi.com) is an OpenAI-compatible LLM gateway providing access to 20+ open-source and open-weight models (DeepSeek, Qwen, LLaMA, Gemma, Kimi, and more) through a single endpoint.\n",
+        "\n",
+        "Key features:\n",
+        "- **20+ models** across quality tiers (Tier 1–3)\n",
+        "- **4-layer fallback routing** for high availability\n",
+        "- **OpenAI-compatible** `/v1/chat/completions` endpoint\n",
+        "- **Streaming support** with standard SSE format\n",
+        "- **Tool calling** support on most models\n",
+        "\n",
+        "Since Portkey is fully compatible with the OpenAI signature, you can connect to the Portkey AI Gateway through the OpenAI Client.\n",
+        "\n",
+        "- Set the `base_url` as `PORTKEY_GATEWAY_URL`\n",
+        "- Add `default_headers` to consume the headers needed by Portkey using the `createHeaders` helper method."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "You will need Portkey and Kyma API keys to run this notebook.\n",
+        "\n",
+        "- Sign up for [Portkey here](https://app.portkey.ai/signup) and generate your API key.\n",
+        "- Sign up at [kymaapi.com](https://kymaapi.com) and get your API key from the dashboard."
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "!pip install -qU portkey-ai openai"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## With OpenAI Client"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from openai import OpenAI\n",
+        "from portkey_ai import PORTKEY_GATEWAY_URL, createHeaders\n",
+        "\n",
+        "client = OpenAI(\n",
+        "    base_url=PORTKEY_GATEWAY_URL,\n",
+        "    default_headers=createHeaders(\n",
+        "        provider=\"kyma\",\n",
+        "        api_key=\"YOUR_KYMA_API_KEY\"\n",
+        "    )\n",
+        ")\n",
+        "\n",
+        "chat_completion = client.chat.completions.create(\n",
+        "    messages=[{\"role\": \"user\", \"content\": \"What is the meaning of life?\"}],\n",
+        "    model=\"deepseek-v3\"  # Try: deepseek-r1, llama-3.3-70b, qwen-3-32b, gemma-4-31b\n",
+        ")\n",
+        "\n",
+        "print(chat_completion.choices[0].message.content)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## With Portkey Client"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "from portkey_ai import Portkey\n",
+        "\n",
+        "portkey = Portkey(\n",
+        "    api_key=\"YOUR_PORTKEY_API_KEY\",\n",
+        "    provider=\"kyma\",\n",
+        "    Authorization=\"YOUR_KYMA_API_KEY\"\n",
+        ")\n",
+        "\n",
+        "completion = portkey.chat.completions.create(\n",
+        "    messages=[{\"role\": \"user\", \"content\": \"Explain quantum computing in simple terms\"}],\n",
+        "    model=\"llama-3.3-70b\"\n",
+        ")\n",
+        "\n",
+        "print(completion.choices[0].message.content)"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Streaming Responses"
+      ]
+    },
+    {
+      "cell_type": "code",
+      "execution_count": null,
+      "metadata": {},
+      "outputs": [],
+      "source": [
+        "stream = portkey.chat.completions.create(\n",
+        "    messages=[{\"role\": \"user\", \"content\": \"Write a short poem about open-source AI\"}],\n",
+        "    model=\"deepseek-v3\",\n",
+        "    stream=True\n",
+        ")\n",
+        "\n",
+        "for chunk in stream:\n",
+        "    if chunk.choices[0].delta.content:\n",
+        "        print(chunk.choices[0].delta.content, end=\"\")"
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Available Models\n",
+        "\n",
+        "Kyma API provides access to 20+ open-source models across quality tiers:\n",
+        "\n",
+        "**Tier 1 — Highest Quality:**\n",
+        "- `deepseek-v3` — GPT-5 class reasoning, cost-effective\n",
+        "- `deepseek-r1` — Deep reasoning, 96% cheaper than o1\n",
+        "- `qwen-3-32b` — Top coding performance\n",
+        "- `llama-3.3-70b` — Most popular open model\n",
+        "- `gemma-4-31b` — Multimodal, Google Gemma 4\n",
+        "- `kimi-k2.5` — Multimodal agentic\n",
+        "\n",
+        "**Tier 2 — High Quality:**\n",
+        "- `gemini-2.5-flash`, `gemini-3-flash`\n",
+        "- `qwen-3-coder`, `kimi-k2`, `minimax-m2.5`\n",
+        "\n",
+        "**Tier 3 — Fast & Cheap:**\n",
+        "- `llama-4-scout`, `gemini-2.5-flash-lite`\n",
+        "- `step-3.5-flash`, `glm-4.5-air`\n",
+        "\n",
+        "See the full model list at [kymaapi.com/dashboard/models](https://kymaapi.com/dashboard/models)."
+      ]
+    },
+    {
+      "cell_type": "markdown",
+      "metadata": {},
+      "source": [
+        "## Observability with Portkey\n",
+        "\n",
+        "By routing requests through Portkey you can track metrics like:\n",
+        "- Token usage and costs\n",
+        "- Request latency\n",
+        "- Success/error rates\n",
+        "\n",
+        "View all your analytics at [Portkey Dashboard](https://app.portkey.ai/)."
+      ]
+    }
+  ],
+  "metadata": {
+    "colab": {
+      "provenance": []
+    },
+    "kernelspec": {
+      "display_name": "Python 3",
+      "name": "python3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "nbformat": 4,
+  "nbformat_minor": 0
+}

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -113,6 +113,7 @@ export const ORACLE: string = 'oracle';
 export const IO_INTELLIGENCE: string = 'iointelligence';
 export const AIBADGR: string = 'aibadgr';
 export const OVHCLOUD: string = 'ovhcloud';
+export const KYMA: string = 'kyma';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -189,6 +190,7 @@ export const VALID_PROVIDERS = [
   IO_INTELLIGENCE,
   AIBADGR,
   OVHCLOUD,
+  KYMA,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,6 +74,7 @@ import OracleConfig from './oracle';
 import IOIntelligenceConfig from './iointelligence';
 import AIBadgrConfig from './aibadgr';
 import OVHcloudConfig from './ovhcloud';
+import KymaConfig from './kyma';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -148,6 +149,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   iointelligence: IOIntelligenceConfig,
   aibadgr: AIBadgrConfig,
   ovhcloud: OVHcloudConfig,
+  kyma: KymaConfig,
 };
 
 export default Providers;

--- a/src/providers/kyma/api.ts
+++ b/src/providers/kyma/api.ts
@@ -1,0 +1,18 @@
+import { ProviderAPIConfig } from '../types';
+
+const KymaAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://kymaapi.com/v1',
+  headers: ({ providerOptions }) => {
+    return { Authorization: `Bearer ${providerOptions.apiKey}` };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      default:
+        return '';
+    }
+  },
+};
+
+export default KymaAPIConfig;

--- a/src/providers/kyma/chatComplete.ts
+++ b/src/providers/kyma/chatComplete.ts
@@ -1,0 +1,61 @@
+import { KYMA } from '../../globals';
+
+interface KymaStreamChunk {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: {
+    index: number;
+    delta: {
+      role?: string;
+      content?: string;
+      tool_calls?: object[];
+    };
+    finish_reason: string | null;
+  }[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export const KymaChatCompleteStreamChunkTransform = (
+  responseChunk: string
+) => {
+  let chunk = responseChunk.trim();
+  chunk = chunk.replace(/^data: /, '');
+  chunk = chunk.trim();
+
+  if (chunk === '[DONE]') {
+    return `data: ${chunk}\n\n`;
+  }
+
+  try {
+    const parsedChunk: KymaStreamChunk = JSON.parse(chunk);
+    return (
+      `data: ${JSON.stringify({
+        id: parsedChunk.id,
+        object: parsedChunk.object,
+        created: parsedChunk.created,
+        model: parsedChunk.model,
+        provider: KYMA,
+        choices: parsedChunk.choices.map((choice) => ({
+          index: choice.index,
+          delta: choice.delta,
+          finish_reason: choice.finish_reason,
+        })),
+        usage: parsedChunk.usage,
+      })}` + '\n\n'
+    );
+  } catch (error) {
+    console.error(
+      'Error parsing Kyma stream chunk:',
+      error,
+      'Chunk:',
+      chunk
+    );
+    return `data: ${chunk}\n\n`;
+  }
+};

--- a/src/providers/kyma/index.ts
+++ b/src/providers/kyma/index.ts
@@ -1,0 +1,18 @@
+import { ProviderConfigs } from '../types';
+import KymaAPIConfig from './api';
+import { KymaChatCompleteStreamChunkTransform } from './chatComplete';
+import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import { KYMA } from '../../globals';
+
+const KymaConfig: ProviderConfigs = {
+  api: KymaAPIConfig,
+  chatComplete: chatCompleteParams([]),
+  responseTransforms: {
+    ...responseTransformers(KYMA, {
+      chatComplete: true,
+    }),
+    'stream-chatComplete': KymaChatCompleteStreamChunkTransform,
+  },
+};
+
+export default KymaConfig;


### PR DESCRIPTION
## Description

- Added Kyma API to the global provider registry (`src/globals.ts`)
- Implemented OpenAI-compatible chat completion and streaming support
- Added provider-specific API configuration (base URL, auth headers)
- Included a usage notebook demonstrating Portkey + Kyma API integration

## About Kyma API

[Kyma API](https://kymaapi.com) is an LLM gateway providing access to 20+ open-source and open-weight models through a single OpenAI-compatible endpoint:

- **20+ models**: DeepSeek V3/R1, Qwen 3, LLaMA 3.3 70B, Gemma 4, Kimi K2, and more
- **4-layer fallback routing** for high availability (multi-provider, never-die architecture)
- **Standard OpenAI `/v1/chat/completions`** endpoint with streaming (SSE)
- **Tool calling** support on most models
- Free credits on signup, pay-per-token after

## Tests Run/Test cases added

- Manual verification via OpenAI client with `provider="kyma"` header
- Streaming responses validated against live endpoint

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)