### PR TITLE
fix(anthropic): use correct content_block format for tool_use in cache replay

### DIFF
--- a/src/providers/anthropic-base/utils/streamGenerator.ts
+++ b/src/providers/anthropic-base/utils/streamGenerator.ts
@@ -62,7 +62,9 @@ const toolUseContentBlockStartEvent = (
     index,
     content_block: {
       type: 'tool_use',
-      tool_use: { ...toolUseBlock, input: {} },
+      id: toolUseBlock.id,
+      name: toolUseBlock.name,
+      input: {},
     },
   })}\n\n`;
 };


### PR DESCRIPTION
## Summary

- Fix `toolUseContentBlockStartEvent` in `streamGenerator.ts` to put `id` and `name` at the `content_block` level instead of nesting them under a `tool_use` sub-key.

## Problem

When a cached Anthropic `/v1/messages` JSON response is replayed as an SSE stream via `anthropicMessagesJsonToStreamGenerator`, the `content_block_start` event for `tool_use` blocks is emitted as:

```json
{
  "type": "content_block_start",
  "index": 0,
  "content_block": {
    "type": "tool_use",
    "tool_use": { "id": "toolu_01X...", "name": "my_tool", "input": {} }
  }
}
```

The [Anthropic streaming spec](https://docs.anthropic.com/en/api/streaming#raw-sse-stream) puts `id` and `name` at the `content_block` level:

```json
{
  "type": "content_block_start",
  "index": 0,
  "content_block": {
    "type": "tool_use",
    "id": "toolu_01X...",
    "name": "my_tool",
    "input": {}
  }
}
```

This causes downstream clients (e.g. `langchain-anthropic`'s `ChatAnthropic`) to read `null` for `id` and `name` from the outer object, breaking tool call extraction on cache hits.

## Fix

Promote `id` and `name` from `toolUseBlock` to the `content_block` level, matching the format used by Anthropic's real SSE stream and by the other content block helpers in the same file (`textContentBlockStartEvent`, `thinkingContentBlockStartEvent`).