### PR TITLE
fix: normalize prompt_tokens to include cache tokens across all Anthropic providers

### DIFF
--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -610,7 +610,10 @@ export const getAnthropicChatCompleteResponseTransform = (provider: string) => {
           },
         ],
         usage: {
-          prompt_tokens: input_tokens,
+          prompt_tokens:
+            input_tokens +
+            (cache_creation_input_tokens ?? 0) +
+            (cache_read_input_tokens ?? 0),
           completion_tokens: output_tokens,
           total_tokens:
             input_tokens +
@@ -699,7 +702,10 @@ export const getAnthropicStreamChunkTransform = (provider: string) => {
     if (parsedChunk.type === 'message_start' && parsedChunk.message?.usage) {
       streamState.model = parsedChunk?.message?.model ?? '';
       streamState.usage = {
-        prompt_tokens: parsedChunk.message?.usage?.input_tokens,
+        prompt_tokens:
+          (parsedChunk.message?.usage?.input_tokens ?? 0) +
+          (parsedChunk.message?.usage?.cache_creation_input_tokens ?? 0) +
+          (parsedChunk.message?.usage?.cache_read_input_tokens ?? 0),
         ...(shouldSendCacheUsage && {
           cache_read_input_tokens:
             parsedChunk.message?.usage?.cache_read_input_tokens,

--- a/src/providers/google-vertex-ai/chatComplete.ts
+++ b/src/providers/google-vertex-ai/chatComplete.ts
@@ -896,7 +896,10 @@ export const VertexAnthropicChatCompleteResponseTransform: (
         },
       ],
       usage: {
-        prompt_tokens: input_tokens,
+        prompt_tokens:
+          input_tokens +
+          (cache_creation_input_tokens ?? 0) +
+          (cache_read_input_tokens ?? 0),
         completion_tokens: output_tokens,
         total_tokens: totalTokens,
         prompt_tokens_details: {
@@ -981,7 +984,10 @@ export const VertexAnthropicChatCompleteStreamChunkTransform: (
     streamState.model = parsedChunk?.message?.model ?? '';
 
     streamState.usage = {
-      prompt_tokens: parsedChunk.message.usage?.input_tokens,
+      prompt_tokens:
+        (parsedChunk.message.usage?.input_tokens ?? 0) +
+        (parsedChunk.message?.usage?.cache_creation_input_tokens ?? 0) +
+        (parsedChunk.message?.usage?.cache_read_input_tokens ?? 0),
       ...(shouldSendCacheUsage && {
         cache_read_input_tokens:
           parsedChunk.message?.usage?.cache_read_input_tokens,


### PR DESCRIPTION
## Summary

Fixes #1564

`prompt_tokens` normalization is inconsistent across Anthropic access paths:

| Provider | `prompt_tokens` includes cache? |
|----------|----------------------------------|
| Anthropic direct | ❌ No (`input_tokens` only) |
| Vertex AI | ❌ No (`input_tokens` only) |
| Bedrock | ✅ Yes (`inputTokens + cache*`) |

Per OpenAI convention, `prompt_tokens` should include cached tokens, with breakdown in `prompt_tokens_details.cached_tokens`.

## Changes

Updated 4 code paths (non-streaming + streaming × 2 providers):

**Anthropic direct** (`src/providers/anthropic/chatComplete.ts`):
```ts
// Before
prompt_tokens: input_tokens

// After
prompt_tokens: input_tokens + (cache_creation_input_tokens ?? 0) + (cache_read_input_tokens ?? 0)
```

**Vertex AI** (`src/providers/google-vertex-ai/chatComplete.ts`): same change.

Both non-streaming and streaming paths updated. `total_tokens` was already correct.