### PR TITLE
fix: upgrade @hono/node-server to fix Node.js v24 crash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
       "dependencies": {
         "@aws-crypto/sha256-js": "^5.2.0",
         "@cfworker/json-schema": "^4.0.3",
-        "@hono/node-server": "^1.3.3",
+        "@hono/node-server": "^1.14.2",
         "@hono/node-ws": "^1.2.0",
         "@portkey-ai/mustache": "^2.1.3",
         "@smithy/signature-v4": "^2.1.1",
@@ -1361,9 +1361,10 @@
       }
     },
     "node_modules/@hono/node-server": {
-      "version": "1.13.5",
-      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.13.5.tgz",
-      "integrity": "sha512-lSo+CFlLqAFB4fX7ePqI9nauEn64wOfJHAfc9duYFTvAG3o416pC0nTGeNjuLHchLedH+XyWda5v79CVx1PIjg==",
+      "version": "1.19.14",
+      "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+      "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+      "license": "MIT",
       "engines": {
         "node": ">=18.14.1"
       },

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@aws-crypto/sha256-js": "^5.2.0",
     "@cfworker/json-schema": "^4.0.3",
-    "@hono/node-server": "^1.3.3",
+    "@hono/node-server": "^1.14.2",
     "@hono/node-ws": "^1.2.0",
     "@portkey-ai/mustache": "^2.1.3",
     "@smithy/signature-v4": "^2.1.1",


### PR DESCRIPTION
Closes #1604

## Summary

- Bump `@hono/node-server` from `^1.3.3` (resolved 1.13.5) to `^1.14.2` (resolved 1.19.14)
- Fixes `Failed to find Response internal state key` error on Node.js v24
- One-line change in `package.json` + lockfile update

## Root Cause

Node.js v24 ships a newer version of Undici that changed how `Response` internal state is accessed ([nodejs/undici@45dceeaf](https://github.com/nodejs/undici/commit/45dceeaf376325df0fee3de83bc3d9f1e82a2cfd)). This was fixed upstream in [honojs/node-server#241](https://github.com/honojs/node-server/pull/241) and released in `@hono/node-server@1.14.2`.

## Before (Node v24)

```
Failed to find Response internal state key
Failed to start the app: 1
```

## After (Node v24)

```
🚀 Your AI Gateway is running at:
   http://localhost:8787

✨ Ready for connections!
```

## Test Plan

- [x] `npm run build` — clean
- [x] `node start-test.js` — boots without error, exits 0
- [x] Unit tests — no regressions (same 6 pre-existing failures in `handlers/services/`)