### PR TITLE
Adding tavily as a plugin integration

### DIFF
--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -52,6 +52,7 @@ import { pluginHandler as bedrockHandler } from './bedrock/index';
 import { handler as acuvityScan } from './acuvity/scan';
 import { handler as lassoclassify } from './lasso/classify';
 import { handler as exaonline } from './exa/online';
+import { handler as tavilyonline } from './tavily/online';
 import { handler as azurePii } from './azure/pii';
 import { handler as azureContentSafety } from './azure/contentSafety';
 import { handler as promptSecurityProtectPrompt } from './promptsecurity/protectPrompt';
@@ -153,6 +154,9 @@ export const plugins = {
   },
   exa: {
     online: exaonline,
+  },
+  tavily: {
+    online: tavilyonline,
   },
   azure: {
     pii: azurePii,

--- a/plugins/tavily/manifest.json
+++ b/plugins/tavily/manifest.json
@@ -79,7 +79,7 @@
             "description": [
               {
                 "type": "subHeading",
-                "text": "Maximum number of chunks returned per source. Tavily documents this for advanced search depth."
+                "text": "Maximum number of chunks returned per source. Tavily documents this for advanced and fast search depths."
               }
             ],
             "default": 3

--- a/plugins/tavily/manifest.json
+++ b/plugins/tavily/manifest.json
@@ -1,0 +1,296 @@
+{
+  "id": "tavily",
+  "name": "Tavily",
+  "description": "Tavily integration for enriching LLM prompts with fresh web search context before inference.",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "label": "API Key",
+        "description": "Your Tavily API key.",
+        "encrypted": true
+      }
+    },
+    "required": ["apiKey"]
+  },
+  "functions": [
+    {
+      "name": "Online Search",
+      "id": "online",
+      "supportedHooks": ["beforeRequestHook"],
+      "type": "transformer",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Adds relevant Tavily web results to the prompt so the model can answer with current online information."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "prefix": {
+            "type": "string",
+            "label": "Context Prefix",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Text inserted before the Tavily search context in the prompt."
+              }
+            ],
+            "default": "\n<web_search_context>"
+          },
+          "suffix": {
+            "type": "string",
+            "label": "Context Suffix",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Text inserted after the Tavily search context in the prompt."
+              }
+            ],
+            "default": "\n</web_search_context>"
+          },
+          "maxResults": {
+            "type": "number",
+            "label": "Maximum Results",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Maximum number of Tavily search results to return."
+              }
+            ],
+            "default": 5
+          },
+          "searchDepth": {
+            "type": "string",
+            "label": "Search Depth",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Controls the latency versus relevance tradeoff for Tavily search."
+              }
+            ],
+            "enum": ["advanced", "basic", "fast", "ultra-fast"]
+          },
+          "chunksPerSource": {
+            "type": "number",
+            "label": "Chunks Per Source",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Maximum number of chunks returned per source. Tavily documents this for advanced search depth."
+              }
+            ],
+            "default": 3
+          },
+          "topic": {
+            "type": "string",
+            "label": "Topic",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Category of results to retrieve."
+              }
+            ],
+            "enum": ["general", "news", "finance"]
+          },
+          "timeRange": {
+            "type": "string",
+            "label": "Time Range",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Filter results based on how recently sources were published or updated."
+              }
+            ],
+            "enum": ["day", "week", "month", "year", "d", "w", "m", "y"]
+          },
+          "startDate": {
+            "type": "string",
+            "label": "Start Date",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Return results after this date in YYYY-MM-DD format."
+              }
+            ]
+          },
+          "endDate": {
+            "type": "string",
+            "label": "End Date",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Return results before this date in YYYY-MM-DD format."
+              }
+            ]
+          },
+          "includeAnswer": {
+            "label": "Include Answer",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Include a Tavily-generated answer in the response."
+              }
+            ],
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string",
+                "enum": ["basic", "advanced"]
+              }
+            ],
+            "default": false
+          },
+          "includeRawContent": {
+            "label": "Include Raw Content",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Include cleaned and parsed HTML content for each result."
+              }
+            ],
+            "oneOf": [
+              {
+                "type": "boolean"
+              },
+              {
+                "type": "string",
+                "enum": ["markdown", "text"]
+              }
+            ],
+            "default": false
+          },
+          "includeImages": {
+            "type": "boolean",
+            "label": "Include Images",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Include query-related images and per-result images in the Tavily response."
+              }
+            ],
+            "default": false
+          },
+          "includeImageDescriptions": {
+            "type": "boolean",
+            "label": "Include Image Descriptions",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "When images are included, also include descriptive text for each image."
+              }
+            ],
+            "default": false
+          },
+          "includeFavicon": {
+            "type": "boolean",
+            "label": "Include Favicon",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Include the favicon URL for each result."
+              }
+            ],
+            "default": false
+          },
+          "includeDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "label": "Include Domains",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Restrict results to the listed domains."
+              }
+            ]
+          },
+          "excludeDomains": {
+            "type": "array",
+            "items": {
+              "type": "string"
+            },
+            "label": "Exclude Domains",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Exclude results from the listed domains."
+              }
+            ]
+          },
+          "country": {
+            "type": "string",
+            "label": "Country",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Boost results from a specific country. Tavily supports this only when topic is general."
+              }
+            ]
+          },
+          "autoParameters": {
+            "type": "boolean",
+            "label": "Auto Parameters",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Let Tavily automatically configure search parameters from the query. Explicit values still override Tavily's choices."
+              }
+            ],
+            "default": false
+          },
+          "exactMatch": {
+            "type": "boolean",
+            "label": "Exact Match",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Return only results matching exact quoted phrases from the query."
+              }
+            ],
+            "default": false
+          },
+          "includeUsage": {
+            "type": "boolean",
+            "label": "Include Usage",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Include Tavily credit usage information in the response metadata."
+              }
+            ],
+            "default": false
+          },
+          "safeSearch": {
+            "type": "boolean",
+            "label": "Safe Search",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Enterprise-only. Filters adult or unsafe content. Tavily does not support this for fast or ultra-fast search depth."
+              }
+            ],
+            "default": false
+          },
+          "timeout": {
+            "type": "number",
+            "label": "Timeout",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Maximum time to wait for the Tavily request in milliseconds."
+              }
+            ],
+            "default": 30000
+          }
+        },
+        "required": []
+      }
+    }
+  ]
+}

--- a/plugins/tavily/online.ts
+++ b/plugins/tavily/online.ts
@@ -185,7 +185,10 @@ const performTavilySearch = async (
     searchBody.exclude_domains = parameters.excludeDomains;
   }
 
-  if (effectiveSearchDepth === 'advanced' && parameters.chunksPerSource) {
+  if (
+    (effectiveSearchDepth === 'advanced' || effectiveSearchDepth === 'fast') &&
+    parameters.chunksPerSource
+  ) {
     searchBody.chunks_per_source = parameters.chunksPerSource;
   }
 

--- a/plugins/tavily/online.ts
+++ b/plugins/tavily/online.ts
@@ -1,0 +1,510 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { getCurrentContentPart, post } from '../utils';
+
+const BASE_URL = 'https://api.tavily.com/search';
+const TAVILY_CLIENT_SOURCE = 'portkey-ai';
+const MAX_PROMPT_IMAGES = 5;
+
+type TavilySearchDepth = 'advanced' | 'basic' | 'fast' | 'ultra-fast';
+type TavilyTopic = 'general' | 'news' | 'finance';
+type TavilyTimeRange =
+  | 'day'
+  | 'week'
+  | 'month'
+  | 'year'
+  | 'd'
+  | 'w'
+  | 'm'
+  | 'y';
+type TavilyIncludeAnswer = boolean | 'basic' | 'advanced';
+type TavilyIncludeRawContent = boolean | 'markdown' | 'text';
+
+interface TavilyImageObject {
+  url: string;
+  description?: string;
+}
+
+type TavilyImage = string | TavilyImageObject;
+
+interface TavilySearchResult {
+  title: string;
+  url: string;
+  content: string;
+  score?: number;
+  raw_content?: string | null;
+  favicon?: string | null;
+  images?: TavilyImage[];
+}
+
+interface FormattedSearchResult {
+  title: string;
+  url: string;
+  text: string;
+  score?: number;
+  raw_content?: string | null;
+  favicon?: string | null;
+  images?: TavilyImage[];
+}
+
+interface TavilySearchResponse {
+  query: string;
+  answer?: string;
+  images: TavilyImage[];
+  results: TavilySearchResult[];
+  response_time: number | string;
+  auto_parameters?: {
+    topic: TavilyTopic;
+    search_depth: TavilySearchDepth;
+  };
+  usage?: {
+    credits: number;
+  };
+  request_id?: string;
+}
+
+interface TavilySearchRequest {
+  query: string;
+  max_results?: number;
+  search_depth?: TavilySearchDepth;
+  chunks_per_source?: number;
+  topic?: TavilyTopic;
+  time_range?: TavilyTimeRange;
+  start_date?: string;
+  end_date?: string;
+  include_answer?: TavilyIncludeAnswer;
+  include_raw_content?: TavilyIncludeRawContent;
+  include_images?: boolean;
+  include_image_descriptions?: boolean;
+  include_favicon?: boolean;
+  include_domains?: string[];
+  exclude_domains?: string[];
+  country?: string;
+  auto_parameters?: boolean;
+  exact_match?: boolean;
+  include_usage?: boolean;
+  safe_search?: boolean;
+}
+
+interface TavilyOnlineParameters extends PluginParameters<{ apiKey: string }> {
+  prefix?: string;
+  suffix?: string;
+  maxResults?: number;
+  includeDomains?: string[];
+  excludeDomains?: string[];
+  timeout?: number;
+  searchDepth?: TavilySearchDepth;
+  chunksPerSource?: number;
+  topic?: TavilyTopic;
+  timeRange?: TavilyTimeRange;
+  startDate?: string;
+  endDate?: string;
+  includeAnswer?: TavilyIncludeAnswer;
+  includeRawContent?: TavilyIncludeRawContent;
+  includeImages?: boolean;
+  includeImageDescriptions?: boolean;
+  includeFavicon?: boolean;
+  country?: string;
+  autoParameters?: boolean;
+  exactMatch?: boolean;
+  includeUsage?: boolean;
+  safeSearch?: boolean;
+}
+
+const isDefined = <T>(value: T | undefined): value is T =>
+  typeof value !== 'undefined';
+
+const normalizeImage = (image: TavilyImage): TavilyImageObject | null => {
+  if (typeof image === 'string') {
+    const url = image.trim();
+    return url ? { url } : null;
+  }
+
+  const url = image.url?.trim();
+  if (!url) {
+    return null;
+  }
+
+  const description = image.description?.trim();
+  return {
+    url,
+    description: description || undefined,
+  };
+};
+
+const selectPromptImages = (
+  images: TavilyImage[] = [],
+  limit: number = MAX_PROMPT_IMAGES
+): TavilyImageObject[] =>
+  images
+    .map(normalizeImage)
+    .filter((image): image is TavilyImageObject => Boolean(image))
+    .slice(0, limit);
+
+const performTavilySearch = async (
+  query: string,
+  parameters: TavilyOnlineParameters
+) => {
+  if (!query.trim()) {
+    return { searchResults: null, data: null };
+  }
+
+  const searchBody: TavilySearchRequest = {
+    query,
+    max_results: parameters.maxResults ?? 5,
+  };
+
+  if (isDefined(parameters.autoParameters)) {
+    searchBody.auto_parameters = parameters.autoParameters;
+  }
+
+  if (parameters.topic) {
+    searchBody.topic = parameters.topic;
+  } else if (!parameters.autoParameters) {
+    searchBody.topic = 'general';
+  }
+
+  if (parameters.searchDepth) {
+    searchBody.search_depth = parameters.searchDepth;
+  } else if (!parameters.autoParameters) {
+    searchBody.search_depth = 'basic';
+  }
+
+  const effectiveSearchDepth = searchBody.search_depth;
+  const effectiveTopic = searchBody.topic;
+
+  if (parameters.includeDomains?.length) {
+    searchBody.include_domains = parameters.includeDomains;
+  }
+
+  if (parameters.excludeDomains?.length) {
+    searchBody.exclude_domains = parameters.excludeDomains;
+  }
+
+  if (effectiveSearchDepth === 'advanced' && parameters.chunksPerSource) {
+    searchBody.chunks_per_source = parameters.chunksPerSource;
+  }
+
+  if (parameters.timeRange) {
+    searchBody.time_range = parameters.timeRange;
+  }
+
+  if (parameters.startDate) {
+    searchBody.start_date = parameters.startDate;
+  }
+
+  if (parameters.endDate) {
+    searchBody.end_date = parameters.endDate;
+  }
+
+  if (isDefined(parameters.includeAnswer)) {
+    searchBody.include_answer = parameters.includeAnswer;
+  }
+
+  if (isDefined(parameters.includeRawContent)) {
+    searchBody.include_raw_content = parameters.includeRawContent;
+  }
+
+  if (isDefined(parameters.includeImages)) {
+    searchBody.include_images = parameters.includeImages;
+  }
+
+  if (
+    parameters.includeImages &&
+    isDefined(parameters.includeImageDescriptions)
+  ) {
+    searchBody.include_image_descriptions = parameters.includeImageDescriptions;
+  }
+
+  if (isDefined(parameters.includeFavicon)) {
+    searchBody.include_favicon = parameters.includeFavicon;
+  }
+
+  if (isDefined(parameters.exactMatch)) {
+    searchBody.exact_match = parameters.exactMatch;
+  }
+
+  if (isDefined(parameters.includeUsage)) {
+    searchBody.include_usage = parameters.includeUsage;
+  }
+
+  if (
+    isDefined(parameters.safeSearch) &&
+    (effectiveSearchDepth === 'basic' || effectiveSearchDepth === 'advanced')
+  ) {
+    searchBody.safe_search = parameters.safeSearch;
+  }
+
+  if (parameters.country && effectiveTopic === 'general') {
+    searchBody.country = parameters.country;
+  }
+
+  const options = {
+    headers: {
+      Authorization: `Bearer ${parameters.credentials?.apiKey}`,
+      'Content-Type': 'application/json',
+      'X-Client-Source': TAVILY_CLIENT_SOURCE,
+    },
+  };
+
+  try {
+    const result: TavilySearchResponse = await post(
+      BASE_URL,
+      searchBody,
+      options,
+      parameters.timeout ?? 30000
+    );
+
+    if (!result.results || result.results.length === 0) {
+      return { searchResults: null, data: result };
+    }
+
+    const formattedResults: FormattedSearchResult[] = result.results.map(
+      (item) => ({
+        title: item.title,
+        url: item.url,
+        text: item.content || item.raw_content || '',
+        score: item.score,
+        raw_content: item.raw_content,
+        favicon: item.favicon,
+        images: item.images,
+      })
+    );
+
+    return { searchResults: formattedResults, data: result };
+  } catch (error) {
+    console.error('Error searching with Tavily:', error);
+    return { searchResults: null, data: { error } };
+  }
+};
+
+const formatImageLine = (image: TavilyImageObject, index: number): string => {
+  if (image.description) {
+    return `Image ${index + 1}: ${image.url}\nDescription: ${image.description}\n`;
+  }
+
+  return `Image ${index + 1}: ${image.url}\n`;
+};
+
+const appendImagesSection = (
+  formattedText: string,
+  heading: string,
+  images?: TavilyImage[]
+): string => {
+  const promptImages = selectPromptImages(images, MAX_PROMPT_IMAGES);
+
+  if (!promptImages.length) {
+    return formattedText;
+  }
+
+  let nextText = formattedText + `${heading}\n`;
+
+  promptImages.forEach((image, index) => {
+    nextText += formatImageLine(image, index);
+  });
+
+  return nextText;
+};
+
+const formatSearchResultsForPrompt = (
+  results: FormattedSearchResult[],
+  topLevelImages: TavilyImage[] = [],
+  answer?: string,
+  prefix: string = '\n<web_search_context>',
+  suffix: string = '\n</web_search_context>'
+): string => {
+  if (!results || results.length === 0) {
+    return '';
+  }
+
+  let formattedText = prefix + '\n';
+
+  if (answer) {
+    formattedText += `Search Answer: ${answer}\n`;
+  }
+
+  formattedText = appendImagesSection(
+    formattedText,
+    'Query-Related Images:',
+    topLevelImages
+  );
+
+  results.forEach((result, index) => {
+    formattedText += `[${index + 1}] "${result.title}"\n`;
+    formattedText += `URL: ${result.url}\n`;
+    formattedText += `${result.text}\n`;
+    formattedText = appendImagesSection(
+      formattedText,
+      `Result ${index + 1} Images:`,
+      result.images
+    );
+  });
+
+  formattedText += suffix;
+  return formattedText;
+};
+
+const appendSearchResultsToContent = (content: any, searchResults: string) => {
+  if (typeof content === 'string') {
+    return content + searchResults;
+  }
+
+  if (Array.isArray(content)) {
+    return [
+      ...content,
+      {
+        type: 'text',
+        text: searchResults,
+      },
+    ];
+  }
+
+  return searchResults;
+};
+
+const prependSearchResultsToPrompt = (prompt: any, searchResults: string) => {
+  if (typeof prompt === 'string') {
+    return searchResults + prompt;
+  }
+
+  if (Array.isArray(prompt)) {
+    return [searchResults, ...prompt];
+  }
+
+  return searchResults;
+};
+
+const insertSearchResults = (
+  context: PluginContext,
+  searchResults: string
+): Record<string, any> => {
+  const json = context.request.json;
+  const updatedJson = { ...json };
+
+  if (context.requestType === 'chatComplete') {
+    const messages = [...json.messages];
+    const systemIndex = messages.findIndex((msg) => msg.role === 'system');
+
+    if (systemIndex !== -1) {
+      messages[systemIndex] = {
+        ...messages[systemIndex],
+        content: appendSearchResultsToContent(
+          messages[systemIndex].content,
+          searchResults
+        ),
+      };
+    } else {
+      messages.unshift({
+        role: 'system',
+        content: searchResults,
+      });
+    }
+
+    updatedJson.messages = messages;
+  } else {
+    updatedJson.prompt = prependSearchResultsToPrompt(
+      updatedJson.prompt,
+      searchResults
+    );
+  }
+
+  return {
+    request: {
+      json: updatedJson,
+    },
+    response: {
+      json: null,
+    },
+  };
+};
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  rawParameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  const parameters = rawParameters as TavilyOnlineParameters;
+
+  let error = null;
+  let verdict = true;
+  let data = null;
+  const transformedData: Record<string, any> = {
+    request: {
+      json: null,
+    },
+    response: {
+      json: null,
+    },
+  };
+  let transformed = false;
+
+  try {
+    if (
+      eventType !== 'beforeRequestHook' ||
+      (context.requestType !== 'complete' &&
+        context.requestType !== 'chatComplete')
+    ) {
+      return {
+        error: null,
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed,
+      };
+    }
+
+    const { content, textArray } = getCurrentContentPart(context, eventType);
+
+    if (!content) {
+      return {
+        error: { message: 'request or response json is empty' },
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed,
+      };
+    }
+
+    const combinedQuery = textArray.join(' ').trim();
+    const result = await performTavilySearch(combinedQuery, parameters);
+
+    const sources =
+      result?.searchResults?.map((r) => ({
+        title: r.title,
+        url: r.url,
+        text: r.text,
+        score: r.score,
+        raw_content: r.raw_content,
+        favicon: r.favicon,
+        images: r.images,
+      })) ?? [];
+
+    data = {
+      ...result?.data,
+      sources,
+    };
+
+    if (result?.searchResults && result?.data) {
+      const formattedResults = formatSearchResultsForPrompt(
+        result.searchResults,
+        result.data.images,
+        result.data.answer,
+        parameters.prefix,
+        parameters.suffix
+      );
+
+      const newTransformedData = insertSearchResults(context, formattedResults);
+      Object.assign(transformedData, newTransformedData);
+      transformed = true;
+    }
+  } catch (e: any) {
+    delete e.stack;
+    error = e;
+  }
+
+  return { error, verdict, data, transformedData, transformed };
+};

--- a/plugins/tavily/online.ts
+++ b/plugins/tavily/online.ts
@@ -7,7 +7,7 @@ import {
 import { getCurrentContentPart, post } from '../utils';
 
 const BASE_URL = 'https://api.tavily.com/search';
-const TAVILY_CLIENT_SOURCE = 'portkey-ai';
+const TAVILY_CLIENT_NAME = 'portkey-ai';
 const MAX_PROMPT_IMAGES = 5;
 
 type TavilySearchDepth = 'advanced' | 'basic' | 'fast' | 'ultra-fast';
@@ -250,7 +250,7 @@ const performTavilySearch = async (
     headers: {
       Authorization: `Bearer ${parameters.credentials?.apiKey}`,
       'Content-Type': 'application/json',
-      'X-Client-Source': TAVILY_CLIENT_SOURCE,
+      'X-Client-Name': TAVILY_CLIENT_NAME,
     },
   };
 

--- a/plugins/tavily/tavily.test.ts
+++ b/plugins/tavily/tavily.test.ts
@@ -512,7 +512,7 @@ describe('tavily online handler', () => {
     expect(parsedBody.safe_search).toBeUndefined();
   });
 
-  it('should omit chunks per source when search depth is not advanced', async () => {
+  it('should omit chunks per source when search depth is not advanced or fast', async () => {
     const context = {
       request: {
         text: 'Latest design system news',
@@ -544,6 +544,40 @@ describe('tavily online handler', () => {
 
     expect(parsedBody.search_depth).toBe('basic');
     expect(parsedBody.chunks_per_source).toBeUndefined();
+  });
+
+  it('should include chunks per source for fast search depth', async () => {
+    const context = {
+      request: {
+        text: 'Latest robotics news',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'Latest robotics news',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+        searchDepth: 'fast',
+        chunksPerSource: 2,
+      },
+      'beforeRequestHook'
+    );
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const parsedBody = JSON.parse(options.body);
+
+    expect(parsedBody.search_depth).toBe('fast');
+    expect(parsedBody.chunks_per_source).toBe(2);
   });
 
   it('should omit image descriptions when images are not requested', async () => {

--- a/plugins/tavily/tavily.test.ts
+++ b/plugins/tavily/tavily.test.ts
@@ -1,0 +1,679 @@
+import { handler as onlineHandler } from './online';
+import { PluginContext } from '../types';
+
+const defaultSearchResult = {
+  title: 'Latest AI Research',
+  url: 'https://example.com/ai-research',
+  content: 'A summary of the latest research progress in AI.',
+  score: 0.91,
+  raw_content: 'Full article text.',
+  favicon: 'https://example.com/favicon.ico',
+};
+
+const createMockSearchResponse = (overrides: Record<string, any> = {}) => ({
+  query: 'What are recent advances in AI?',
+  images: [],
+  results: [defaultSearchResult],
+  response_time: 0.87,
+  request_id: 'test-request-id',
+  ...overrides,
+});
+
+const mockFetchResponse = (responseData = createMockSearchResponse()) => {
+  global.fetch = jest.fn().mockResolvedValue({
+    ok: true,
+    json: async () => responseData,
+  } as Response);
+};
+
+describe('tavily online handler', () => {
+  beforeEach(() => {
+    mockFetchResponse();
+  });
+
+  afterEach(() => {
+    jest.resetAllMocks();
+  });
+
+  it('should only run on beforeRequestHook', async () => {
+    const context = {
+      request: {
+        text: 'What are recent advances in AI?',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'What are recent advances in AI?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+      },
+      'afterRequestHook'
+    );
+
+    expect(result.verdict).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.transformed).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it('should enhance chat completion requests by appending search results to the system message', async () => {
+    const context = {
+      request: {
+        text: 'What are recent advances in AI?',
+        json: {
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful assistant.',
+            },
+            {
+              role: 'user',
+              content: 'What are recent advances in AI?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+      },
+      'beforeRequestHook'
+    );
+
+    expect(result.verdict).toBe(true);
+    expect(result.error).toBeNull();
+    expect(result.transformed).toBe(true);
+
+    const messages = result.transformedData?.request?.json?.messages;
+
+    expect(messages[0].role).toBe('system');
+    expect(messages[0].content).toContain('You are a helpful assistant.');
+    expect(messages[0].content).toContain('<web_search_context>');
+    expect(messages[0].content).toContain('Latest AI Research');
+    expect(messages[0].content).toContain('https://example.com/ai-research');
+  });
+
+  it('should add a new system message if none exists', async () => {
+    const context = {
+      request: {
+        text: 'What are recent advances in AI?',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'What are recent advances in AI?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+      },
+      'beforeRequestHook'
+    );
+
+    const messages = result.transformedData?.request?.json?.messages;
+
+    expect(result.transformed).toBe(true);
+    expect(messages[0].role).toBe('system');
+    expect(messages[0].content).toContain('<web_search_context>');
+    expect(messages[1].role).toBe('user');
+    expect(messages[1].content).toBe('What are recent advances in AI?');
+  });
+
+  it('should use custom prefix and suffix for injected search results', async () => {
+    const context = {
+      request: {
+        text: 'What are recent advances in AI?',
+        json: {
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful assistant.',
+            },
+            {
+              role: 'user',
+              content: 'What are recent advances in AI?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        prefix: '\n[SEARCH_RESULTS]',
+        suffix: '[END_RESULTS]\n',
+      },
+      'beforeRequestHook'
+    );
+
+    const content = result.transformedData?.request?.json?.messages[0].content;
+
+    expect(result.transformed).toBe(true);
+    expect(content).toContain('[SEARCH_RESULTS]');
+    expect(content).not.toContain('<web_search_context>');
+    expect(content).toContain('[END_RESULTS]');
+    expect(content).not.toContain('</web_search_context>');
+  });
+
+  it('should handle completion requests by prepending search results to the prompt', async () => {
+    const context = {
+      request: {
+        text: 'What are recent advances in AI?',
+        json: {
+          prompt: 'What are recent advances in AI?',
+        },
+      },
+      requestType: 'complete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+      },
+      'beforeRequestHook'
+    );
+
+    const prompt = result.transformedData?.request?.json?.prompt;
+
+    expect(result.transformed).toBe(true);
+    expect(prompt).toContain('<web_search_context>');
+    expect(prompt).toContain('What are recent advances in AI?');
+    expect(prompt.indexOf('<web_search_context>')).toBeLessThan(
+      prompt.indexOf('What are recent advances in AI?')
+    );
+  });
+
+  it('should inject object images with descriptions into the prompt', async () => {
+    mockFetchResponse(
+      createMockSearchResponse({
+        images: [
+          {
+            url: 'https://example.com/query-image.png',
+            description: 'Query image',
+          },
+        ],
+        results: [
+          {
+            ...defaultSearchResult,
+            images: [
+              {
+                url: 'https://example.com/result-image.png',
+                description: 'Result image',
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const context = {
+      request: {
+        text: 'What are recent advances in AI?',
+        json: {
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful assistant.',
+            },
+            {
+              role: 'user',
+              content: 'What are recent advances in AI?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        includeImages: true,
+        includeImageDescriptions: true,
+      },
+      'beforeRequestHook'
+    );
+
+    const content = result.transformedData?.request?.json?.messages[0].content;
+
+    expect(content).toContain('Query-Related Images:');
+    expect(content).toContain('https://example.com/query-image.png');
+    expect(content).toContain('Description: Query image');
+    expect(content).toContain('Result 1 Images:');
+    expect(content).toContain('https://example.com/result-image.png');
+    expect(content).toContain('Description: Result image');
+  });
+
+  it('should inject string image URLs into the prompt', async () => {
+    mockFetchResponse(
+      createMockSearchResponse({
+        images: ['https://example.com/query-image.png'],
+        results: [
+          {
+            ...defaultSearchResult,
+            images: ['https://example.com/result-image.png'],
+          },
+        ],
+      })
+    );
+
+    const context = {
+      request: {
+        text: 'What are recent advances in AI?',
+        json: {
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful assistant.',
+            },
+            {
+              role: 'user',
+              content: 'What are recent advances in AI?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        includeImages: true,
+      },
+      'beforeRequestHook'
+    );
+
+    const content = result.transformedData?.request?.json?.messages[0].content;
+
+    expect(content).toContain('Query-Related Images:');
+    expect(content).toContain('Image 1: https://example.com/query-image.png');
+    expect(content).toContain('Result 1 Images:');
+    expect(content).toContain('Image 1: https://example.com/result-image.png');
+  });
+
+  it('should limit prompt image injection to the first five valid images', async () => {
+    mockFetchResponse(
+      createMockSearchResponse({
+        images: [
+          'https://example.com/image-1.png',
+          'https://example.com/image-2.png',
+          'https://example.com/image-3.png',
+          'https://example.com/image-4.png',
+          'https://example.com/image-5.png',
+          'https://example.com/image-6.png',
+        ],
+      })
+    );
+
+    const context = {
+      request: {
+        text: 'What are recent advances in AI?',
+        json: {
+          messages: [
+            {
+              role: 'system',
+              content: 'You are a helpful assistant.',
+            },
+            {
+              role: 'user',
+              content: 'What are recent advances in AI?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        includeImages: true,
+      },
+      'beforeRequestHook'
+    );
+
+    const content = result.transformedData?.request?.json?.messages[0].content;
+
+    expect(content).toContain('https://example.com/image-1.png');
+    expect(content).toContain('https://example.com/image-5.png');
+    expect(content).not.toContain('https://example.com/image-6.png');
+  });
+
+  it('should map Tavily request parameters, send the client source header, and include source metadata', async () => {
+    mockFetchResponse(
+      createMockSearchResponse({
+        results: [
+          {
+            ...defaultSearchResult,
+            images: [
+              {
+                url: 'https://example.com/result-image.png',
+                description: 'Result image',
+              },
+            ],
+          },
+        ],
+      })
+    );
+
+    const context = {
+      request: {
+        text: 'Latest climate change news',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'Latest climate change news',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 3,
+        searchDepth: 'advanced',
+        chunksPerSource: 2,
+        topic: 'general',
+        timeRange: 'week',
+        startDate: '2026-04-01',
+        endDate: '2026-04-14',
+        includeAnswer: 'basic',
+        includeRawContent: 'text',
+        includeImages: true,
+        includeImageDescriptions: true,
+        includeFavicon: true,
+        includeDomains: ['bbc.com'],
+        excludeDomains: ['reddit.com'],
+        country: 'india',
+        exactMatch: true,
+        includeUsage: true,
+        safeSearch: true,
+        timeout: 1234,
+      },
+      'beforeRequestHook'
+    );
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+
+    const [url, options] = (global.fetch as jest.Mock).mock.calls[0];
+    expect(url).toBe('https://api.tavily.com/search');
+    expect(options.headers.Authorization).toBe('Bearer tvly-test-key');
+    expect(options.headers['Content-Type']).toBe('application/json');
+    expect(options.headers['X-Client-Source']).toBe('portkey-ai');
+
+    const parsedBody = JSON.parse(options.body);
+    expect(parsedBody.max_results).toBe(3);
+    expect(parsedBody.search_depth).toBe('advanced');
+    expect(parsedBody.chunks_per_source).toBe(2);
+    expect(parsedBody.topic).toBe('general');
+    expect(parsedBody.time_range).toBe('week');
+    expect(parsedBody.start_date).toBe('2026-04-01');
+    expect(parsedBody.end_date).toBe('2026-04-14');
+    expect(parsedBody.include_answer).toBe('basic');
+    expect(parsedBody.include_raw_content).toBe('text');
+    expect(parsedBody.include_images).toBe(true);
+    expect(parsedBody.include_image_descriptions).toBe(true);
+    expect(parsedBody.include_favicon).toBe(true);
+    expect(parsedBody.include_domains).toEqual(['bbc.com']);
+    expect(parsedBody.exclude_domains).toEqual(['reddit.com']);
+    expect(parsedBody.country).toBe('india');
+    expect(parsedBody.exact_match).toBe(true);
+    expect(parsedBody.include_usage).toBe(true);
+    expect(parsedBody.safe_search).toBe(true);
+
+    expect(result.data.sources).toEqual([
+      {
+        title: 'Latest AI Research',
+        url: 'https://example.com/ai-research',
+        text: 'A summary of the latest research progress in AI.',
+        score: 0.91,
+        raw_content: 'Full article text.',
+        favicon: 'https://example.com/favicon.ico',
+        images: [
+          {
+            url: 'https://example.com/result-image.png',
+            description: 'Result image',
+          },
+        ],
+      },
+    ]);
+  });
+
+  it('should let Tavily choose topic and search depth when autoParameters is enabled', async () => {
+    const context = {
+      request: {
+        text: 'What are the latest developments in AI chips?',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'What are the latest developments in AI chips?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        autoParameters: true,
+        maxResults: 1,
+        safeSearch: true,
+      },
+      'beforeRequestHook'
+    );
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const parsedBody = JSON.parse(options.body);
+
+    expect(parsedBody.auto_parameters).toBe(true);
+    expect(parsedBody.topic).toBeUndefined();
+    expect(parsedBody.search_depth).toBeUndefined();
+    expect(parsedBody.safe_search).toBeUndefined();
+  });
+
+  it('should omit chunks per source when search depth is not advanced', async () => {
+    const context = {
+      request: {
+        text: 'Latest design system news',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'Latest design system news',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+        searchDepth: 'basic',
+        chunksPerSource: 2,
+      },
+      'beforeRequestHook'
+    );
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const parsedBody = JSON.parse(options.body);
+
+    expect(parsedBody.search_depth).toBe('basic');
+    expect(parsedBody.chunks_per_source).toBeUndefined();
+  });
+
+  it('should omit image descriptions when images are not requested', async () => {
+    const context = {
+      request: {
+        text: 'Latest design system news',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'Latest design system news',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+        includeImages: false,
+        includeImageDescriptions: true,
+      },
+      'beforeRequestHook'
+    );
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const parsedBody = JSON.parse(options.body);
+
+    expect(parsedBody.include_images).toBe(false);
+    expect(parsedBody.include_image_descriptions).toBeUndefined();
+  });
+
+  it('should omit safe search for fast search depths', async () => {
+    const context = {
+      request: {
+        text: 'Latest robotics news',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'Latest robotics news',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+        searchDepth: 'fast',
+        safeSearch: true,
+      },
+      'beforeRequestHook'
+    );
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const parsedBody = JSON.parse(options.body);
+
+    expect(parsedBody.search_depth).toBe('fast');
+    expect(parsedBody.safe_search).toBeUndefined();
+  });
+
+  it('should omit country when topic is not general', async () => {
+    const context = {
+      request: {
+        text: 'What is the latest political news?',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: 'What is the latest political news?',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        topic: 'news',
+        country: 'india',
+      },
+      'beforeRequestHook'
+    );
+
+    const [, options] = (global.fetch as jest.Mock).mock.calls[0];
+    const parsedBody = JSON.parse(options.body);
+
+    expect(parsedBody.topic).toBe('news');
+    expect(parsedBody.country).toBeUndefined();
+  });
+
+  it('should handle empty queries gracefully', async () => {
+    const context = {
+      request: {
+        text: '',
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content: '',
+            },
+          ],
+        },
+      },
+      requestType: 'chatComplete',
+    };
+
+    const result = await onlineHandler(
+      context as PluginContext,
+      {
+        credentials: { apiKey: 'tvly-test-key' },
+        maxResults: 1,
+      },
+      'beforeRequestHook'
+    );
+
+    expect(result.verdict).toBe(true);
+    expect(result.transformed).toBe(false);
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+});

--- a/plugins/tavily/tavily.test.ts
+++ b/plugins/tavily/tavily.test.ts
@@ -436,7 +436,7 @@ describe('tavily online handler', () => {
     expect(url).toBe('https://api.tavily.com/search');
     expect(options.headers.Authorization).toBe('Bearer tvly-test-key');
     expect(options.headers['Content-Type']).toBe('application/json');
-    expect(options.headers['X-Client-Source']).toBe('portkey-ai');
+    expect(options.headers['X-Client-Name']).toBe('portkey-ai');
 
     const parsedBody = JSON.parse(options.body);
     expect(parsedBody.max_results).toBe(3);


### PR DESCRIPTION
- Added Tavily as a guardrail plugin for online search enrichment

**Description:** (required)
- Added a new `tavily.online` guardrail that calls Tavily Search before inference and injects fresh web search context into chat and completion prompts
- Added support for Tavily search parameters and response metadata, including answer/raw content/images/favicon handling, plus tests covering prompt injection and request mapping

**Tests Run/Test cases added:** (required)
- [x] Added tests for chat and completion prompt enrichment, custom prefix/suffix handling, request parameter mapping, image handling for both string and object formats, and parameter gating for `safeSearch`, `country`, `chunksPerSource`, and `autoParameters`

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
