### PR TITLE
Add Resemble AI Detect guardrail plugin

### DIFF
--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -66,6 +66,7 @@ import { handler as javelinguardrails } from './javelin/guardrails';
 import { handler as f5GuardrailsScan } from './f5-guardrails/scan';
 import { handler as azureShieldPrompt } from './azure/shieldPrompt';
 import { handler as azureProtectedMaterial } from './azure/protectedMaterial';
+import { handler as resembledetect } from './resemble/detect';
 
 export const plugins = {
   default: {
@@ -175,5 +176,8 @@ export const plugins = {
   },
   'f5-guardrails': {
     scan: f5GuardrailsScan,
+  },
+  resemble: {
+    detect: resembledetect,
   },
 };

--- a/plugins/resemble/detect.test.ts
+++ b/plugins/resemble/detect.test.ts
@@ -1,0 +1,634 @@
+import {
+  handler,
+  extractMediaUrl,
+  evaluateDetection,
+  RESEMBLE_DEFAULT_BASE_URL,
+} from './detect';
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function makeContext(opts: {
+  messages?: any[];
+  prompt?: string;
+  metadata?: Record<string, any>;
+  requestType?: 'chatComplete' | 'complete' | 'messages';
+}) {
+  return {
+    requestType: opts.requestType || 'chatComplete',
+    request: {
+      json: {
+        messages: opts.messages,
+        prompt: opts.prompt,
+      },
+      text: '',
+    },
+    metadata: opts.metadata || {},
+  } as any;
+}
+
+function baseParameters(overrides: Record<string, any> = {}) {
+  return {
+    credentials: { apiKey: 'test-key' },
+    threshold: 0.5,
+    pollIntervalMs: 5, // tiny interval so polling tests run fast
+    pollTimeoutMs: 500,
+    timeout: 1000,
+    ...overrides,
+  };
+}
+
+/**
+ * Minimal fetch mock. Each entry is keyed by URL substring; if the URL includes
+ * the substring, the body is returned. Use `sequences` to simulate polling.
+ */
+function mockFetch(config: {
+  create?: { ok?: boolean; status?: number; body: any };
+  getSequence?: Array<{ ok?: boolean; status?: number; body: any }>;
+  createError?: any;
+}) {
+  let getCalls = 0;
+  const calls: { url: string; init?: RequestInit }[] = [];
+
+  const fn = jest.fn(async (url: string, init?: RequestInit) => {
+    calls.push({ url, init });
+    // POST /detect (creation)
+    if (init?.method === 'POST' || (!init?.method && url.endsWith('/detect'))) {
+      if (config.createError) throw config.createError;
+      const c = config.create!;
+      return fakeResponse(c.ok ?? true, c.status ?? 200, c.body);
+    }
+    // GET /detect/{uuid}
+    const seq = config.getSequence || [];
+    const entry = seq[getCalls] || seq[seq.length - 1];
+    getCalls += 1;
+    return fakeResponse(entry.ok ?? true, entry.status ?? 200, entry.body);
+  }) as any;
+
+  (fn as any).calls = calls;
+  return fn;
+}
+
+function fakeResponse(ok: boolean, status: number, body: any) {
+  return {
+    ok,
+    status,
+    statusText: ok ? 'OK' : 'Error',
+    headers: new Map() as any,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as any;
+}
+
+// ---------------------------------------------------------------------------
+// Unit tests: helpers
+// ---------------------------------------------------------------------------
+
+describe('extractMediaUrl', () => {
+  it('finds an https audio URL in plain text content', () => {
+    const context = makeContext({
+      messages: [
+        {
+          role: 'user',
+          content: 'Please check https://cdn.example.com/clip.mp3 for me',
+        },
+      ],
+    });
+    expect(
+      extractMediaUrl(context, 'beforeRequestHook', 'auto', 'mediaUrl')
+    ).toBe('https://cdn.example.com/clip.mp3');
+  });
+
+  it('finds a URL in an OpenAI-style image_url content part', () => {
+    const context = makeContext({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            { type: 'text', text: 'Is this real?' },
+            {
+              type: 'image_url',
+              image_url: { url: 'https://cdn.example.com/face.png' },
+            },
+          ],
+        },
+      ],
+    });
+    expect(
+      extractMediaUrl(context, 'beforeRequestHook', 'auto', 'mediaUrl')
+    ).toBe('https://cdn.example.com/face.png');
+  });
+
+  it('finds a URL in an OpenAI-style input_audio content part', () => {
+    const context = makeContext({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'input_audio',
+              input_audio: { url: 'https://cdn.example.com/a.wav' },
+            },
+          ],
+        },
+      ],
+    });
+    expect(
+      extractMediaUrl(context, 'beforeRequestHook', 'auto', 'mediaUrl')
+    ).toBe('https://cdn.example.com/a.wav');
+  });
+
+  it('finds a URL in an Anthropic-style image source.url', () => {
+    const context = makeContext({
+      messages: [
+        {
+          role: 'user',
+          content: [
+            {
+              type: 'image',
+              source: { type: 'url', url: 'https://cdn.example.com/x.jpg' },
+            },
+          ],
+        },
+      ],
+    });
+    expect(
+      extractMediaUrl(context, 'beforeRequestHook', 'auto', 'mediaUrl')
+    ).toBe('https://cdn.example.com/x.jpg');
+  });
+
+  it('falls back to metadata when no URL in content and urlSource=auto', () => {
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'hello there' }],
+      metadata: { mediaUrl: 'https://cdn.example.com/clip.mp4' },
+    });
+    expect(
+      extractMediaUrl(context, 'beforeRequestHook', 'auto', 'mediaUrl')
+    ).toBe('https://cdn.example.com/clip.mp4');
+  });
+
+  it('uses only metadata when urlSource=metadata', () => {
+    const context = makeContext({
+      messages: [
+        { role: 'user', content: 'https://cdn.example.com/in_text.mp3' },
+      ],
+      metadata: { customKey: 'https://cdn.example.com/from_meta.mp3' },
+    });
+    expect(
+      extractMediaUrl(context, 'beforeRequestHook', 'metadata', 'customKey')
+    ).toBe('https://cdn.example.com/from_meta.mp3');
+  });
+
+  it('returns null when no URL is found', () => {
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'nothing to see here' }],
+    });
+    expect(
+      extractMediaUrl(context, 'beforeRequestHook', 'auto', 'mediaUrl')
+    ).toBeNull();
+  });
+});
+
+describe('evaluateDetection', () => {
+  it('treats label=fake as failing regardless of score', () => {
+    const result = evaluateDetection(
+      {
+        uuid: 'u',
+        status: 'completed',
+        metrics: { label: 'fake', score: ['0.1'], aggregated_score: '0.2' },
+      } as any,
+      0.5
+    );
+    expect(result.verdict).toBe(false);
+    expect(result.label).toBe('fake');
+  });
+
+  it('treats label=real with low score as passing', () => {
+    const result = evaluateDetection(
+      {
+        uuid: 'u',
+        status: 'completed',
+        metrics: { label: 'real', score: ['0.1'], aggregated_score: '0.1' },
+      } as any,
+      0.5
+    );
+    expect(result.verdict).toBe(true);
+    expect(result.label).toBe('real');
+  });
+
+  it('treats label=real but score >= threshold as failing', () => {
+    const result = evaluateDetection(
+      {
+        uuid: 'u',
+        status: 'completed',
+        metrics: { label: 'real', score: ['0.7'], aggregated_score: '0.7' },
+      } as any,
+      0.5
+    );
+    expect(result.verdict).toBe(false);
+  });
+
+  it('handles image_metrics shape', () => {
+    const result = evaluateDetection(
+      {
+        uuid: 'u',
+        status: 'completed',
+        image_metrics: { label: 'Fake', score: 0.9 },
+      } as any,
+      0.5
+    );
+    expect(result.verdict).toBe(false);
+    expect(result.score).toBe(0.9);
+  });
+
+  it('handles video_metrics shape', () => {
+    const result = evaluateDetection(
+      {
+        uuid: 'u',
+        status: 'completed',
+        video_metrics: { label: 'Real', score: 0.2 },
+      } as any,
+      0.5
+    );
+    expect(result.verdict).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Handler integration tests (with mocked fetch)
+// ---------------------------------------------------------------------------
+
+describe('detect handler', () => {
+  let fetchSpy: jest.SpyInstance;
+
+  afterEach(() => {
+    if (fetchSpy) fetchSpy.mockRestore();
+  });
+
+  it('passes through when credentials are missing (fail-open default)', async () => {
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    const result = await handler(
+      context,
+      { credentials: {} } as any,
+      'beforeRequestHook'
+    );
+    expect(result.verdict).toBe(true);
+    expect(result.error).toBeDefined();
+    expect(result.data).toEqual({ reason: 'missing_credentials' });
+  });
+
+  it('blocks when credentials are missing and failClosed=true', async () => {
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'hi' }],
+    });
+    const result = await handler(
+      context,
+      { credentials: {}, failClosed: true } as any,
+      'beforeRequestHook'
+    );
+    expect(result.verdict).toBe(false);
+  });
+
+  it('passes through when no media URL is found', async () => {
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'no url in this text' }],
+    });
+    const result = await handler(
+      context,
+      baseParameters() as any,
+      'beforeRequestHook'
+    );
+    expect(result.verdict).toBe(true);
+    expect(result.data?.reason).toBe('no_media_url_found');
+  });
+
+  it('returns verdict=true when Resemble labels audio as real (polling path)', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      mockFetch({
+        create: {
+          body: {
+            success: true,
+            item: { uuid: 'abc-123', status: 'processing' },
+          },
+        },
+        getSequence: [
+          {
+            body: {
+              success: true,
+              item: { uuid: 'abc-123', status: 'processing' },
+            },
+          },
+          {
+            body: {
+              success: true,
+              item: {
+                uuid: 'abc-123',
+                media_type: 'audio',
+                status: 'completed',
+                metrics: {
+                  label: 'real',
+                  score: ['0.1', '0.2'],
+                  aggregated_score: '0.15',
+                  consistency: '0.9',
+                },
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    const context = makeContext({
+      messages: [
+        {
+          role: 'user',
+          content: 'check https://cdn.example.com/audio.mp3 please',
+        },
+      ],
+    });
+    const result = await handler(
+      context,
+      baseParameters() as any,
+      'beforeRequestHook'
+    );
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(true);
+    expect(result.data?.uuid).toBe('abc-123');
+    expect(result.data?.label).toBe('real');
+    expect(result.data?.mediaUrl).toBe('https://cdn.example.com/audio.mp3');
+  });
+
+  it('returns verdict=false when Resemble labels audio as fake', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      mockFetch({
+        create: {
+          body: {
+            success: true,
+            item: { uuid: 'fake-1', status: 'processing' },
+          },
+        },
+        getSequence: [
+          {
+            body: {
+              success: true,
+              item: {
+                uuid: 'fake-1',
+                media_type: 'audio',
+                status: 'completed',
+                metrics: {
+                  label: 'fake',
+                  score: ['0.9'],
+                  aggregated_score: '0.91',
+                  consistency: '0.95',
+                },
+                audio_source_tracing: {
+                  label: 'elevenlabs',
+                  error_message: null,
+                },
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    const context = makeContext({
+      messages: [
+        { role: 'user', content: 'https://cdn.example.com/cloned.wav fake?' },
+      ],
+    });
+    const result = await handler(
+      context,
+      baseParameters({ audioSourceTracing: true }) as any,
+      'beforeRequestHook'
+    );
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(false);
+    expect(result.data?.label).toBe('fake');
+    expect(result.data?.audioSourceTracing?.label).toBe('elevenlabs');
+  });
+
+  it('returns verdict=false when image detection score exceeds threshold', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      mockFetch({
+        create: {
+          body: {
+            success: true,
+            item: {
+              uuid: 'img-1',
+              status: 'completed',
+              media_type: 'image',
+              image_metrics: { label: 'real', score: 0.85, type: 'facial' },
+            },
+          },
+        },
+        getSequence: [
+          {
+            body: {
+              success: true,
+              item: {
+                uuid: 'img-1',
+                status: 'completed',
+                media_type: 'image',
+                image_metrics: { label: 'real', score: 0.85, type: 'facial' },
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    const context = makeContext({
+      messages: [
+        { role: 'user', content: 'Real? https://cdn.example.com/photo.jpg' },
+      ],
+    });
+    const result = await handler(
+      context,
+      baseParameters({ threshold: 0.5 }) as any,
+      'beforeRequestHook'
+    );
+    expect(result.verdict).toBe(false);
+    expect(result.data?.score).toBe(0.85);
+  });
+
+  it('times out polling when status never reaches completed', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      mockFetch({
+        create: {
+          body: {
+            success: true,
+            item: { uuid: 'slow-1', status: 'processing' },
+          },
+        },
+        getSequence: [
+          {
+            body: {
+              success: true,
+              item: { uuid: 'slow-1', status: 'processing' },
+            },
+          },
+        ],
+      })
+    );
+
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'https://cdn.example.com/slow.mp3' }],
+    });
+    const result = await handler(
+      context,
+      baseParameters({ pollTimeoutMs: 50, pollIntervalMs: 10 }) as any,
+      'beforeRequestHook'
+    );
+    // fail-open by default on timeout error
+    expect(result.verdict).toBe(true);
+    expect(result.error).toBeDefined();
+    expect(String(result.error.message || result.error)).toContain('timed out');
+  });
+
+  it('fails closed on HTTP error when failClosed=true', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      mockFetch({
+        create: { ok: false, status: 401, body: { error: 'unauthorized' } },
+      })
+    );
+
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'https://cdn.example.com/x.mp3' }],
+    });
+    const result = await handler(
+      context,
+      baseParameters({ failClosed: true }) as any,
+      'beforeRequestHook'
+    );
+    expect(result.verdict).toBe(false);
+    expect(result.error).toBeDefined();
+    expect(result.data?.reason).toBe('http_error');
+  });
+
+  it('fails open on HTTP error by default', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      mockFetch({
+        create: { ok: false, status: 500, body: { error: 'boom' } },
+      })
+    );
+
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'https://cdn.example.com/x.mp3' }],
+    });
+    const result = await handler(
+      context,
+      baseParameters() as any,
+      'beforeRequestHook'
+    );
+    expect(result.verdict).toBe(true);
+    expect(result.error).toBeDefined();
+  });
+
+  it('posts to the configured API base URL and bearer-authorizes', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      mockFetch({
+        create: {
+          body: {
+            success: true,
+            item: {
+              uuid: 'ok-1',
+              status: 'completed',
+              metrics: {
+                label: 'real',
+                score: ['0.1'],
+                aggregated_score: '0.1',
+              },
+            },
+          },
+        },
+        getSequence: [
+          {
+            body: {
+              success: true,
+              item: {
+                uuid: 'ok-1',
+                status: 'completed',
+                metrics: {
+                  label: 'real',
+                  score: ['0.1'],
+                  aggregated_score: '0.1',
+                },
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'https://cdn.example.com/x.mp3' }],
+    });
+    await handler(
+      context,
+      baseParameters({
+        credentials: {
+          apiKey: 'secret-xyz',
+          apiBase: 'https://custom.example/api/v2',
+        },
+      }) as any,
+      'beforeRequestHook'
+    );
+
+    const calls = fetchSpy.mock.calls as any[];
+    expect(calls.length).toBeGreaterThan(0);
+    const [firstUrl, firstInit] = calls[0];
+    expect(firstUrl).toBe('https://custom.example/api/v2/detect');
+    expect(firstInit.headers.Authorization).toBe('Bearer secret-xyz');
+    const body = JSON.parse(firstInit.body);
+    expect(body.url).toBe('https://cdn.example.com/x.mp3');
+  });
+
+  it('uses the default Resemble base URL when none is provided', async () => {
+    fetchSpy = jest.spyOn(global, 'fetch').mockImplementation(
+      mockFetch({
+        create: {
+          body: {
+            success: true,
+            item: {
+              uuid: 'ok-2',
+              status: 'completed',
+              metrics: {
+                label: 'real',
+                score: ['0.1'],
+                aggregated_score: '0.1',
+              },
+            },
+          },
+        },
+        getSequence: [
+          {
+            body: {
+              success: true,
+              item: {
+                uuid: 'ok-2',
+                status: 'completed',
+                metrics: {
+                  label: 'real',
+                  score: ['0.1'],
+                  aggregated_score: '0.1',
+                },
+              },
+            },
+          },
+        ],
+      })
+    );
+
+    const context = makeContext({
+      messages: [{ role: 'user', content: 'https://cdn.example.com/x.mp3' }],
+    });
+    await handler(context, baseParameters() as any, 'beforeRequestHook');
+
+    const firstUrl = (fetchSpy.mock.calls as any[])[0][0];
+    expect(firstUrl).toBe(`${RESEMBLE_DEFAULT_BASE_URL}/detect`);
+  });
+});

--- a/plugins/resemble/detect.ts
+++ b/plugins/resemble/detect.ts
@@ -1,0 +1,386 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { post, HttpError } from '../utils';
+
+export const RESEMBLE_DEFAULT_BASE_URL = 'https://app.resemble.ai/api/v2';
+
+// Matches HTTPS URLs ending in common audio/video/image extensions. Query
+// strings and fragments are allowed. Kept intentionally simple — multimodal
+// content parts and metadata lookups handle the non-URL-in-text cases.
+const MEDIA_URL_REGEX =
+  /https?:\/\/[^\s<>"')\]}]+?\.(?:mp3|wav|m4a|flac|ogg|opus|aac|webm|mp4|mov|avi|mkv|jpg|jpeg|png|webp|gif)(?:\?[^\s<>"')\]}]*)?/gi;
+
+interface ResembleCredentials {
+  apiKey: string;
+  apiBase?: string;
+}
+
+interface ResembleDetectParameters {
+  credentials?: ResembleCredentials;
+  threshold?: number;
+  mediaType?: 'audio' | 'video' | 'image';
+  audioSourceTracing?: boolean;
+  useReverseSearch?: boolean;
+  zeroRetentionMode?: boolean;
+  urlSource?: 'auto' | 'metadata' | 'content';
+  metadataKey?: string;
+  pollIntervalMs?: number;
+  pollTimeoutMs?: number;
+  failClosed?: boolean;
+  timeout?: number; // per-HTTP-call timeout
+}
+
+interface DetectCreateResponse {
+  success: boolean;
+  item: {
+    uuid: string;
+    status: 'processing' | 'completed' | 'failed';
+  };
+}
+
+interface DetectResultResponse {
+  success: boolean;
+  item: {
+    uuid: string;
+    media_type?: 'audio' | 'video' | 'image';
+    status: 'processing' | 'completed' | 'failed';
+    metrics?: {
+      label: string;
+      score: string[];
+      aggregated_score: string;
+      consistency?: string;
+    } | null;
+    image_metrics?: {
+      label: string;
+      score: number;
+      type?: string;
+    } | null;
+    video_metrics?: {
+      label: string;
+      score: number;
+      certainty?: number;
+    } | null;
+    audio_source_tracing?: {
+      label?: string;
+      error_message?: string | null;
+    } | null;
+    error_message?: string | null;
+  };
+}
+
+/**
+ * Extracts a single media URL from the request context. Inspects (in order,
+ * depending on urlSource):
+ *   1. Multimodal content parts (input_audio, image_url, video_url)
+ *   2. Text regex for audio/video/image extensions
+ *   3. context.metadata[metadataKey]
+ */
+export function extractMediaUrl(
+  context: PluginContext,
+  eventType: HookEventType,
+  urlSource: 'auto' | 'metadata' | 'content',
+  metadataKey: string
+): string | null {
+  const metadataCandidate = context.metadata?.[metadataKey];
+  if (urlSource === 'metadata') {
+    return typeof metadataCandidate === 'string' ? metadataCandidate : null;
+  }
+
+  const target = eventType === 'beforeRequestHook' ? 'request' : 'response';
+  const json = context[target]?.json;
+
+  // 1) Multimodal content parts — chat completion style
+  if (json?.messages && Array.isArray(json.messages)) {
+    for (let i = json.messages.length - 1; i >= 0; i--) {
+      const message = json.messages[i];
+      if (!message || !Array.isArray(message.content)) continue;
+      for (const part of message.content) {
+        if (!part || typeof part !== 'object') continue;
+        // OpenAI-style input_audio part
+        if (part.type === 'input_audio' && part.input_audio?.url) {
+          return part.input_audio.url;
+        }
+        // OpenAI-style image_url part
+        if (part.type === 'image_url' && part.image_url?.url) {
+          return part.image_url.url;
+        }
+        // Anthropic-style source.url (image or document)
+        if (
+          (part.type === 'image' || part.type === 'document') &&
+          part.source?.type === 'url' &&
+          part.source?.url
+        ) {
+          return part.source.url;
+        }
+      }
+    }
+  }
+
+  // 2) Regex over joined text
+  const textChunks: string[] = [];
+  if (json?.messages && Array.isArray(json.messages)) {
+    for (const message of json.messages) {
+      if (typeof message.content === 'string') {
+        textChunks.push(message.content);
+      } else if (Array.isArray(message.content)) {
+        for (const part of message.content) {
+          if (part?.type === 'text' && typeof part.text === 'string') {
+            textChunks.push(part.text);
+          }
+        }
+      }
+    }
+  }
+  if (typeof json?.prompt === 'string') textChunks.push(json.prompt);
+  if (typeof json?.input === 'string') textChunks.push(json.input);
+
+  const joined = textChunks.join('\n');
+  const match = joined.match(MEDIA_URL_REGEX);
+  if (match && match.length > 0) {
+    return match[0];
+  }
+
+  // 3) Metadata fallback (only when urlSource === 'auto')
+  if (urlSource === 'auto' && typeof metadataCandidate === 'string') {
+    return metadataCandidate;
+  }
+
+  return null;
+}
+
+/**
+ * Polls GET /detect/{uuid} until status is completed/failed or timeout hits.
+ */
+export async function pollDetectResult(
+  uuid: string,
+  credentials: ResembleCredentials,
+  pollIntervalMs: number,
+  pollTimeoutMs: number,
+  httpTimeoutMs: number,
+  fetchJson: (url: string, init: RequestInit) => Promise<any> = defaultFetchJson
+): Promise<DetectResultResponse['item']> {
+  const baseUrl = credentials.apiBase || RESEMBLE_DEFAULT_BASE_URL;
+  const url = `${baseUrl}/detect/${uuid}`;
+  const deadline = Date.now() + pollTimeoutMs;
+
+  while (Date.now() < deadline) {
+    const result = (await fetchJson(url, {
+      method: 'GET',
+      headers: {
+        Authorization: `Bearer ${credentials.apiKey}`,
+        'Content-Type': 'application/json',
+      },
+      // @ts-expect-error AbortController merged below
+      __timeoutMs: httpTimeoutMs,
+    })) as DetectResultResponse;
+
+    const item = result?.item;
+    if (!item) {
+      throw new Error(`Resemble GET /detect/${uuid} returned no item`);
+    }
+    if (item.status === 'completed' || item.status === 'failed') {
+      return item;
+    }
+    await sleep(pollIntervalMs);
+  }
+
+  throw new Error(
+    `Resemble detection timed out after ${pollTimeoutMs}ms (uuid=${uuid})`
+  );
+}
+
+async function defaultFetchJson(url: string, init: RequestInit): Promise<any> {
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  const { __timeoutMs, ...rest } = init as any;
+  const controller = new AbortController();
+  const id =
+    typeof __timeoutMs === 'number'
+      ? setTimeout(() => controller.abort(), __timeoutMs)
+      : null;
+  try {
+    const response = await fetch(url, { ...rest, signal: controller.signal });
+    if (!response.ok) {
+      const body = await safeText(response);
+      throw new HttpError(`HTTP error! status: ${response.status}`, {
+        status: response.status,
+        statusText: response.statusText,
+        body,
+        headers: response.headers,
+      });
+    }
+    return await response.json();
+  } finally {
+    if (id) clearTimeout(id);
+  }
+}
+
+async function safeText(response: Response): Promise<string> {
+  try {
+    return await response.text();
+  } catch {
+    return '';
+  }
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Evaluates a completed detect item against the configured threshold and
+ * returns a pass/fail decision plus a human-readable summary for `data`.
+ */
+export function evaluateDetection(
+  item: DetectResultResponse['item'],
+  threshold: number
+): { verdict: boolean; label: string; score: number; reason: string } {
+  let label = 'unknown';
+  let score = 0;
+
+  if (item.metrics) {
+    label = (item.metrics.label || '').toLowerCase();
+    score = Number(item.metrics.aggregated_score || '0');
+  } else if (item.image_metrics) {
+    label = (item.image_metrics.label || '').toLowerCase();
+    score = Number(item.image_metrics.score || 0);
+  } else if (item.video_metrics) {
+    label = (item.video_metrics.label || '').toLowerCase();
+    score = Number(item.video_metrics.score || 0);
+  }
+
+  const isFake = label === 'fake' || score >= threshold;
+  const reason = isFake
+    ? `Resemble Detect flagged media as ${label} (score=${score}, threshold=${threshold})`
+    : `Resemble Detect passed: label=${label}, score=${score}`;
+
+  return { verdict: !isFake, label, score, reason };
+}
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  const typed = parameters as unknown as ResembleDetectParameters;
+  const credentials = typed.credentials;
+  const failClosed = typed.failClosed ?? false;
+
+  // Helper that respects failClosed for errors
+  const errorOutcome = (
+    error: any,
+    dataNote: Record<string, any> | null = null
+  ) => ({
+    error,
+    verdict: failClosed ? false : true,
+    data: dataNote,
+  });
+
+  if (!credentials?.apiKey) {
+    return errorOutcome(
+      new Error("'parameters.credentials.apiKey' must be set"),
+      { reason: 'missing_credentials' }
+    );
+  }
+
+  const threshold = typed.threshold ?? 0.5;
+  const urlSource = typed.urlSource ?? 'auto';
+  const metadataKey = typed.metadataKey ?? 'mediaUrl';
+  const pollIntervalMs = typed.pollIntervalMs ?? 2000;
+  const pollTimeoutMs = typed.pollTimeoutMs ?? 60000;
+  const httpTimeoutMs = typed.timeout ?? 10000;
+
+  const mediaUrl = extractMediaUrl(context, eventType, urlSource, metadataKey);
+  if (!mediaUrl) {
+    // No media referenced — nothing to check. Pass through with data note.
+    return {
+      error: null,
+      verdict: true,
+      data: { reason: 'no_media_url_found', urlSource, metadataKey },
+    };
+  }
+
+  const baseUrl = credentials.apiBase || RESEMBLE_DEFAULT_BASE_URL;
+  const createUrl = `${baseUrl}/detect`;
+  const createBody: Record<string, any> = { url: mediaUrl };
+  if (typed.mediaType) createBody.media_type = typed.mediaType;
+  if (typed.audioSourceTracing) createBody.audio_source_tracing = true;
+  if (typed.useReverseSearch) createBody.use_reverse_search = true;
+  if (typed.zeroRetentionMode) createBody.zero_retention_mode = true;
+
+  try {
+    const createResponse = (await post(
+      createUrl,
+      createBody,
+      {
+        headers: {
+          Authorization: `Bearer ${credentials.apiKey}`,
+        },
+      },
+      httpTimeoutMs
+    )) as DetectCreateResponse;
+
+    const uuid = createResponse?.item?.uuid;
+    if (!uuid) {
+      return errorOutcome(
+        new Error(
+          'Resemble /detect response is missing item.uuid — cannot poll'
+        ),
+        { reason: 'missing_uuid', createResponse }
+      );
+    }
+
+    // If already completed synchronously, skip polling
+    const initialStatus = createResponse.item.status;
+    let finalItem: DetectResultResponse['item'];
+    if (initialStatus === 'completed' && (createResponse.item as any).metrics) {
+      finalItem = createResponse.item as DetectResultResponse['item'];
+    } else {
+      finalItem = await pollDetectResult(
+        uuid,
+        credentials,
+        pollIntervalMs,
+        pollTimeoutMs,
+        httpTimeoutMs
+      );
+    }
+
+    if (finalItem.status === 'failed') {
+      return errorOutcome(
+        new Error(
+          `Resemble detection failed: ${finalItem.error_message || 'unknown reason'}`
+        ),
+        { reason: 'detection_failed', item: finalItem }
+      );
+    }
+
+    const evaluation = evaluateDetection(finalItem, threshold);
+    return {
+      error: null,
+      verdict: evaluation.verdict,
+      data: {
+        uuid: finalItem.uuid,
+        mediaUrl,
+        mediaType: finalItem.media_type,
+        label: evaluation.label,
+        score: evaluation.score,
+        threshold,
+        reason: evaluation.reason,
+        audioSourceTracing: finalItem.audio_source_tracing ?? null,
+      },
+    };
+  } catch (e: any) {
+    if (e instanceof HttpError) {
+      const errMessage = `${e.message}. body: ${e.response.body}`;
+      return errorOutcome(new Error(errMessage), {
+        reason: 'http_error',
+        status: e.response.status,
+      });
+    }
+    if (e && typeof e === 'object' && 'stack' in e) delete (e as any).stack;
+    return errorOutcome(e, { reason: 'exception' });
+  }
+};

--- a/plugins/resemble/manifest.json
+++ b/plugins/resemble/manifest.json
@@ -1,0 +1,155 @@
+{
+  "id": "resemble",
+  "description": "Resemble AI Detect: deepfake detection for audio, video, and image content. Blocks LLM requests whose media inputs are flagged as synthetic or manipulated. Includes optional audio source tracing, reverse image search, and Zero Retention Mode.",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "label": "API Key",
+        "description": "Your Resemble AI API token. Get one from https://app.resemble.ai/account/api",
+        "encrypted": true
+      },
+      "apiBase": {
+        "type": "string",
+        "label": "API Base URL",
+        "description": "Override the Resemble API base URL (default: https://app.resemble.ai/api/v2)"
+      }
+    },
+    "required": ["apiKey"]
+  },
+  "functions": [
+    {
+      "name": "Detect Deepfake Media",
+      "id": "detect",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "type": "guardrail",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Scan audio, video, or image URLs referenced in the request for deepfake / synthetic content. The guardrail fails when Resemble labels the media as fake or when the aggregated score exceeds the configured threshold."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "threshold": {
+            "type": "number",
+            "label": "Fake score threshold",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Aggregated score above which media is treated as fake (0.0–1.0). Default 0.5."
+              }
+            ],
+            "default": 0.5,
+            "minimum": 0,
+            "maximum": 1
+          },
+          "mediaType": {
+            "type": "string",
+            "label": "Force media type",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Optionally force audio / video / image. If omitted, Resemble auto-detects from the file extension or content type."
+              }
+            ],
+            "enum": ["audio", "video", "image"]
+          },
+          "audioSourceTracing": {
+            "type": "boolean",
+            "label": "Audio source tracing",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Identify which TTS vendor (elevenlabs, resemble_ai, etc.) generated the audio when it is flagged as fake."
+              }
+            ],
+            "default": false
+          },
+          "useReverseSearch": {
+            "type": "boolean",
+            "label": "Reverse image search (image only)",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "For image detections, search the web for matching images to improve accuracy."
+              }
+            ],
+            "default": false
+          },
+          "zeroRetentionMode": {
+            "type": "boolean",
+            "label": "Zero Retention Mode",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Automatically delete submitted media after detection completes. URLs are redacted and filenames are tokenized."
+              }
+            ],
+            "default": false
+          },
+          "urlSource": {
+            "type": "string",
+            "label": "URL source",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Where to find the media URL. 'auto' inspects multimodal content parts, then regex-extracts from text, then metadata. 'metadata' reads context.metadata[metadataKey]. 'content' only inspects message content."
+              }
+            ],
+            "enum": ["auto", "metadata", "content"],
+            "default": "auto"
+          },
+          "metadataKey": {
+            "type": "string",
+            "label": "Metadata key",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "When urlSource is 'metadata' or 'auto', read the URL from context.metadata[metadataKey]. Default 'mediaUrl'."
+              }
+            ],
+            "default": "mediaUrl"
+          },
+          "pollIntervalMs": {
+            "type": "number",
+            "label": "Poll interval (ms)",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "How often to poll Resemble for the detection result. Default 2000ms."
+              }
+            ],
+            "default": 2000,
+            "minimum": 250
+          },
+          "pollTimeoutMs": {
+            "type": "number",
+            "label": "Poll timeout (ms)",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Maximum total time to wait for the detection result before failing open. Default 60000ms (60s)."
+              }
+            ],
+            "default": 60000,
+            "minimum": 1000
+          },
+          "failClosed": {
+            "type": "boolean",
+            "label": "Fail closed on error",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "If true, Resemble API errors (network, auth, timeout) will BLOCK the request. If false (default), errors are logged but the request passes through."
+              }
+            ],
+            "default": false
+          }
+        }
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Adds a new guardrail plugin that scans audio, video, and image URLs referenced in LLM requests for deepfake / synthetic content via the [Resemble AI Detect API](https://docs.app.resemble.ai/docs/detect).

The plugin runs in `beforeRequestHook` and `afterRequestHook`. It extracts a media URL from the request, submits it to `POST /detect`, polls `GET /detect/{uuid}` until completion, and returns `verdict: false` when Resemble labels the media as \`fake\` or the aggregated score exceeds the configured threshold.

## Why

Deepfakes are increasingly being used to manipulate AI workflows — voice-cloned audio pasted into a chat-completion prompt, synthetic images submitted to a multimodal model, video content slipped through a RAG pipeline. Portkey users asking "is this input real?" currently have no option in the plugins catalog. Resemble Detect covers audio, video, and image from a single endpoint, and ships with useful side signals like **audio source tracing** (identifies which TTS vendor — ElevenLabs, Resemble, PlayHT, OpenAI — generated flagged audio) and **reverse image search** for images.

## What this PR adds

- \`plugins/resemble/manifest.json\` — plugin declaration with credentials schema, parameters, and supported hooks
- \`plugins/resemble/detect.ts\` — handler, URL extraction, polling, and verdict logic
- \`plugins/resemble/detect.test.ts\` — 23 jest tests
- Registers \`resemble: { detect: ... }\` in \`plugins/index.ts\`

### Configuration

| Param | Default | Description |
|---|---|---|
| \`credentials.apiKey\` | — (required) | Resemble API token (encrypted) |
| \`credentials.apiBase\` | \`https://app.resemble.ai/api/v2\` | Override for self-hosted / staging |
| \`threshold\` | 0.5 | Aggregated score above which media is treated as fake |
| \`mediaType\` | auto | Force \`audio\` / \`video\` / \`image\`, or let Resemble auto-detect |
| \`audioSourceTracing\` | false | Identify TTS vendor for flagged audio |
| \`useReverseSearch\` | false | Run reverse image search for images |
| \`zeroRetentionMode\` | false | Delete media after detection completes |
| \`urlSource\` | \`auto\` | Where to look for the URL: \`auto\`, \`metadata\`, or \`content\` |
| \`metadataKey\` | \`mediaUrl\` | Metadata key when \`urlSource\` is \`metadata\` or \`auto\` |
| \`pollIntervalMs\` | 2000 | How often to poll Resemble |
| \`pollTimeoutMs\` | 60000 | Max wait before failing open |
| \`failClosed\` | false | If \`true\`, API errors block the request |

## URL extraction

The handler searches for a media URL in three places, in order:
1. **Multimodal content parts** — OpenAI-style \`input_audio\`, \`image_url\`, and Anthropic-style \`source.url\` (image / document)
2. **Regex over joined text** — matches https URLs ending in common audio/video/image extensions, inside message content, \`prompt\`, or \`input\`
3. **\`context.metadata[metadataKey]\`** — fallback for the \`auto\` mode, primary source when \`urlSource: 'metadata'\`

## Fail modes

By default the plugin fails **open** — if the Resemble API errors out (auth, network, timeout), the request still passes through and the error is recorded in \`data\`. Set \`failClosed: true\` to block on API errors. This matches the pattern in other guardrail plugins.

## Test plan

- [x] 23 jest tests pass (\`npm run test:plugins -- plugins/resemble\`)
- [x] Prettier check passes
- [x] Existing plugins tests unaffected
- [x] Manifest conforms to the plugin schema (loads via plugin manager)

\`\`\`
Test Suites: 1 passed, 1 total
Tests:       23 passed, 23 total
\`\`\`

## Notes

- This is the first new guardrail under the \`resemble\` namespace — happy to adjust the ID / naming to fit your conventions before merge.
- Resemble AI will co-announce the plugin on launch and add Portkey to our integrations documentation.