### PR TITLE
fix(mistral-ai): forward response_format for JSON schema

### DIFF
--- a/src/providers/mistral-ai/chatComplete.ts
+++ b/src/providers/mistral-ai/chatComplete.ts
@@ -100,6 +100,30 @@ export const MistralAIChatCompleteConfig: ProviderConfig = {
     param: 'parallel_tool_calls',
     default: null,
   },
+  response_format: {
+    param: 'response_format',
+    default: null,
+    transform: (params: Params) => {
+      const rf = params.response_format;
+      if (!rf) {
+        return null;
+      }
+      if (rf.type !== 'json_schema' || !rf.json_schema) {
+        return rf;
+      }
+      const inner = rf.json_schema;
+      if (inner.name) {
+        return rf;
+      }
+      return {
+        ...rf,
+        json_schema: {
+          ...inner,
+          name: 'response',
+        },
+      };
+    },
+  },
 };
 
 interface MistralToolCallFunction {


### PR DESCRIPTION
**Description:** (required)
- Register `response_format` on the Mistral AI chat completion `ProviderConfig` so the gateway forwards OpenAI-compatible `response_format` (including `type: "json_schema"` and nested `json_schema`) to Mistral’s `/v1/chat/completions` API instead of dropping it during `transformUsingProviderConfig`.
- When `response_format.type` is `json_schema` and the inner `json_schema` object omits `name`, set a default `name` of `"response"` so payloads match Mistral’s OpenAPI (required `name` + `schema` on the inner object) while staying compatible with clients that omit `name`.

Fixes #1559

**Tests Run/Test cases added:** (required)
- [x] Ran `transformUsingProviderConfig(MistralAIChatCompleteConfig, …)` with `response_format.type: "json_schema"` and verified the transformed body includes `response_format` and defaulted `json_schema.name` when omitted.
- [x] End-to-end: `curl` to local gateway (`x-portkey-provider: mistral-ai`) with `response_format` / JSON schema and confirmed a successful structured response from Mistral.

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)