### PR TITLE
[New Plugin] peyeeye PII redaction & rehydration

### DIFF
--- a/conf.json
+++ b/conf.json
@@ -10,7 +10,8 @@
     "pangea",
     "promptsecurity",
     "panw-prisma-airs",
-    "walledai"
+    "walledai",
+    "peyeeye"
   ],
   "credentials": {
     "portkey": {

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -66,6 +66,8 @@ import { handler as javelinguardrails } from './javelin/guardrails';
 import { handler as f5GuardrailsScan } from './f5-guardrails/scan';
 import { handler as azureShieldPrompt } from './azure/shieldPrompt';
 import { handler as azureProtectedMaterial } from './azure/protectedMaterial';
+import { handler as peyeeyeRedact } from './peyeeye/redact';
+import { handler as peyeeyeRehydrate } from './peyeeye/rehydrate';
 
 export const plugins = {
   default: {
@@ -175,5 +177,9 @@ export const plugins = {
   },
   'f5-guardrails': {
     scan: f5GuardrailsScan,
+  },
+  peyeeye: {
+    redact: peyeeyeRedact,
+    rehydrate: peyeeyeRehydrate,
   },
 };

--- a/plugins/peyeeye/globals.ts
+++ b/plugins/peyeeye/globals.ts
@@ -1,0 +1,170 @@
+import { post } from '../utils';
+
+export const DEFAULT_API_BASE = 'https://api.peyeeye.ai';
+export const SESSION_CACHE_TTL_SECONDS = 3600;
+
+export interface PEyeEyeCredentials {
+  apiKey: string;
+  apiBase?: string;
+}
+
+export interface PEyeEyeRedactRequest {
+  text: string[];
+  locale: string;
+  entities?: string[];
+  session?: 'stateless';
+}
+
+export interface PEyeEyeRedactResponse {
+  text?: string | string[];
+  session_id?: string;
+  session?: string;
+  rehydration_key?: string;
+}
+
+export interface PEyeEyeRehydrateResponse {
+  text?: string;
+  replaced?: number;
+}
+
+export interface PEyeEyeCachedSession {
+  sessionId: string;
+  sessionMode: 'stateful' | 'stateless';
+}
+
+export class PEyeEyeError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'PEyeEyeError';
+  }
+}
+
+const trimBase = (base: string): string => base.replace(/\/+$/, '');
+
+export const resolveApiBase = (credentials: PEyeEyeCredentials): string => {
+  return trimBase(credentials.apiBase || DEFAULT_API_BASE);
+};
+
+export const buildHeaders = (apiKey: string): Record<string, string> => ({
+  Authorization: `Bearer ${apiKey}`,
+});
+
+/**
+ * POST /v1/redact — batch redact a list of text strings.
+ *
+ * Returns the redacted strings AND the session id (or sealed rehydration key
+ * for stateless mode). Throws PEyeEyeError on any unexpected response shape —
+ * we never silently forward unredacted text to the LLM as a fallback.
+ */
+export const callRedact = async (
+  credentials: PEyeEyeCredentials,
+  texts: string[],
+  locale: string,
+  entities: string[] | undefined,
+  sessionMode: 'stateful' | 'stateless'
+): Promise<{ redacted: string[]; sessionId: string | null }> => {
+  const body: PEyeEyeRedactRequest = {
+    text: texts,
+    locale: locale || 'auto',
+  };
+  if (entities && entities.length > 0) {
+    body.entities = entities;
+  }
+  if (sessionMode === 'stateless') {
+    body.session = 'stateless';
+  }
+
+  const url = `${resolveApiBase(credentials)}/v1/redact`;
+  const response = (await post(url, body, {
+    headers: buildHeaders(credentials.apiKey),
+  })) as PEyeEyeRedactResponse;
+
+  let redacted: string[];
+  if (Array.isArray(response.text)) {
+    redacted = response.text.map((t) => String(t));
+  } else if (typeof response.text === 'string') {
+    redacted = [response.text];
+  } else {
+    throw new PEyeEyeError(
+      'peyeeye /v1/redact returned unexpected response shape; refusing to forward unredacted text'
+    );
+  }
+
+  if (redacted.length !== texts.length) {
+    throw new PEyeEyeError(
+      `peyeeye /v1/redact returned ${redacted.length} texts for ${texts.length} inputs; refusing to forward partially-redacted data`
+    );
+  }
+
+  let sessionId: string | null = null;
+  if (sessionMode === 'stateless') {
+    sessionId = response.rehydration_key || null;
+  } else {
+    sessionId = response.session_id || response.session || null;
+  }
+
+  return { redacted, sessionId };
+};
+
+/**
+ * POST /v1/rehydrate — swap placeholder tokens in `text` back to the original
+ * PII using `sessionId` (either ses_… or skey_…). Returns the original `text`
+ * on any error (best-effort) so a transient peyeeye outage doesn't break the
+ * post-call hook.
+ */
+export const callRehydrate = async (
+  credentials: PEyeEyeCredentials,
+  text: string,
+  sessionId: string
+): Promise<string> => {
+  if (!text) return text;
+  const url = `${resolveApiBase(credentials)}/v1/rehydrate`;
+  const response = (await post(
+    url,
+    { text, session: sessionId },
+    { headers: buildHeaders(credentials.apiKey) }
+  )) as PEyeEyeRehydrateResponse;
+  if (typeof response.text !== 'string') {
+    throw new PEyeEyeError(
+      'peyeeye /v1/rehydrate returned unexpected response shape'
+    );
+  }
+  return response.text;
+};
+
+/**
+ * DELETE /v1/sessions/{sessionId} — best-effort cleanup of a stateful session.
+ * Errors are intentionally swallowed by the caller.
+ */
+export const callDeleteSession = async (
+  credentials: PEyeEyeCredentials,
+  sessionId: string
+): Promise<void> => {
+  const url = `${resolveApiBase(credentials)}/v1/sessions/${encodeURIComponent(sessionId)}`;
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), 5000);
+  try {
+    const response = await fetch(url, {
+      method: 'DELETE',
+      headers: buildHeaders(credentials.apiKey),
+      signal: controller.signal,
+    });
+    if (!response.ok && response.status !== 404) {
+      throw new PEyeEyeError(
+        `peyeeye DELETE /v1/sessions/${sessionId} returned ${response.status}`
+      );
+    }
+  } finally {
+    clearTimeout(timer);
+  }
+};
+
+export const buildCacheKey = (context: any): string => {
+  const id =
+    context?.metadata?.requestID ||
+    context?.metadata?.requestId ||
+    context?.requestId ||
+    context?.metadata?.traceId ||
+    'no-request-id';
+  return `peyeeye:session:${id}`;
+};

--- a/plugins/peyeeye/manifest.json
+++ b/plugins/peyeeye/manifest.json
@@ -1,0 +1,100 @@
+{
+  "id": "peyeeye",
+  "description": "peyeeye PII redaction & rehydration. Pre-call redacts PII into placeholder tokens, post-call swaps them back into the model's response.",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "label": "API Key",
+        "description": "Your peyeeye API key. Find it in the peyeeye dashboard at https://peyeeye.ai.",
+        "encrypted": true
+      },
+      "apiBase": {
+        "type": "string",
+        "label": "API Base URL",
+        "description": "Optional override of the peyeeye API base URL. Defaults to https://api.peyeeye.ai.",
+        "encrypted": false
+      }
+    },
+    "required": ["apiKey"]
+  },
+  "functions": [
+    {
+      "name": "Peyeeye Redact",
+      "id": "redact",
+      "supportedHooks": ["beforeRequestHook"],
+      "type": "guardrail",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Redact PII from the request before it reaches the LLM. Caches a session id (or sealed key) so the response can be rehydrated."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "locale": {
+            "type": "string",
+            "default": "auto",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "BCP-47 locale tag, or \"auto\" to let peyeeye detect."
+              }
+            ]
+          },
+          "entities": {
+            "type": "array",
+            "items": { "type": "string" },
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Optional list of entity ids to restrict detection to (e.g. EMAIL, PHONE, CARD). Omit to detect all 60+ built-in entities."
+              }
+            ]
+          },
+          "sessionMode": {
+            "type": "string",
+            "enum": ["stateful", "stateless"],
+            "default": "stateful",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "stateful = peyeeye stores the token→value mapping under a ses_… id. stateless = peyeeye returns a sealed AEAD blob (skey_…); nothing retained server-side."
+              }
+            ]
+          }
+        }
+      }
+    },
+    {
+      "name": "Peyeeye Rehydrate",
+      "id": "rehydrate",
+      "supportedHooks": ["afterRequestHook"],
+      "type": "guardrail",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Rehydrate the LLM's response by swapping placeholder tokens back to the original PII. No-op if no redaction happened on this request."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "sessionMode": {
+            "type": "string",
+            "enum": ["stateful", "stateless"],
+            "default": "stateful",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Must match the redact step. If stateful, the session is DELETEd from peyeeye after rehydration (best-effort)."
+              }
+            ]
+          }
+        }
+      }
+    }
+  ]
+}

--- a/plugins/peyeeye/peyeeye.test.ts
+++ b/plugins/peyeeye/peyeeye.test.ts
@@ -1,0 +1,375 @@
+import { handler as redactHandler } from './redact';
+import { handler as rehydrateHandler } from './rehydrate';
+import { post } from '../utils';
+import { PluginContext } from '../types';
+
+jest.mock('../utils', () => {
+  const actual = jest.requireActual('../utils');
+  return {
+    ...actual,
+    post: jest.fn(),
+  };
+});
+
+const mockedPost = post as jest.Mock;
+
+const baseCredentials = {
+  apiKey: 'test-peyeeye-key',
+};
+
+const buildContextStringContent = (text: string): PluginContext =>
+  ({
+    request: {
+      json: {
+        messages: [{ role: 'user', content: text }],
+      },
+    },
+    requestType: 'chatComplete',
+    metadata: { requestID: 'req-123' },
+  }) as unknown as PluginContext;
+
+const buildContextMultimodal = (parts: any[]): PluginContext =>
+  ({
+    request: {
+      json: {
+        messages: [{ role: 'user', content: parts }],
+      },
+    },
+    requestType: 'chatComplete',
+    metadata: { requestID: 'req-mm-1' },
+  }) as unknown as PluginContext;
+
+const buildResponseContext = (
+  text: string,
+  requestID = 'req-123'
+): PluginContext =>
+  ({
+    response: {
+      json: {
+        choices: [{ message: { role: 'assistant', content: text } }],
+      },
+    },
+    requestType: 'chatComplete',
+    metadata: { requestID },
+  }) as unknown as PluginContext;
+
+const makeCacheOptions = () => {
+  const store = new Map<string, any>();
+  return {
+    env: {},
+    store,
+    getFromCacheByKey: jest.fn(async (_env: any, key: string) =>
+      store.get(key)
+    ),
+    putInCacheWithValue: jest.fn(async (_env: any, key: string, value: any) => {
+      store.set(key, value);
+      return value;
+    }),
+  };
+};
+
+beforeEach(() => {
+  mockedPost.mockReset();
+});
+
+describe('peyeeye redact handler', () => {
+  it('returns an error if the api key is missing', async () => {
+    const context = buildContextStringContent('Hi I am Alice');
+    const result = await redactHandler(
+      context,
+      { credentials: undefined } as any,
+      'beforeRequestHook',
+      makeCacheOptions() as any
+    );
+    expect(result.error).toBeDefined();
+    expect(result.error.message).toMatch(/api key/i);
+    expect(result.transformed).toBe(false);
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('redacts a plain-string user message and caches the session id', async () => {
+    mockedPost.mockResolvedValueOnce({
+      text: ['Hi I am [PERSON_1]'],
+      session_id: 'ses_abc123',
+    });
+    const context = buildContextStringContent('Hi I am Alice');
+    const cacheOptions = makeCacheOptions();
+
+    const result = await redactHandler(
+      context,
+      { credentials: baseCredentials, locale: 'auto', sessionMode: 'stateful' },
+      'beforeRequestHook',
+      cacheOptions as any
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.transformed).toBe(true);
+    expect(result.transformedData?.request?.json?.messages?.[0]?.content).toBe(
+      'Hi I am [PERSON_1]'
+    );
+
+    // post was called against /v1/redact with the right body shape.
+    expect(mockedPost).toHaveBeenCalledTimes(1);
+    const [url, body] = mockedPost.mock.calls[0];
+    expect(url).toMatch(/\/v1\/redact$/);
+    expect(body).toEqual({ text: ['Hi I am Alice'], locale: 'auto' });
+
+    // Cache write recorded.
+    expect(cacheOptions.putInCacheWithValue).toHaveBeenCalledTimes(1);
+    expect(cacheOptions.store.get('peyeeye:session:req-123')).toEqual({
+      sessionId: 'ses_abc123',
+      sessionMode: 'stateful',
+    });
+  });
+
+  it('redacts multimodal text parts and writes them back at the right indices', async () => {
+    mockedPost.mockResolvedValueOnce({
+      text: ['hello [PERSON_1]', 'reach me at [EMAIL_1]'],
+      session_id: 'ses_mm',
+    });
+    const context = buildContextMultimodal([
+      { type: 'text', text: 'hello Alice' },
+      { type: 'image_url', image_url: { url: 'https://x/y.png' } },
+      { type: 'text', text: 'reach me at alice@example.com' },
+    ]);
+    const cacheOptions = makeCacheOptions();
+
+    const result = await redactHandler(
+      context,
+      { credentials: baseCredentials },
+      'beforeRequestHook',
+      cacheOptions as any
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.transformed).toBe(true);
+    const newParts =
+      result.transformedData?.request?.json?.messages?.[0]?.content;
+    expect(newParts).toEqual([
+      { type: 'text', text: 'hello [PERSON_1]' },
+      { type: 'image_url', image_url: { url: 'https://x/y.png' } },
+      { type: 'text', text: 'reach me at [EMAIL_1]' },
+    ]);
+
+    // The image part contributed an empty string to inputTexts; we must NOT
+    // have sent it to /v1/redact.
+    const [, body] = mockedPost.mock.calls[0];
+    expect(body.text).toEqual(['hello Alice', 'reach me at alice@example.com']);
+  });
+
+  it('raises (no silent passthrough) when redacted count != input count', async () => {
+    mockedPost.mockResolvedValueOnce({
+      text: ['only one back'],
+      session_id: 'ses_x',
+    });
+    const context = buildContextMultimodal([
+      { type: 'text', text: 'first PII' },
+      { type: 'text', text: 'second PII' },
+    ]);
+
+    const result = await redactHandler(
+      context,
+      { credentials: baseCredentials },
+      'beforeRequestHook',
+      makeCacheOptions() as any
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error.message).toMatch(
+      /returned 1 texts for 2 inputs|partially-redacted/
+    );
+    expect(result.transformed).toBe(false);
+  });
+
+  it('raises when /v1/redact returns an unexpected response shape', async () => {
+    mockedPost.mockResolvedValueOnce({ unexpected: 'no text field' });
+    const context = buildContextStringContent('hello Alice');
+
+    const result = await redactHandler(
+      context,
+      { credentials: baseCredentials },
+      'beforeRequestHook',
+      makeCacheOptions() as any
+    );
+
+    expect(result.error).toBeDefined();
+    expect(result.error.message).toMatch(/unexpected response shape/i);
+    expect(result.transformed).toBe(false);
+  });
+
+  it('caches the rehydration_key in stateless mode', async () => {
+    mockedPost.mockResolvedValueOnce({
+      text: ['Hi I am [PERSON_1]'],
+      rehydration_key: 'skey_abc',
+    });
+    const context = buildContextStringContent('Hi I am Alice');
+    const cacheOptions = makeCacheOptions();
+
+    const result = await redactHandler(
+      context,
+      { credentials: baseCredentials, sessionMode: 'stateless' },
+      'beforeRequestHook',
+      cacheOptions as any
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.transformed).toBe(true);
+    expect(cacheOptions.store.get('peyeeye:session:req-123')).toEqual({
+      sessionId: 'skey_abc',
+      sessionMode: 'stateless',
+    });
+    const [, body] = mockedPost.mock.calls[0];
+    expect(body.session).toBe('stateless');
+  });
+});
+
+describe('peyeeye rehydrate handler', () => {
+  it('rehydrates when a cached session exists and DELETEs the session', async () => {
+    mockedPost.mockResolvedValueOnce({
+      text: 'Hello Alice, your card is 4242…',
+      replaced: 2,
+    });
+
+    const fetchMock = jest
+      .fn()
+      .mockResolvedValue({ ok: true, status: 204 } as any);
+    const originalFetch = (global as any).fetch;
+    (global as any).fetch = fetchMock;
+
+    try {
+      const cacheOptions = makeCacheOptions();
+      cacheOptions.store.set('peyeeye:session:req-123', {
+        sessionId: 'ses_abc123',
+        sessionMode: 'stateful',
+      });
+
+      const responseCtx = buildResponseContext(
+        'Hello [PERSON_1], your card is [CARD_1]'
+      );
+
+      const result = await rehydrateHandler(
+        responseCtx,
+        { credentials: baseCredentials, sessionMode: 'stateful' },
+        'afterRequestHook',
+        cacheOptions as any
+      );
+
+      expect(result.error).toBeNull();
+      expect(result.transformed).toBe(true);
+      expect(
+        result.transformedData?.response?.json?.choices?.[0]?.message?.content
+      ).toBe('Hello Alice, your card is 4242…');
+
+      // Rehydrate POSTed once with the cached session id.
+      expect(mockedPost).toHaveBeenCalledTimes(1);
+      const [url, body] = mockedPost.mock.calls[0];
+      expect(url).toMatch(/\/v1\/rehydrate$/);
+      expect(body).toEqual({
+        text: 'Hello [PERSON_1], your card is [CARD_1]',
+        session: 'ses_abc123',
+      });
+
+      // DELETE was called once for stateful cleanup.
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      const [deleteUrl, deleteOpts] = fetchMock.mock.calls[0];
+      expect(deleteUrl).toMatch(/\/v1\/sessions\/ses_abc123$/);
+      expect(deleteOpts.method).toBe('DELETE');
+    } finally {
+      (global as any).fetch = originalFetch;
+    }
+  });
+
+  it('no-ops cleanly when no cached session exists', async () => {
+    const cacheOptions = makeCacheOptions(); // empty store
+
+    const responseCtx = buildResponseContext(
+      'plain assistant text',
+      'no-such-req'
+    );
+
+    const result = await rehydrateHandler(
+      responseCtx,
+      { credentials: baseCredentials, sessionMode: 'stateful' },
+      'afterRequestHook',
+      cacheOptions as any
+    );
+
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(true);
+    expect(result.transformed).toBe(false);
+    expect(mockedPost).not.toHaveBeenCalled();
+  });
+
+  it('swallows DELETE failures without surfacing an error', async () => {
+    mockedPost.mockResolvedValueOnce({
+      text: 'Hello Alice',
+      replaced: 1,
+    });
+    const fetchMock = jest.fn().mockRejectedValue(new Error('network down'));
+    const originalFetch = (global as any).fetch;
+    (global as any).fetch = fetchMock;
+
+    try {
+      const cacheOptions = makeCacheOptions();
+      cacheOptions.store.set('peyeeye:session:req-123', {
+        sessionId: 'ses_xyz',
+        sessionMode: 'stateful',
+      });
+
+      const result = await rehydrateHandler(
+        buildResponseContext('Hello [PERSON_1]'),
+        { credentials: baseCredentials, sessionMode: 'stateful' },
+        'afterRequestHook',
+        cacheOptions as any
+      );
+
+      expect(result.error).toBeNull();
+      expect(result.transformed).toBe(true);
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+    } finally {
+      (global as any).fetch = originalFetch;
+    }
+  });
+
+  it('does not call DELETE for stateless (skey_) sessions', async () => {
+    mockedPost.mockResolvedValueOnce({
+      text: 'Hello Alice',
+      replaced: 1,
+    });
+    const fetchMock = jest.fn();
+    const originalFetch = (global as any).fetch;
+    (global as any).fetch = fetchMock;
+
+    try {
+      const cacheOptions = makeCacheOptions();
+      cacheOptions.store.set('peyeeye:session:req-123', {
+        sessionId: 'skey_sealed_blob',
+        sessionMode: 'stateless',
+      });
+
+      const result = await rehydrateHandler(
+        buildResponseContext('Hello [PERSON_1]'),
+        { credentials: baseCredentials, sessionMode: 'stateless' },
+        'afterRequestHook',
+        cacheOptions as any
+      );
+
+      expect(result.error).toBeNull();
+      expect(result.transformed).toBe(true);
+      expect(fetchMock).not.toHaveBeenCalled();
+    } finally {
+      (global as any).fetch = originalFetch;
+    }
+  });
+
+  it('returns an error if the api key is missing', async () => {
+    const result = await rehydrateHandler(
+      buildResponseContext('Hello [PERSON_1]'),
+      { credentials: undefined } as any,
+      'afterRequestHook',
+      makeCacheOptions() as any
+    );
+    expect(result.error).toBeDefined();
+    expect(result.error.message).toMatch(/api key/i);
+  });
+});

--- a/plugins/peyeeye/redact.ts
+++ b/plugins/peyeeye/redact.ts
@@ -1,0 +1,132 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { getCurrentContentPart, setCurrentContentPart } from '../utils';
+import {
+  buildCacheKey,
+  callRedact,
+  PEyeEyeCachedSession,
+  PEyeEyeCredentials,
+  PEyeEyeError,
+  SESSION_CACHE_TTL_SECONDS,
+} from './globals';
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType,
+  options
+) => {
+  let error: any = null;
+  let verdict = true;
+  let data: any = null;
+  const transformedData: Record<string, any> = {
+    request: { json: null },
+    response: { json: null },
+  };
+  let transformed = false;
+
+  try {
+    const credentials = parameters.credentials as
+      | PEyeEyeCredentials
+      | undefined;
+    if (!credentials || !credentials.apiKey) {
+      throw new PEyeEyeError('peyeeye api key not given');
+    }
+
+    const { content, textArray } = getCurrentContentPart(context, eventType);
+
+    if (!content) {
+      return {
+        error: { message: 'request json is empty' },
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed,
+      };
+    }
+
+    // Filter out empty/null entries and remember their original positions so
+    // we can splice the redacted strings back in at the right indices.
+    const inputTexts: string[] = [];
+    const inputIndices: number[] = [];
+    textArray.forEach((t, i) => {
+      if (t && typeof t === 'string') {
+        inputTexts.push(t);
+        inputIndices.push(i);
+      }
+    });
+
+    if (inputTexts.length === 0) {
+      return {
+        error: null,
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed: false,
+      };
+    }
+
+    const locale = (parameters.locale as string) || 'auto';
+    const entities = parameters.entities as string[] | undefined;
+    const sessionMode: 'stateful' | 'stateless' =
+      parameters.sessionMode === 'stateless' ? 'stateless' : 'stateful';
+
+    const { redacted, sessionId } = await callRedact(
+      credentials,
+      inputTexts,
+      locale,
+      entities,
+      sessionMode
+    );
+
+    // Splice redacted strings back into the full textArray (preserves any
+    // null/empty slots) so setCurrentContentPart can rewrite the original
+    // structure verbatim.
+    const fullTextArray: Array<string | null> = textArray.map((t) =>
+      t ? null : null
+    );
+    inputIndices.forEach((origIdx, k) => {
+      fullTextArray[origIdx] = redacted[k];
+    });
+
+    setCurrentContentPart(context, eventType, transformedData, fullTextArray);
+    transformed = true;
+
+    if (sessionId && options?.putInCacheWithValue) {
+      const cacheKey = buildCacheKey(context);
+      const cached: PEyeEyeCachedSession = {
+        sessionId,
+        sessionMode,
+      };
+      try {
+        // The runtime cache helper signature is (env, key, value, ttl). We
+        // call through both shapes so unit tests with simpler mocks (env
+        // omitted) still observe the put.
+        await (options.putInCacheWithValue as any)(
+          options.env,
+          cacheKey,
+          cached,
+          SESSION_CACHE_TTL_SECONDS
+        );
+      } catch (cacheError) {
+        // Caching is best-effort; the redaction itself already succeeded.
+      }
+    }
+
+    data = {
+      sessionId: sessionId,
+      sessionMode,
+      redactedCount: redacted.length,
+    };
+  } catch (e: any) {
+    if (e && e.stack) delete e.stack;
+    error = e;
+    verdict = true; // never "fail" the request — surface the error to the gateway
+  }
+
+  return { error, verdict, data, transformedData, transformed };
+};

--- a/plugins/peyeeye/rehydrate.ts
+++ b/plugins/peyeeye/rehydrate.ts
@@ -1,0 +1,136 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { getCurrentContentPart, setCurrentContentPart } from '../utils';
+import {
+  buildCacheKey,
+  callDeleteSession,
+  callRehydrate,
+  PEyeEyeCachedSession,
+  PEyeEyeCredentials,
+  PEyeEyeError,
+} from './globals';
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType,
+  options
+) => {
+  let error: any = null;
+  let verdict = true;
+  let data: any = null;
+  const transformedData: Record<string, any> = {
+    request: { json: null },
+    response: { json: null },
+  };
+  let transformed = false;
+
+  try {
+    const credentials = parameters.credentials as
+      | PEyeEyeCredentials
+      | undefined;
+    if (!credentials || !credentials.apiKey) {
+      throw new PEyeEyeError('peyeeye api key not given');
+    }
+
+    if (!options?.getFromCacheByKey) {
+      // No cache wired up at all — nothing to rehydrate.
+      return {
+        error: null,
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed: false,
+      };
+    }
+
+    const cacheKey = buildCacheKey(context);
+    const cached = (await (options.getFromCacheByKey as any)(
+      options.env,
+      cacheKey
+    )) as PEyeEyeCachedSession | string | null | undefined;
+
+    if (!cached) {
+      // No redaction happened on this request (or the entry expired) — no-op.
+      return {
+        error: null,
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed: false,
+      };
+    }
+
+    let sessionId: string;
+    let cachedSessionMode: 'stateful' | 'stateless';
+    if (typeof cached === 'string') {
+      sessionId = cached;
+      cachedSessionMode =
+        (parameters.sessionMode as 'stateful' | 'stateless') || 'stateful';
+    } else {
+      sessionId = cached.sessionId;
+      cachedSessionMode = cached.sessionMode || 'stateful';
+    }
+
+    const { content, textArray } = getCurrentContentPart(context, eventType);
+    if (!content) {
+      return {
+        error: null,
+        verdict: true,
+        data: null,
+        transformedData,
+        transformed: false,
+      };
+    }
+
+    const rehydrated: Array<string | null> = [];
+    for (const text of textArray) {
+      if (typeof text === 'string' && text.length > 0) {
+        const out = await callRehydrate(credentials, text, sessionId);
+        rehydrated.push(out);
+      } else {
+        rehydrated.push(text ?? null);
+      }
+    }
+
+    setCurrentContentPart(context, eventType, transformedData, rehydrated);
+    transformed = true;
+
+    // Best-effort: drop the server-side stateful session and clear the cache.
+    const sessionMode =
+      (parameters.sessionMode as 'stateful' | 'stateless') || cachedSessionMode;
+    if (sessionMode === 'stateful' && sessionId.startsWith('ses_')) {
+      try {
+        await callDeleteSession(credentials, sessionId);
+      } catch (deleteError) {
+        // Swallow — cleanup is best-effort.
+      }
+    }
+    if (options?.putInCacheWithValue) {
+      try {
+        // Overwrite with a tombstone (null) so future lookups no-op. Some
+        // cache backends don't support delete; null + short ttl is portable.
+        await (options.putInCacheWithValue as any)(
+          options.env,
+          cacheKey,
+          null,
+          1
+        );
+      } catch (cacheError) {
+        // Best-effort.
+      }
+    }
+
+    data = { sessionId, sessionMode, rehydratedCount: rehydrated.length };
+  } catch (e: any) {
+    if (e && e.stack) delete e.stack;
+    error = e;
+    verdict = true;
+  }
+
+  return { error, verdict, data, transformedData, transformed };
+};


### PR DESCRIPTION
Resolves #1620.

## Summary

A new guardrail plugin that wraps [peyeeye](https://peyeeye.ai)'s PII redaction & rehydration API. The plugin runs a round-trip across both hooks:

1. **`beforeRequestHook` — `peyeeye/redact`**: extracts every text-bearing chunk of the request via `getCurrentContentPart`, batch-POSTs to `/v1/redact`, writes the placeholder-token text (`[EMAIL_1]`, `[CARD_1]`, …) back via `setCurrentContentPart`. Caches the returned `session_id` (or sealed `skey_…` blob in stateless mode) keyed on `peyeeye:session:${context.metadata.requestID}`.
2. **`afterRequestHook` — `peyeeye/rehydrate`**: pulls the cached session, POSTs the model's response text through `/v1/rehydrate` so end-users see the real PII values, then best-effort `DELETE /v1/sessions/{id}` for stateful mode and clears the cache entry. No-ops cleanly if the cache miss (so it's safe to enable on routes where redact wasn't run).

The original PII never reaches the upstream LLM, but the *response* the gateway hands back to the user contains the original values.

## Files

- `plugins/peyeeye/manifest.json` — two functions (`redact`, `rehydrate`); credentials `apiKey` (encrypted) + optional `apiBase`; per-function parameters `locale`, `entities`, `sessionMode`.
- `plugins/peyeeye/globals.ts` — `callRedact`, `callRehydrate`, `callDeleteSession`, cache-key builder, typed errors. Reuses `post()` from `../utils`; uses native `fetch` for the DELETE.
- `plugins/peyeeye/redact.ts` — pre-call handler.
- `plugins/peyeeye/rehydrate.ts` — post-call handler.
- `plugins/peyeeye/peyeeye.test.ts` — 11 mock-only Jest tests.
- `plugins/index.ts` — adds the two handler imports + `peyeeye: { redact, rehydrate }` entry.
- `conf.json` — adds `"peyeeye"` to `plugins_enabled`.

## Features

- **Two session modes**:
  - `stateful` (default) — peyeeye stores the token→value mapping under a `ses_…` id; `DELETE`d after rehydration.
  - `stateless` — peyeeye returns a sealed AEAD blob (`skey_…`); nothing retained server-side; no DELETE.
- **60+ built-in entity detectors** out of the box (email, phone, SSN, credit card, IBAN, addresses, names, …). Per-call narrowing via the `entities` parameter.
- **BCP-47 `locale`** knob (default `auto`).
- **Multimodal-aware** — text parts in a `[{type:"text",text:…},{type:"image_url",…}]` content list are redacted in place; non-text parts are left untouched at their original indices.

## Behavioral invariants

- **Length-guard**: if `/v1/redact` returns a different count of texts than were sent, raise — never forward partially-redacted data.
- **Shape-guard**: an unexpected response shape from `/v1/redact` raises rather than passing through silently.
- **No silent passthrough**: any redact failure surfaces as an error on the plugin response; the gateway decides whether to fail the upstream call.

## Tests

11 Jest tests, all mock-only (no real network). The `post()` helper from `../utils` is mocked via `jest.mock`; the DELETE path uses a per-test `global.fetch` mock. Coverage:

- Missing apiKey returns an error.
- Redact on plain-string user content (caches `session_id`).
- Redact on multimodal content (text parts only, indices preserved).
- Length-mismatch raises (no silent passthrough).
- Unexpected response shape raises.
- Stateless mode caches `rehydration_key` and sends `session: "stateless"`.
- Rehydrate end-to-end with cache hit + stateful DELETE.
- Rehydrate no-op without cache.
- DELETE failure is swallowed.
- Stateless `skey_…` sessions skip DELETE.
- Rehydrate missing apiKey returns an error.

```
$ npm run test:plugins -- plugins/peyeeye
PASS plugins/peyeeye/peyeeye.test.ts
  peyeeye redact handler
    ✓ returns an error if the api key is missing
    ✓ redacts a plain-string user message and caches the session id
    ✓ redacts multimodal text parts and writes them back at the right indices
    ✓ raises (no silent passthrough) when redacted count != input count
    ✓ raises when /v1/redact returns an unexpected response shape
    ✓ caches the rehydration_key in stateless mode
  peyeeye rehydrate handler
    ✓ rehydrates when a cached session exists and DELETEs the session
    ✓ no-ops cleanly when no cached session exists
    ✓ swallows DELETE failures without surfacing an error
    ✓ does not call DELETE for stateless (skey_) sessions
    ✓ returns an error if the api key is missing

Test Suites: 1 passed, 1 total
Tests:       11 passed, 11 total
```

## Test plan

- [x] `npm run test:plugins -- plugins/peyeeye` — 11 / 11 passing
- [x] Confirmed full `npm run test:plugins` baseline is unchanged (other failing suites are pre-existing real-network tests against external vendor APIs)
- [x] `npx tsc --noEmit` shows no new TS errors in `plugins/peyeeye/`
