### PR TITLE
Add embedding support for OpenRouter provider

### DIFF
--- a/src/providers/openrouter/api.ts
+++ b/src/providers/openrouter/api.ts
@@ -14,6 +14,8 @@ const OpenrouterAPIConfig: ProviderAPIConfig = {
     switch (fn) {
       case 'chatComplete':
         return '/v1/chat/completions';
+      case 'embed':
+        return '/v1/embeddings';
       default:
         return '';
     }

--- a/src/providers/openrouter/embed.ts
+++ b/src/providers/openrouter/embed.ts
@@ -1,0 +1,59 @@
+import { OPENROUTER } from '../../globals';
+import { EmbedResponse } from '../../types/embedRequestBody';
+import { ErrorResponse, ProviderConfig } from '../types';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+} from '../utils';
+import { OpenrouterErrorResponse } from './chatComplete';
+
+export const OpenrouterEmbedConfig: ProviderConfig = {
+  model: {
+    param: 'model',
+    required: true,
+  },
+  input: {
+    param: 'input',
+    required: true,
+  },
+  encoding_format: {
+    param: 'encoding_format',
+  },
+  dimensions: {
+    param: 'dimensions',
+  },
+  user: {
+    param: 'user',
+  },
+};
+
+interface OpenrouterEmbedResponse extends EmbedResponse {}
+
+export const OpenrouterEmbedResponseTransform: (
+  response: OpenrouterEmbedResponse | OpenrouterErrorResponse,
+  responseStatus: number
+) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+  if ('message' in response && responseStatus !== 200) {
+    return generateErrorResponse(
+      {
+        message: response.message,
+        type: response.type,
+        param: response.param,
+        code: response.code,
+      },
+      OPENROUTER
+    );
+  }
+
+  if ('data' in response) {
+    return {
+      object: response.object,
+      data: response.data,
+      model: response.model,
+      usage: response.usage,
+      provider: OPENROUTER,
+    };
+  }
+
+  return generateInvalidProviderResponseError(response, OPENROUTER);
+};

--- a/src/providers/openrouter/index.ts
+++ b/src/providers/openrouter/index.ts
@@ -5,13 +5,19 @@ import {
   OpenrouterChatCompleteResponseTransform,
   OpenrouterChatCompleteStreamChunkTransform,
 } from './chatComplete';
+import {
+  OpenrouterEmbedConfig,
+  OpenrouterEmbedResponseTransform,
+} from './embed';
 
 const OpenrouterConfig: ProviderConfigs = {
   chatComplete: OpenrouterChatCompleteConfig,
+  embed: OpenrouterEmbedConfig,
   api: OpenrouterAPIConfig,
   responseTransforms: {
     chatComplete: OpenrouterChatCompleteResponseTransform,
     'stream-chatComplete': OpenrouterChatCompleteStreamChunkTransform,
+    embed: OpenrouterEmbedResponseTransform,
   },
 };
 


### PR DESCRIPTION
**Description:**
- Added new `embed.ts` module for OpenRouter embeddings with `OpenrouterEmbedConfig` and `OpenrouterEmbedResponseTransform`
- Configured embedding request parameters: `model`, `input`, `encoding_format`, `dimensions`, and `user`
- Implemented response transformation to handle OpenRouter embedding responses and error cases
- Updated `index.ts` to register embedding config and response transform in provider configuration
- Added `/v1/embeddings` endpoint mapping in `api.ts` for embedding function calls

Tested locally with `text-embedding-3-small` on OpenRouter.