### PR TITLE
feat(triton): add embed and chatComplete support

### DIFF
--- a/src/providers/triton/api.ts
+++ b/src/providers/triton/api.ts
@@ -1,17 +1,23 @@
 import { ProviderAPIConfig } from '../types';
 
 const TritonAPIConfig: ProviderAPIConfig = {
-  headers: () => {
-    return {};
-  },
   getBaseURL: ({ providerOptions }) => {
     return providerOptions.customHost ?? '';
   },
-  getEndpoint: ({ fn, providerOptions }) => {
-    let mappedFn = fn;
-    switch (mappedFn) {
+  headers: () => {
+    return {};
+  },
+  getEndpoint: ({ fn, providerOptions, gatewayRequestBodyJSON }) => {
+    const model = gatewayRequestBodyJSON?.model || '';
+    switch (fn) {
       case 'complete': {
         return `/generate`;
+      }
+      case 'chatComplete': {
+        return model ? `/v2/models/${model}/generate` : '/generate';
+      }
+      case 'embed': {
+        return model ? `/v2/models/${model}/infer` : '';
       }
       default:
         return '';

--- a/src/providers/triton/chatComplete.ts
+++ b/src/providers/triton/chatComplete.ts
@@ -1,0 +1,138 @@
+import { TRITON } from '../../globals';
+import { Params } from '../../types/requestBody';
+import {
+  ChatCompletionResponse,
+  ErrorResponse,
+  ProviderConfig,
+} from '../types';
+import { generateInvalidProviderResponseError } from '../utils';
+
+function messagesToPrompt(messages: { role: string; content: string }[]): string {
+  if (!messages || messages.length === 0) return '';
+  return messages
+    .map((m) => {
+      switch (m.role) {
+        case 'system':
+          return `System: ${m.content}`;
+        case 'user':
+          return `User: ${m.content}`;
+        case 'assistant':
+          return `Assistant: ${m.content}`;
+        default:
+          return `${m.role}: ${m.content}`;
+      }
+    })
+    .join('\n');
+}
+
+export const TritonChatCompleteConfig: ProviderConfig = {
+  model: {
+    param: 'model',
+    required: true,
+  },
+  messages: {
+    param: 'text_input',
+    required: true,
+    transform: (params: Params) => {
+      return messagesToPrompt(params.messages as any);
+    },
+  },
+  max_tokens: {
+    param: 'max_tokens',
+    default: 100,
+    required: true,
+  },
+  max_completion_tokens: {
+    param: 'max_tokens',
+    default: 100,
+  },
+  temperature: {
+    param: 'temperature',
+    default: 0.7,
+    min: 0,
+    max: 1,
+  },
+  top_p: {
+    param: 'top_p',
+    default: 0.7,
+  },
+  top_k: {
+    param: 'top_k',
+    default: 50,
+  },
+  stop: {
+    param: 'stop_words',
+  },
+  stream: {
+    param: 'stream',
+    default: false,
+  },
+  bad_words: {
+    param: 'bad_words',
+  },
+};
+
+interface TritonChatCompleteResponse {
+  cum_log_probs: number;
+  model_name: string;
+  model_version: number;
+  output_log_probs: number[];
+  sequence_end: boolean;
+  sequence_id: number;
+  sequence_start: boolean;
+  text_output: string;
+}
+
+export const TritonChatCompleteResponseTransform: (
+  response: TritonChatCompleteResponse | any,
+  responseStatus: number
+) => ChatCompletionResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200) {
+    return {
+      error: {
+        message: response?.error || 'Unknown error',
+        type: null,
+        param: null,
+        code: null,
+      },
+      provider: TRITON,
+    };
+  }
+
+  // Handle Triton generate endpoint response
+  if (response?.text_output) {
+    return {
+      id: crypto.randomUUID(),
+      object: 'chat.completion',
+      created: Math.floor(Date.now() / 1000),
+      model: response.model_name || '',
+      provider: TRITON,
+      choices: [
+        {
+          index: 0,
+          message: {
+            role: 'assistant',
+            content: response.text_output,
+          },
+          finish_reason: 'stop',
+        },
+      ],
+      usage: {
+        prompt_tokens: -1,
+        completion_tokens: -1,
+        total_tokens: -1,
+      },
+    };
+  }
+
+  // If response is already OpenAI-compatible (e.g. via Triton Python backend wrapper)
+  if (response?.choices) {
+    return {
+      ...response,
+      id: 'portkey-' + crypto.randomUUID(),
+      provider: TRITON,
+    };
+  }
+
+  return generateInvalidProviderResponseError(response, TRITON);
+};

--- a/src/providers/triton/embed.ts
+++ b/src/providers/triton/embed.ts
@@ -1,0 +1,69 @@
+import { TRITON } from '../../globals';
+import { EmbedParams, EmbedResponse } from '../../types/embedRequestBody';
+import { ErrorResponse, ProviderConfig } from '../types';
+import { generateInvalidProviderResponseError } from '../utils';
+
+export const TritonEmbedConfig: ProviderConfig = {
+  model: {
+    param: 'model',
+    required: true,
+  },
+  input: {
+    param: 'input',
+    required: true,
+  },
+  encoding_format: {
+    param: 'encoding_format',
+  },
+};
+
+export const TritonEmbedResponseTransform: (
+  response: any,
+  responseStatus: number
+) => EmbedResponse | ErrorResponse = (response, responseStatus) => {
+  if (responseStatus !== 200) {
+    return {
+      error: {
+        message: response?.error || 'Unknown error',
+        type: null,
+        param: null,
+        code: null,
+      },
+      provider: TRITON,
+    };
+  }
+
+  // Handle Triton V2 Inference API response (KFServing format)
+  if (response?.outputs) {
+    const embeddingOutput = response.outputs.find(
+      (o: any) => o.name === 'embedding'
+    );
+    if (embeddingOutput?.data) {
+      return {
+        object: 'list',
+        data: [
+          {
+            object: 'embedding',
+            embedding: embeddingOutput.data,
+            index: 0,
+          },
+        ],
+        model: response.model_name || '',
+        usage: {
+          prompt_tokens: -1,
+          total_tokens: -1,
+        },
+      };
+    }
+  }
+
+  // If response is already OpenAI-compatible (e.g. via Triton Python backend wrapper)
+  if (response?.data) {
+    return {
+      ...response,
+      provider: TRITON,
+    };
+  }
+
+  return generateInvalidProviderResponseError(response, TRITON);
+};

--- a/src/providers/triton/index.ts
+++ b/src/providers/triton/index.ts
@@ -4,12 +4,21 @@ import {
   TritonCompleteConfig,
   TritonCompleteResponseTransform,
 } from './complete';
+import {
+  TritonChatCompleteConfig,
+  TritonChatCompleteResponseTransform,
+} from './chatComplete';
+import { TritonEmbedConfig, TritonEmbedResponseTransform } from './embed';
 
 const TritonConfig: ProviderConfigs = {
   api: TritonAPIConfig,
   complete: TritonCompleteConfig,
+  chatComplete: TritonChatCompleteConfig,
+  embed: TritonEmbedConfig,
   responseTransforms: {
     complete: TritonCompleteResponseTransform,
+    chatComplete: TritonChatCompleteResponseTransform,
+    embed: TritonEmbedResponseTransform,
   },
 };
 


### PR DESCRIPTION
# Add embed and chatComplete support to Triton provider

## Problem
The built-in Triton provider only supports the `complete` (text completion) function. Users self-hosting embedding models (e.g., BAAI/bge-large-en-v1.5) or chat models on NVIDIA Triton Inference Server receive errors: `embed is not supported by triton` and `chatComplete is not supported by triton`.

## Acceptance Criteria
- [ ] `POST /v1/embeddings` with `provider: triton` returns embeddings instead of error
- [ ] `POST /v1/chat/completions` with `provider: triton` returns chat completions instead of error
- [ ] Existing `complete` function remains unchanged (backward compatible)
- [ ] Triton V2 Inference API response format (KFServing) is transformed to OpenAI-compatible format

## Approach
1. Create `src/providers/triton/embed.ts` — Embed config (param mapping) + response transform handling Triton's `/v2/models/{model}/infer` output and OpenAI-compatible fallback
2. Create `src/providers/triton/chatComplete.ts` — Chat complete config (messages → text_input conversion) + response transform handling Triton's generate endpoint output
3. Update `api.ts` — Add `embed` → `/v2/models/{model}/infer` and `chatComplete` → `/v2/models/{model}/generate` endpoint mappings
4. Update `index.ts` — Import and register new configs + response transforms

## Files Touched
- `src/providers/triton/embed.ts` (new)
- `src/providers/triton/chatComplete.ts` (new)
- `src/providers/triton/api.ts` (update: 2 new switch cases)
- `src/providers/triton/index.ts` (update: 2 new imports + 3 new config entries)

## Risk / Blast Radius
Low. Changes are scoped entirely to the Triton provider. New functions are registered alongside existing `complete` — no existing code paths are modified, only extended. Backward compatible.

## Test Plan
1. Verify existing `complete` function still works with existing Triton configs
2. Test `embed` with Triton V2 infer endpoint response format
3. Test `chatComplete` with Triton generate endpoint response format
4. Verify error responses for both new functions
