### PR TITLE
fireworks-ai: handle empty choices in streaming chunks

### DIFF
--- a/src/providers/fireworks-ai/chatComplete.ts
+++ b/src/providers/fireworks-ai/chatComplete.ts
@@ -222,6 +222,7 @@ export const FireworksAIChatCompleteStreamChunkTransform: (
     return `data: ${chunk}\n\n`;
   }
   const parsedChunk: FireworksAIStreamChunk = JSON.parse(chunk);
+  const choice = parsedChunk.choices?.[0];
   return (
     `data: ${JSON.stringify({
       id: parsedChunk.id,
@@ -229,14 +230,16 @@ export const FireworksAIChatCompleteStreamChunkTransform: (
       created: parsedChunk.created,
       model: parsedChunk.model,
       provider: FIREWORKS_AI,
-      choices: [
-        {
-          index: parsedChunk.choices[0].index,
-          delta: parsedChunk.choices[0].delta,
-          finish_reason: parsedChunk.choices[0].finish_reason,
-          logprobs: parsedChunk.choices[0].logprobs,
-        },
-      ],
+      choices: choice
+        ? [
+            {
+              index: choice.index,
+              delta: choice.delta,
+              finish_reason: choice.finish_reason,
+              logprobs: choice.logprobs,
+            },
+          ]
+        : [],
       ...(parsedChunk.usage ? { usage: parsedChunk.usage } : {}),
     })}` + '\n\n'
   );


### PR DESCRIPTION
Closes #1627. Mirrors the groq #1073 / together-ai #1321 fix, guard `chunk.choices?.[0]` and emit `choices: []` on usage-only chunks.