### PR TITLE
fix(fireworks-ai): tolerate empty choices in stream chunks

### DIFF
--- a/src/providers/fireworks-ai/chatComplete.ts
+++ b/src/providers/fireworks-ai/chatComplete.ts
@@ -222,6 +222,7 @@ export const FireworksAIChatCompleteStreamChunkTransform: (
     return `data: ${chunk}\n\n`;
   }
   const parsedChunk: FireworksAIStreamChunk = JSON.parse(chunk);
+  const choice = parsedChunk.choices?.[0];
   return (
     `data: ${JSON.stringify({
       id: parsedChunk.id,
@@ -229,14 +230,16 @@ export const FireworksAIChatCompleteStreamChunkTransform: (
       created: parsedChunk.created,
       model: parsedChunk.model,
       provider: FIREWORKS_AI,
-      choices: [
-        {
-          index: parsedChunk.choices[0].index,
-          delta: parsedChunk.choices[0].delta,
-          finish_reason: parsedChunk.choices[0].finish_reason,
-          logprobs: parsedChunk.choices[0].logprobs,
-        },
-      ],
+      choices: choice
+        ? [
+            {
+              index: choice.index,
+              delta: choice.delta,
+              finish_reason: choice.finish_reason,
+              logprobs: choice.logprobs,
+            },
+          ]
+        : [],
       ...(parsedChunk.usage ? { usage: parsedChunk.usage } : {}),
     })}` + '\n\n'
   );


### PR DESCRIPTION
Fixes #1627.

`FireworksAIChatCompleteStreamChunkTransform` indexed `parsedChunk.choices[0].index` directly. Fireworks emits chunks where `choices` is empty or absent (e.g. usage-only chunks when `stream_options.include_usage` is set), and the transform threw `Cannot read properties of undefined (reading 'index')`. Mirror the fix landed for groq (#1073) and together-ai (#1321): emit `choices: []` when the choice is missing, otherwise pass through unchanged. Usage continues to flow through.