### PR TITLE
fix(huggingface): use HF inference router for default base URL

### DIFF
--- a/src/providers/huggingface/api.ts
+++ b/src/providers/huggingface/api.ts
@@ -3,23 +3,18 @@ import { ProviderAPIConfig } from '../types';
 const HuggingfaceAPIConfig: ProviderAPIConfig = {
   getBaseURL: ({ providerOptions }) => {
     return (
-      providerOptions.huggingfaceBaseUrl ||
-      'https://api-inference.huggingface.co'
+      providerOptions.huggingfaceBaseUrl || 'https://router.huggingface.co'
     );
   },
   headers: ({ providerOptions }) => ({
     Authorization: `Bearer ${providerOptions.apiKey}`,
   }),
-  getEndpoint: ({ fn, gatewayRequestBodyJSON, providerOptions }) => {
-    const { model } = gatewayRequestBodyJSON;
-    const modelPath = providerOptions.huggingfaceBaseUrl
-      ? ''
-      : `/models/${model}`;
+  getEndpoint: ({ fn }) => {
     switch (fn) {
       case 'chatComplete':
-        return `${modelPath}/v1/chat/completions`;
+        return '/v1/chat/completions';
       case 'complete':
-        return `${modelPath}/v1/completions`;
+        return '/v1/completions';
       default:
         return '';
     }


### PR DESCRIPTION
Closes #1626

## What
Update the default Hugging Face base URL from `https://api-inference.huggingface.co` (the legacy HF Serverless Inference API) to `https://router.huggingface.co` (the new HF Inference Providers OpenAI-compatible router), and drop the per-model path from the default endpoint construction since the router takes the model in the request body.

## Why
The legacy serverless API endpoint with the `/models/{model}/v1/chat/completions` path has been superseded by HF's unified Inference Providers router (per https://huggingface.co/docs/inference-providers). Issue #1626 reports the documented Hugging Face setup no longer working through Portkey, and points at the outdated default URL.

## Notes
- Opened as draft — please review before marking ready.
- The `huggingfaceBaseUrl` override path already used a bare `/v1/chat/completions` endpoint (no `/models/{model}`), so dedicated-endpoint users are unaffected.
- Verification: no test suite was run locally — the change is a config-only edit. Reviewers should sanity-check the new URL and the assumption that the inference router accepts the OpenAI-compatible chat-completions / completions schema with model in the body.