### PR TITLE
improvement: map max_completion_tokens to max_tokens for Groq and Cerebras

### DIFF
--- a/src/providers/cerebras/index.ts
+++ b/src/providers/cerebras/index.ts
@@ -4,14 +4,20 @@ import { ProviderConfigs } from '../types';
 import { cerebrasAPIConfig } from './api';
 
 export const cerebrasProviderAPIConfig: ProviderConfigs = {
-  chatComplete: chatCompleteParams([
-    'frequency_penalty',
-    'logit_bias',
-    'logprobs',
-    'presence_penalty',
-    'parallel_tool_calls',
-    'service_tier',
-  ]),
+  chatComplete: chatCompleteParams(
+    [
+      'frequency_penalty',
+      'logit_bias',
+      'logprobs',
+      'presence_penalty',
+      'parallel_tool_calls',
+      'service_tier',
+    ],
+    {},
+    {
+      max_completion_tokens: { param: 'max_tokens', min: 1 },
+    }
+  ),
   api: cerebrasAPIConfig,
   responseTransforms: responseTransformers(CEREBRAS, {
     chatComplete: true,

--- a/src/providers/groq/index.ts
+++ b/src/providers/groq/index.ts
@@ -16,6 +16,7 @@ const GroqConfig: ProviderConfigs = {
     {
       service_tier: { param: 'service_tier', required: false },
       reasoning_effort: { param: 'reasoning_effort', required: false },
+      max_completion_tokens: { param: 'max_tokens', min: 1 },
     }
   ),
   createTranscription: {},


### PR DESCRIPTION
## Description
- Map `max_completion_tokens` to `max_tokens` for Groq and Cerebras providers
- Groq and Cerebras APIs only understand `max_tokens`, not `max_completion_tokens`
- This mapping is already done for Deepinfra, Fireworks, and many other providers

Closes #1341

Supersedes #1516 (stale since March, maintainer feedback unaddressed)

## Changes
- `src/providers/groq/index.ts`: Added `max_completion_tokens` entry to the existing extra params object
- `src/providers/cerebras/index.ts`: Added third argument to `chatCompleteParams()` with `max_completion_tokens` mapping, using `{}` for defaultValues (per review feedback on #1516)

## Tests Run
- [x] Build passes (`npm run build`)
- [x] Formatting passes (`npm run format:check`)

## Type of Change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation
- [ ] Refactoring