### PR TITLE
feat(oracle): add Cohere embeddings support

### DIFF
--- a/src/providers/oracle/api.ts
+++ b/src/providers/oracle/api.ts
@@ -37,6 +37,9 @@ const OracleAPIConfig: ProviderAPIConfig = {
       case 'stream-chatComplete':
         endpoint = '/actions/chat';
         break;
+      case 'embed':
+        endpoint = '/actions/embedText';
+        break;
       default:
         return '';
     }

--- a/src/providers/oracle/embed.test.ts
+++ b/src/providers/oracle/embed.test.ts
@@ -1,0 +1,100 @@
+import { OracleEmbedConfig, OracleEmbedResponseTransform } from './embed';
+
+const baseProviderOptions = {
+  oracleCompartmentId: 'ocid1.compartment.oc1..test',
+} as any;
+
+const transformInput = (params: any) => {
+  const cfg = OracleEmbedConfig.input as any;
+  return cfg.transform(params, baseProviderOptions);
+};
+
+const transformInputType = (params: any) => {
+  const cfg = OracleEmbedConfig.input_type as any;
+  return cfg.transform(params, baseProviderOptions);
+};
+
+const transformServingMode = (params: any) => {
+  const cfg = OracleEmbedConfig.model as any;
+  return cfg.transform(params, baseProviderOptions);
+};
+
+describe('Oracle Embeddings — request transform', () => {
+  it('wraps a string input into the OCI inputs array', () => {
+    expect(transformInput({ input: 'hello' })).toEqual(['hello']);
+  });
+
+  it('passes through an array of strings', () => {
+    expect(transformInput({ input: ['a', 'b'] })).toEqual(['a', 'b']);
+  });
+
+  it('extracts text from object items in input array', () => {
+    const out = transformInput({
+      input: [{ text: 'first' }, { text: 'second' }],
+    });
+    expect(out).toEqual(['first', 'second']);
+  });
+
+  it('returns undefined for empty array', () => {
+    expect(transformInput({ input: [] })).toBeUndefined();
+  });
+
+  it('maps lowercase input_type to OCI uppercase', () => {
+    expect(transformInputType({ input_type: 'search_document' })).toBe(
+      'SEARCH_DOCUMENT'
+    );
+    expect(transformInputType({ input_type: 'CLUSTERING' })).toBe('CLUSTERING');
+  });
+
+  it('builds an ON_DEMAND servingMode payload', () => {
+    expect(
+      transformServingMode({ model: 'cohere.embed-multilingual-v3.0' })
+    ).toEqual({
+      servingType: 'ON_DEMAND',
+      modelId: 'cohere.embed-multilingual-v3.0',
+    });
+  });
+});
+
+describe('Oracle Embeddings — response transform', () => {
+  it('maps OCI embeddings to OpenAI shape', () => {
+    const oci = {
+      embeddings: [
+        [0.1, 0.2],
+        [0.3, 0.4],
+      ],
+      modelId: 'cohere.embed-multilingual-v3.0',
+      modelVersion: '1.0',
+      inputTextTokenCount: 7,
+    };
+
+    const result: any = OracleEmbedResponseTransform(oci, 200, new Headers());
+
+    expect(result.object).toBe('list');
+    expect(result.data).toEqual([
+      { object: 'embedding', embedding: [0.1, 0.2], index: 0 },
+      { object: 'embedding', embedding: [0.3, 0.4], index: 1 },
+    ]);
+    expect(result.model).toBe('cohere.embed-multilingual-v3.0');
+    expect(result.usage).toEqual({ prompt_tokens: 7, total_tokens: 7 });
+  });
+
+  it('returns an error response for non-200 with code', () => {
+    const result: any = OracleEmbedResponseTransform(
+      { code: '400', message: 'bad input' } as any,
+      400,
+      new Headers()
+    );
+    expect(result.error).toBeDefined();
+    expect(result.error.message).toContain('bad input');
+  });
+
+  it('returns invalid-provider-response when embeddings missing', () => {
+    const result: any = OracleEmbedResponseTransform(
+      { modelId: 'foo' } as any,
+      200,
+      new Headers()
+    );
+    expect(result.error).toBeDefined();
+  });
+});

--- a/src/providers/oracle/embed.ts
+++ b/src/providers/oracle/embed.ts
@@ -1,0 +1,160 @@
+import { ORACLE } from '../../globals';
+import {
+  EmbedParams,
+  EmbedResponse,
+  EmbedResponseData,
+} from '../../types/embedRequestBody';
+import { Options } from '../../types/requestBody';
+import { ErrorResponse, ProviderConfig } from '../types';
+import {
+  generateErrorResponse,
+  generateInvalidProviderResponseError,
+} from '../utils';
+
+type OracleInputType =
+  | 'SEARCH_DOCUMENT'
+  | 'SEARCH_QUERY'
+  | 'CLASSIFICATION'
+  | 'CLUSTERING'
+  | 'IMAGE';
+
+type OracleTruncate = 'NONE' | 'START' | 'END';
+
+export const OracleEmbedConfig: ProviderConfig = {
+  input: {
+    param: 'inputs',
+    required: true,
+    transform: (params: EmbedParams): string[] | undefined => {
+      if (typeof params.input === 'string') {
+        return [params.input];
+      }
+      if (Array.isArray(params.input)) {
+        const texts: string[] = [];
+        params.input.forEach((item) => {
+          if (typeof item === 'string') {
+            texts.push(item);
+          } else if (typeof item === 'object' && 'text' in item) {
+            texts.push((item as { text: string }).text);
+          }
+        });
+        return texts.length > 0 ? texts : undefined;
+      }
+      return undefined;
+    },
+  },
+  input_type: {
+    param: 'inputType',
+    required: false,
+    transform: (params: EmbedParams): OracleInputType | undefined => {
+      const typeMap: Record<string, OracleInputType> = {
+        search_document: 'SEARCH_DOCUMENT',
+        search_query: 'SEARCH_QUERY',
+        classification: 'CLASSIFICATION',
+        clustering: 'CLUSTERING',
+        image: 'IMAGE',
+      };
+      const inputType = (params as any).input_type;
+      if (inputType && typeMap[inputType.toLowerCase()]) {
+        return typeMap[inputType.toLowerCase()];
+      }
+      return undefined;
+    },
+  },
+  truncate: {
+    param: 'truncate',
+    required: false,
+    transform: (params: EmbedParams): OracleTruncate | undefined => {
+      const truncateMap: Record<string, OracleTruncate> = {
+        none: 'NONE',
+        start: 'START',
+        end: 'END',
+      };
+      const truncate = (params as any).truncate;
+      if (truncate && truncateMap[truncate.toLowerCase()]) {
+        return truncateMap[truncate.toLowerCase()];
+      }
+      return undefined;
+    },
+  },
+  is_echo: {
+    param: 'isEcho',
+    required: false,
+    transform: (params: EmbedParams): boolean | undefined => {
+      return (params as any).is_echo;
+    },
+  },
+  model: {
+    param: 'servingMode',
+    required: true,
+    transform: (params: EmbedParams): object => {
+      return {
+        servingType: 'ON_DEMAND',
+        modelId: params.model,
+      };
+    },
+  },
+  compartmentId: {
+    param: 'compartmentId',
+    required: true,
+    default: (_params: EmbedParams, provider: Options): string => {
+      return provider.oracleCompartmentId || '';
+    },
+  },
+};
+
+export interface OracleEmbedResponse {
+  embeddings: number[][];
+  modelId: string;
+  modelVersion: string;
+  inputTextTokenCount?: number;
+}
+
+export interface OracleEmbedErrorResponse {
+  code: string;
+  message: string;
+}
+
+export const OracleEmbedResponseTransform = (
+  response: OracleEmbedResponse | OracleEmbedErrorResponse,
+  responseStatus: number,
+  _responseHeaders: Headers
+): EmbedResponse | ErrorResponse => {
+  if (responseStatus !== 200 && 'code' in response) {
+    return generateErrorResponse(
+      {
+        message: `oracle error: ${response.message || 'Unknown error'}`,
+        type: response.code?.toString() || null,
+        param: null,
+        code: response.code?.toString() || null,
+      },
+      ORACLE
+    );
+  }
+
+  const successResponse = response as OracleEmbedResponse;
+  if (
+    !successResponse.embeddings ||
+    !Array.isArray(successResponse.embeddings)
+  ) {
+    return generateInvalidProviderResponseError(response, ORACLE);
+  }
+
+  const data: EmbedResponseData[] = successResponse.embeddings.map(
+    (embedding, index) => ({
+      object: 'embedding' as const,
+      embedding,
+      index,
+    })
+  );
+
+  return {
+    object: 'list',
+    data,
+    model: successResponse.modelId,
+    usage: {
+      prompt_tokens: successResponse.inputTextTokenCount || 0,
+      total_tokens: successResponse.inputTextTokenCount || 0,
+    },
+    provider: ORACLE,
+  };
+};

--- a/src/providers/oracle/index.ts
+++ b/src/providers/oracle/index.ts
@@ -5,13 +5,16 @@ import {
   OracleChatCompleteResponseTransform,
   OracleChatCompleteStreamChunkTransform,
 } from './chatComplete';
+import { OracleEmbedConfig, OracleEmbedResponseTransform } from './embed';
 
 const OracleConfig: ProviderConfigs = {
   chatComplete: OracleChatCompleteConfig,
+  embed: OracleEmbedConfig,
   api: OracleAPIConfig,
   responseTransforms: {
     chatComplete: OracleChatCompleteResponseTransform,
     'stream-chatComplete': OracleChatCompleteStreamChunkTransform,
+    embed: OracleEmbedResponseTransform,
   },
 };
 


### PR DESCRIPTION
## Summary

Adds the Oracle GenAI embeddings endpoint (Cohere embed models on OCI) and wires it into the gateway's `/v1/embeddings` surface.

This is the embeddings split from the original #1537 (per @narengogi's review asking to trim into focused PRs). #1537 now contains only the streaming tool-call fix.

## What changed

| File | Change |
|------|--------|
| `src/providers/oracle/embed.ts` | New — request transform + OCI-to-OpenAI response transform |
| `src/providers/oracle/api.ts` | Route the `embed` endpoint to OCI `/actions/embedText` |
| `src/providers/oracle/index.ts` | Wire `OracleEmbedConfig` + `OracleEmbedResponseTransform` |
| `src/providers/oracle/embed.test.ts` | New — focused unit tests |

Total diff: **+266 / -0**, 4 files, all under `src/providers/oracle/`.

## Behaviour

- **Input shaping**: handles OpenAI's `input` as string, string array, or object array (`{text: ...}`).
- **`input_type`**: maps OpenAI-style values (`search_document`, `search_query`, `classification`, `clustering`, `image`) to OCI's uppercase enum.
- **`truncate`**: maps `none` / `start` / `end` to OCI's `NONE` / `START` / `END`.
- **Serving mode**: ON_DEMAND only in this PR. DEDICATED can follow once a matching `oracleEndpointId` provider option lands (intentionally out of scope here to keep the PR focused).
- **Response**: maps OCI `embeddings: number[][]` + `inputTextTokenCount` to OpenAI's `data: [{embedding, index}]` + `usage`.

## Verified

- `npm run build` ✓
- `npm run format:check` ✓
- Type-clean (`tsc --noEmit` reports no errors in `src/providers/oracle/`)
- Verified live against `inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/embedText` for `cohere.embed-multilingual-v3.0` (single string, batch, search_document type).

## Related

- Split from #1537 per @narengogi's review
- **Supersedes #1540** (the embeddings portion). The old PR carried a heavier change set that bundled handler dispatch and `modelConfig.ts`; this PR is the trimmed-down equivalent focused solely on the `/v1/embeddings` surface.
- Sibling: #1537 (streaming tool-call fix), #1635 (GPT-5 `maxCompletionTokens` routing). The multi-vendor handler dispatch work that was originally bundled is parked for a separate focused PR.
