### PR TITLE
fix(oracle): route maxTokens to maxCompletionTokens for GPT-5 family

### DIFF
--- a/src/providers/oracle/chatComplete.test.ts
+++ b/src/providers/oracle/chatComplete.test.ts
@@ -1,0 +1,42 @@
+import { OracleChatCompleteConfig } from './chatComplete';
+
+const buildChatRequest = (model: string, params: any = {}) => {
+  const cfg = (OracleChatCompleteConfig.model as any[])[0];
+  return cfg.transform(
+    { model, messages: [{ role: 'user', content: 'hi' }], ...params },
+    { oracleCompartmentId: 'ocid1.compartment.oc1..test' }
+  );
+};
+
+describe('Oracle chat — GPT-5 maxCompletionTokens routing', () => {
+  it('routes maxTokens → maxCompletionTokens for openai.gpt-5', () => {
+    const req = buildChatRequest('openai.gpt-5', { max_tokens: 200 });
+    expect(req.maxTokens).toBeUndefined();
+    expect(req.maxCompletionTokens).toBe(200);
+  });
+
+  it('routes maxTokens → maxCompletionTokens for gpt-5 variants (e.g. gpt-5-mini)', () => {
+    const req = buildChatRequest('openai.gpt-5-mini', { max_tokens: 64 });
+    expect(req.maxTokens).toBeUndefined();
+    expect(req.maxCompletionTokens).toBe(64);
+  });
+
+  it('keeps maxTokens for non-GPT-5 models (gpt-4o)', () => {
+    const req = buildChatRequest('openai.gpt-4o', { max_tokens: 128 });
+    expect(req.maxTokens).toBe(128);
+    expect(req.maxCompletionTokens).toBeUndefined();
+  });
+
+  it('keeps maxTokens for Llama / Cohere / Grok / Gemini', () => {
+    for (const model of [
+      'meta.llama-3.3-70b-instruct',
+      'cohere.command-r-plus-08-2024',
+      'xai.grok-3-mini',
+      'google.gemini-2.5-flash',
+    ]) {
+      const req = buildChatRequest(model, { max_tokens: 50 });
+      expect(req.maxTokens).toBe(50);
+      expect(req.maxCompletionTokens).toBeUndefined();
+    }
+  });
+});

--- a/src/providers/oracle/chatComplete.ts
+++ b/src/providers/oracle/chatComplete.ts
@@ -28,6 +28,16 @@ import {
 } from './types/GenericChatResponse';
 import { openAIToOracleRoleMap, oracleToOpenAIRoleMap } from './utils';
 
+/**
+ * GPT-5+ models on OCI reject `maxTokens` and require `maxCompletionTokens`
+ * instead. Match the family inline so we can route the parameter correctly
+ * without dragging in a separate model-config module.
+ */
+const GPT5_FAMILY_PATTERN = /^openai\.gpt-5/i;
+
+const usesMaxCompletionTokens = (model: string): boolean =>
+  GPT5_FAMILY_PATTERN.test(model);
+
 // transforms from openai format to oracle format for chat completions request
 export const OracleChatCompleteConfig: ProviderConfig = {
   model: [
@@ -35,11 +45,20 @@ export const OracleChatCompleteConfig: ProviderConfig = {
       param: 'chatRequest',
       required: true,
       transform: (params: Params, providerOptions: Options) => {
-        return transformUsingProviderConfig(
+        const chatRequest = transformUsingProviderConfig(
           OracleChatDetailsConfig,
           params,
           providerOptions
         );
+
+        if (usesMaxCompletionTokens(params.model || '')) {
+          if ('maxTokens' in chatRequest) {
+            (chatRequest as any).maxCompletionTokens = chatRequest.maxTokens;
+            delete chatRequest.maxTokens;
+          }
+        }
+
+        return chatRequest;
       },
     },
     {


### PR DESCRIPTION
## Summary

OCI's chat endpoint rejects `maxTokens` for the GPT-5 family with `Use 'maxCompletionTokens' instead`, so any GPT-5 request through the gateway currently fails with a 400 unless the caller already knows the OCI quirk and works around it.

This PR detects the GPT-5 family inline (`/^openai\.gpt-5/i`) and rewrites the parameter on the OCI chat request envelope. Everything else (gpt-4o, Llama, Cohere, Grok, Gemini) continues to use `maxTokens` unchanged.

Split out from #1537 per @narengogi's review.

## What changed

`src/providers/oracle/chatComplete.ts`:

- Add a small inline `usesMaxCompletionTokens(model)` helper (no separate `modelConfig.ts` module — kept tight).
- In the `chatRequest` transform, after building the OCI envelope, swap `maxTokens` → `maxCompletionTokens` when the model is in the GPT-5 family.

`src/providers/oracle/chatComplete.test.ts`:

- `openai.gpt-5` and `openai.gpt-5-mini` route to `maxCompletionTokens`.
- `openai.gpt-4o`, `meta.llama-3.3-70b-instruct`, `cohere.command-r-plus-08-2024`, `xai.grok-3-mini`, `google.gemini-2.5-flash` keep `maxTokens`.

Diff: **+63 / −1**, two files.

## Verified

- `npm run build` ✓
- `npm run format:check` ✓
- Type-clean (`tsc --noEmit` no errors in `src/providers/oracle/`)
- Verified live against `inference.generativeai.us-chicago-1.oci.oraclecloud.com/20231130/actions/chat` for `openai.gpt-5` (now succeeds; previously returned `400 "Use 'maxCompletionTokens' instead"`).

## Related

- Split from #1537 per @narengogi's review
- **Supersedes #1540** (the GPT-5 portion). This PR uses an inline regex (`/^openai\.gpt-5/i`) instead of #1540's separate `modelConfig.ts` module — same behaviour, smaller surface area.
- Sibling: #1537 (streaming tool-call fix), #1634 (Cohere embeddings)
