### PR TITLE
fix(gemini): use thinkingBudget for Gemini 2.5, thinkingLevel for 3+

### DIFF
--- a/src/providers/google-vertex-ai/transformGenerationConfig.test.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.test.ts
@@ -1,0 +1,89 @@
+import {
+  openaiReasoningEffortToVertexThinkingBudget,
+  transformGenerationConfig,
+} from './transformGenerationConfig';
+import { PortkeyGeminiParams } from './types';
+
+describe('openaiReasoningEffortToVertexThinkingBudget', () => {
+  test.each([
+    ['minimal', 512],
+    ['low', 4096],
+    ['medium', 16384],
+    ['high', 24576],
+  ])('maps %s to %d', (effort, expected) => {
+    expect(openaiReasoningEffortToVertexThinkingBudget(effort)).toBe(expected);
+  });
+
+  test('returns undefined for unknown effort', () => {
+    expect(
+      openaiReasoningEffortToVertexThinkingBudget('extreme')
+    ).toBeUndefined();
+  });
+});
+
+describe('transformGenerationConfig — reasoning_effort', () => {
+  test('uses thinkingBudget for gemini-2.5-flash-lite', () => {
+    const params = {
+      model: 'gemini-2.5-flash-lite',
+      reasoning_effort: 'low',
+    } as unknown as PortkeyGeminiParams;
+    expect(transformGenerationConfig(params).thinkingConfig).toEqual({
+      thinkingBudget: 4096,
+    });
+  });
+
+  test('uses thinkingBudget for gemini-2.5-flash', () => {
+    const params = {
+      model: 'gemini-2.5-flash',
+      reasoning_effort: 'medium',
+    } as unknown as PortkeyGeminiParams;
+    expect(transformGenerationConfig(params).thinkingConfig).toEqual({
+      thinkingBudget: 16384,
+    });
+  });
+
+  test('uses thinkingBudget for gemini-2.5-pro', () => {
+    const params = {
+      model: 'gemini-2.5-pro',
+      reasoning_effort: 'high',
+    } as unknown as PortkeyGeminiParams;
+    expect(transformGenerationConfig(params).thinkingConfig).toEqual({
+      thinkingBudget: 24576,
+    });
+  });
+
+  test('uses thinkingLevel for gemini-3-flash-preview', () => {
+    const params = {
+      model: 'gemini-3-flash-preview',
+      reasoning_effort: 'low',
+    } as unknown as PortkeyGeminiParams;
+    expect(transformGenerationConfig(params).thinkingConfig).toEqual({
+      thinkingLevel: 'low',
+    });
+  });
+
+  test('uses thinkingLevel when model is unknown', () => {
+    const params = {
+      reasoning_effort: 'high',
+    } as unknown as PortkeyGeminiParams;
+    expect(transformGenerationConfig(params).thinkingConfig).toEqual({
+      thinkingLevel: 'high',
+    });
+  });
+
+  test("skips thinkingConfig when reasoning_effort is 'none'", () => {
+    const params = {
+      model: 'gemini-2.5-flash-lite',
+      reasoning_effort: 'none',
+    } as unknown as PortkeyGeminiParams;
+    expect(transformGenerationConfig(params).thinkingConfig).toBeUndefined();
+  });
+
+  test('skips thinkingConfig for gemini-2.5 with unknown effort value', () => {
+    const params = {
+      model: 'gemini-2.5-flash',
+      reasoning_effort: 'extreme',
+    } as unknown as PortkeyGeminiParams;
+    expect(transformGenerationConfig(params).thinkingConfig).toBeUndefined();
+  });
+});

--- a/src/providers/google-vertex-ai/transformGenerationConfig.ts
+++ b/src/providers/google-vertex-ai/transformGenerationConfig.ts
@@ -5,6 +5,31 @@ import {
 import { GoogleEmbedParams } from './embed';
 import { EmbedInstancesData, PortkeyGeminiParams } from './types';
 
+// Gemini 2.5 family (Pro, Flash, Flash-Lite) uses `thinkingBudget` (integer).
+// Gemini 3+ uses `thinkingLevel` (enum). `thinkingLevel` is silently dropped
+// on 2.5 models, which on Flash-Lite (default thinkingBudget=0) means no
+// thinking at all — see https://github.com/Portkey-AI/gateway/issues/1639
+const GEMINI_2_5_FAMILY_REGEX = /gemini-2[.-]?5/i;
+
+// Map OpenAI `reasoning_effort` levels to Gemini 2.5 `thinkingBudget` values.
+// Chosen to be valid across Flash, Flash-Lite (512–24576) and Pro (128–32768).
+export const openaiReasoningEffortToVertexThinkingBudget = (
+  reasoningEffort: string
+): number | undefined => {
+  switch (reasoningEffort) {
+    case 'minimal':
+      return 512;
+    case 'low':
+      return 4096;
+    case 'medium':
+      return 16384;
+    case 'high':
+      return 24576;
+    default:
+      return undefined;
+  }
+};
+
 /**
  * @see https://cloud.google.com/vertex-ai/generative-ai/docs/model-reference/gemini#request_body
  */
@@ -66,9 +91,19 @@ export function transformGenerationConfig(params: PortkeyGeminiParams) {
     );
   }
   if (params.reasoning_effort && params.reasoning_effort !== 'none') {
-    generationConfig['thinkingConfig'] = {
-      thinkingLevel: params.reasoning_effort,
-    };
+    const model = (params.model ?? '') as string;
+    if (GEMINI_2_5_FAMILY_REGEX.test(model)) {
+      const thinkingBudget = openaiReasoningEffortToVertexThinkingBudget(
+        params.reasoning_effort
+      );
+      if (thinkingBudget !== undefined) {
+        generationConfig['thinkingConfig'] = { thinkingBudget };
+      }
+    } else {
+      generationConfig['thinkingConfig'] = {
+        thinkingLevel: params.reasoning_effort,
+      };
+    }
   }
   if (params.image_config) {
     generationConfig['imageConfig'] = {

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -9,6 +9,7 @@ import {
   SYSTEM_MESSAGE_ROLES,
   MESSAGE_ROLES,
 } from '../../types/requestBody';
+import { openaiReasoningEffortToVertexThinkingBudget } from '../google-vertex-ai/transformGenerationConfig';
 import { VERTEX_MODALITY } from '../google-vertex-ai/types';
 import {
   getMimeType,
@@ -19,6 +20,8 @@ import {
   transformInputAudioPart,
   transformVertexLogprobs,
 } from '../google-vertex-ai/utils';
+
+const GEMINI_2_5_FAMILY_REGEX = /gemini-2[.-]?5/i;
 import {
   ChatCompletionResponse,
   ErrorResponse,
@@ -93,9 +96,19 @@ const transformGenerationConfig = (params: PortkeyGeminiParams) => {
     );
   }
   if (params.reasoning_effort && params.reasoning_effort !== 'none') {
-    generationConfig['thinkingConfig'] = {
-      thinkingLevel: params.reasoning_effort,
-    };
+    const model = (params.model ?? '') as string;
+    if (GEMINI_2_5_FAMILY_REGEX.test(model)) {
+      const thinkingBudget = openaiReasoningEffortToVertexThinkingBudget(
+        params.reasoning_effort
+      );
+      if (thinkingBudget !== undefined) {
+        generationConfig['thinkingConfig'] = { thinkingBudget };
+      }
+    } else {
+      generationConfig['thinkingConfig'] = {
+        thinkingLevel: params.reasoning_effort,
+      };
+    }
   }
   if (params.image_config) {
     generationConfig['imageConfig'] = {


### PR DESCRIPTION
## Problem

Closes #1639.

Vertex's `thinkingLevel` field (e.g. `LOW`/`MEDIUM`/`HIGH`) is recognized only on Gemini 3+. On Gemini 2.5 models it is silently dropped server-side. The current `reasoning_effort` transform emits `thinkingLevel` for **every** Gemini variant:

https://github.com/Portkey-AI/gateway/blob/main/src/providers/google-vertex-ai/transformGenerationConfig.ts#L68-L72

On `gemini-2.5-flash-lite` (the only 2.5 variant where `thinkingBudget` defaults to `0`), this results in **no reasoning tokens at all** when `reasoning_effort` is set via the OpenAI bare shorthand. The bug is masked on `gemini-2.5-flash` and `gemini-3-flash-preview` because those default to thinking-on.

## Solution

Branch the transform on the target Gemini family:

- **Gemini 2.5 family** (Flash, Flash-Lite, Pro) → emit `thinkingBudget` (integer)
- **Gemini 3+ / unknown** → emit `thinkingLevel` (enum), matching today's behavior

OpenAI `reasoning_effort` levels map to integers that are valid across all 2.5 variants (Flash/Flash-Lite range 512–24576, Pro range 128–32768):

| `reasoning_effort` | `thinkingBudget` |
| --- | --- |
| `minimal` | 512 |
| `low` | 4096 |
| `medium` | 16384 |
| `high` | 24576 |

Per the Vertex thinking docs: `thinkingLevel` (Gemini 3+) vs `thinkingBudget` (Gemini 2.5). The same fix is applied to both the Vertex AI path (`src/providers/google-vertex-ai/transformGenerationConfig.ts`) and the Google AI Studio path (`src/providers/google/chatComplete.ts`), since they share the bug.

## Testing

New unit tests in `src/providers/google-vertex-ai/transformGenerationConfig.test.ts` cover:

- The four `reasoning_effort` → `thinkingBudget` mappings
- `gemini-2.5-flash-lite` / `gemini-2.5-flash` / `gemini-2.5-pro` emit `thinkingBudget`
- `gemini-3-flash-preview` and unknown models keep `thinkingLevel`
- `reasoning_effort: "none"` and unknown effort values skip `thinkingConfig`

```bash
npx jest src/providers/google-vertex-ai/transformGenerationConfig.test.ts
# 12 passed
```