### PR TITLE
provider: add SaladCloud provider

### DIFF
--- a/src/data/providers.json
+++ b/src/data/providers.json
@@ -248,6 +248,13 @@
       "base_url": "https://api.sambanova.ai"
     },
     {
+      "id": "saladcloud",
+      "name": "SaladCloud",
+      "object": "provider",
+      "description": "SaladCloud AI Gateway provides OpenAI-compatible access to open-weight models, including Qwen chat models, with standard chat completions and streaming support.",
+      "base_url": "https://ai.salad.cloud/v1"
+    },
+    {
       "id": "segmind",
       "name": "Segmind",
       "object": "provider",

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -82,6 +82,7 @@ export const SILICONFLOW: string = 'siliconflow';
 export const CEREBRAS: string = 'cerebras';
 export const INFERENCENET: string = 'inference-net';
 export const SAMBANOVA: string = 'sambanova';
+export const SALADCLOUD: string = 'saladcloud';
 export const LEMONFOX_AI: string = 'lemonfox-ai';
 export const UPSTAGE: string = 'upstage';
 export const LAMBDA: string = 'lambda';
@@ -157,6 +158,7 @@ export const VALID_PROVIDERS = [
   CEREBRAS,
   INFERENCENET,
   SAMBANOVA,
+  SALADCLOUD,
   LEMONFOX_AI,
   UPSTAGE,
   LAMBDA,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,6 +74,7 @@ import OracleConfig from './oracle';
 import IOIntelligenceConfig from './iointelligence';
 import AIBadgrConfig from './aibadgr';
 import OVHcloudConfig from './ovhcloud';
+import SaladCloudConfig from './saladcloud';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -148,6 +149,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   iointelligence: IOIntelligenceConfig,
   aibadgr: AIBadgrConfig,
   ovhcloud: OVHcloudConfig,
+  saladcloud: SaladCloudConfig,
 };
 
 export default Providers;

--- a/src/providers/saladcloud/api.ts
+++ b/src/providers/saladcloud/api.ts
@@ -1,0 +1,18 @@
+import { ProviderAPIConfig } from '../types';
+
+const SaladCloudAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://ai.salad.cloud/v1',
+  headers: ({ providerOptions }) => ({
+    Authorization: `Bearer ${providerOptions.apiKey}`,
+  }),
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      default:
+        return '';
+    }
+  },
+};
+
+export default SaladCloudAPIConfig;

--- a/src/providers/saladcloud/index.test.ts
+++ b/src/providers/saladcloud/index.test.ts
@@ -1,0 +1,29 @@
+import { SALADCLOUD } from '../../globals';
+import SaladCloudAPIConfig from './api';
+
+describe('SaladCloud provider', () => {
+  const providerOptions = { provider: SALADCLOUD, apiKey: 'test-key' };
+
+  it('uses the SaladCloud OpenAI-compatible chat completions endpoint', () => {
+    const baseURLArgs = {
+      providerOptions,
+    } as Parameters<typeof SaladCloudAPIConfig.getBaseURL>[0];
+    const endpointArgs = {
+      fn: 'chatComplete',
+      providerOptions,
+    } as Parameters<typeof SaladCloudAPIConfig.getEndpoint>[0];
+    const headerArgs = {
+      providerOptions,
+    } as Parameters<typeof SaladCloudAPIConfig.headers>[0];
+
+    expect(SaladCloudAPIConfig.getBaseURL(baseURLArgs)).toEqual(
+      'https://ai.salad.cloud/v1'
+    );
+    expect(SaladCloudAPIConfig.getEndpoint(endpointArgs)).toEqual(
+      '/chat/completions'
+    );
+    expect(SaladCloudAPIConfig.headers(headerArgs)).toEqual({
+      Authorization: 'Bearer test-key',
+    });
+  });
+});

--- a/src/providers/saladcloud/index.ts
+++ b/src/providers/saladcloud/index.ts
@@ -1,0 +1,40 @@
+import { SALADCLOUD } from '../../globals';
+import { chatCompleteParams, responseTransformers } from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import SaladCloudAPIConfig from './api';
+
+const SaladCloudConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams(
+    [
+      'audio',
+      'logit_bias',
+      'logprobs',
+      'metadata',
+      'modalities',
+      'parallel_tool_calls',
+      'prediction',
+      'prompt_cache_key',
+      'reasoning_effort',
+      'safety_identifier',
+      'service_tier',
+      'store',
+      'top_logprobs',
+      'verbosity',
+      'web_search_options',
+    ],
+    { model: 'qwen3.6-35b-a3b' },
+    {
+      chat_template_kwargs: {
+        param: 'chat_template_kwargs',
+        required: true,
+        default: { enable_thinking: false },
+      },
+    }
+  ),
+  api: SaladCloudAPIConfig,
+  responseTransforms: responseTransformers(SALADCLOUD, {
+    chatComplete: true,
+  }),
+};
+
+export default SaladCloudConfig;

--- a/src/tests/resources/testVariables.ts
+++ b/src/tests/resources/testVariables.ts
@@ -142,6 +142,10 @@ const testVariables: TestVariables = {
       model: 'Qwen/Qwen2.5-Coder-3B-Instruct',
     },
   },
+  saladcloud: {
+    apiKey: process.env.SALADCLOUD_API_KEY || process.env.SALAD_CLOUD_API_KEY,
+    chatCompletions: { model: 'qwen3.6-35b-a3b' },
+  },
 };
 
 export default testVariables;


### PR DESCRIPTION
**Description:**
- Added SaladCloud as an OpenAI-compatible provider for chat completions.
- Registered `saladcloud` as a valid provider and added provider metadata.
- Added SaladCloud API routing for `https://ai.salad.cloud/v1/chat/completions`.
- Added SaladCloud test variables using `SALADCLOUD_API_KEY` or `SALAD_CLOUD_API_KEY`.
- Added a focused provider API config test.

**Tests Run/Test cases added:** (required)
- [x] Added `src/providers/saladcloud/index.test.ts` to verify SaladCloud base URL, chat completions endpoint, and authorization header.
- [x] Ran `npx jest --runTestsByPath src/providers/saladcloud/index.test.ts`.
- [x] Ran `npm run format:check`.
- [x] Ran `npm run build`.
- [x] Verified live non-streaming SaladCloud chat completion request returns `200`.
- [x] Verified live streaming SaladCloud chat completion request returns SSE chunks and `[DONE]`.

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
