### PR TITLE
feat: add Astraflow provider support

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -113,6 +113,8 @@ export const ORACLE: string = 'oracle';
 export const IO_INTELLIGENCE: string = 'iointelligence';
 export const AIBADGR: string = 'aibadgr';
 export const OVHCLOUD: string = 'ovhcloud';
+export const ASTRAFLOW: string = 'astraflow';
+export const ASTRAFLOW_CN: string = 'astraflow-cn';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -189,6 +191,8 @@ export const VALID_PROVIDERS = [
   IO_INTELLIGENCE,
   AIBADGR,
   OVHCLOUD,
+  ASTRAFLOW,
+  ASTRAFLOW_CN,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/astraflow-cn/api.ts
+++ b/src/providers/astraflow-cn/api.ts
@@ -1,0 +1,22 @@
+import { ProviderAPIConfig } from '../types';
+
+const AstraflowCNAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://api.modelverse.cn/v1',
+  headers: ({ providerOptions }) => {
+    return { Authorization: `Bearer ${providerOptions.apiKey}` };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      case 'complete':
+        return '/completions';
+      case 'embed':
+        return '/embeddings';
+      default:
+        return '';
+    }
+  },
+};
+
+export default AstraflowCNAPIConfig;

--- a/src/providers/astraflow-cn/index.ts
+++ b/src/providers/astraflow-cn/index.ts
@@ -1,0 +1,23 @@
+import { ASTRAFLOW_CN } from '../../globals';
+import {
+  chatCompleteParams,
+  completeParams,
+  embedParams,
+  responseTransformers,
+} from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import AstraflowCNAPIConfig from './api';
+
+const AstraflowCNConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams([], {}),
+  complete: completeParams([], {}),
+  embed: embedParams([], {}),
+  api: AstraflowCNAPIConfig,
+  responseTransforms: responseTransformers(ASTRAFLOW_CN, {
+    chatComplete: true,
+    complete: true,
+    embed: true,
+  }),
+};
+
+export default AstraflowCNConfig;

--- a/src/providers/astraflow/api.ts
+++ b/src/providers/astraflow/api.ts
@@ -1,0 +1,22 @@
+import { ProviderAPIConfig } from '../types';
+
+const AstraflowAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://api-us-ca.umodelverse.ai/v1',
+  headers: ({ providerOptions }) => {
+    return { Authorization: `Bearer ${providerOptions.apiKey}` };
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      case 'complete':
+        return '/completions';
+      case 'embed':
+        return '/embeddings';
+      default:
+        return '';
+    }
+  },
+};
+
+export default AstraflowAPIConfig;

--- a/src/providers/astraflow/index.ts
+++ b/src/providers/astraflow/index.ts
@@ -1,0 +1,23 @@
+import { ASTRAFLOW } from '../../globals';
+import {
+  chatCompleteParams,
+  completeParams,
+  embedParams,
+  responseTransformers,
+} from '../open-ai-base';
+import { ProviderConfigs } from '../types';
+import AstraflowAPIConfig from './api';
+
+const AstraflowConfig: ProviderConfigs = {
+  chatComplete: chatCompleteParams([], {}),
+  complete: completeParams([], {}),
+  embed: embedParams([], {}),
+  api: AstraflowAPIConfig,
+  responseTransforms: responseTransformers(ASTRAFLOW, {
+    chatComplete: true,
+    complete: true,
+    embed: true,
+  }),
+};
+
+export default AstraflowConfig;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,6 +74,8 @@ import OracleConfig from './oracle';
 import IOIntelligenceConfig from './iointelligence';
 import AIBadgrConfig from './aibadgr';
 import OVHcloudConfig from './ovhcloud';
+import AstraflowConfig from './astraflow';
+import AstraflowCNConfig from './astraflow-cn';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -148,6 +150,8 @@ const Providers: { [key: string]: ProviderConfigs } = {
   iointelligence: IOIntelligenceConfig,
   aibadgr: AIBadgrConfig,
   ovhcloud: OVHcloudConfig,
+  astraflow: AstraflowConfig,
+  'astraflow-cn': AstraflowCNConfig,
 };
 
 export default Providers;


### PR DESCRIPTION
**Description:** (required)
- Adds **Astraflow** (by UCloud / 优刻得) as a supported provider in Portkey Gateway. Astraflow is an OpenAI-compatible AI model aggregation platform supporting 200+ models.
- Because Astraflow is fully OpenAI-compatible, the integration reuses `open-ai-base` transforms and only requires a `base_url` + `api_key` — no new SDK or custom transform logic.
- Two provider entries are added to support both Astraflow regions: `astraflow` (global, `https://api-us-ca.umodelverse.ai/v1`, env var `ASTRAFLOW_API_KEY`) and `astraflow-cn` (China, `https://api.modelverse.cn/v1`, env var `ASTRAFLOW_CN_API_KEY`).
- `src/globals.ts`: Added `ASTRAFLOW` and `ASTRAFLOW_CN` constants; added both to `VALID_PROVIDERS`
- `src/providers/astraflow/api.ts`: New — API config with global base URL
- `src/providers/astraflow/index.ts`: New — provider config using `open-ai-base` transforms
- `src/providers/astraflow-cn/api.ts`: New — API config with China base URL
- `src/providers/astraflow-cn/index.ts`: New — provider config using `open-ai-base` transforms
- `src/providers/index.ts`: Imported and registered both new providers

**Tests Run/Test cases added:** (required)
- [ ] Description of test case

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)