### PR TITLE
docs: fix parameters typo in comments

### DIFF
--- a/src/providers/open-ai-base/index.ts
+++ b/src/providers/open-ai-base/index.ts
@@ -42,7 +42,7 @@ const excludeObjectKeys = (keyList: string[], object: Record<string, any>) => {
 
 /**
  *
- * @param exclude List of string that we should exclude from open-ai default paramters
+ * @param exclude List of string that we should exclude from open-ai default parameters
  * @param defaultValues Default values specific to the provider for params
  * @param extra Extra parameters type of ProviderConfig should extend to support the provider
  * @returns {ProviderConfig}
@@ -81,7 +81,7 @@ export const chatCompleteParams = (
 
 /**
  *
- * @param exclude List of string that we should exclude from open-ai default paramters
+ * @param exclude List of string that we should exclude from open-ai default parameters
  * @param defaultValues Default values specific to the provider for params
  * @param extra Extra parameters type of ProviderConfig should extend to support the provider
  * @returns {ProviderConfig}


### PR DESCRIPTION
## Problem
Two JSDoc comments in the OpenAI base provider helper spell "parameters" as "paramters".

## Solution
Correct the spelling in both comments.

## Validation
- `git diff --check`

## Confidence
85% — comment-only typo fix (low-risk, directly verifiable).
