### PR TITLE
docs: fix cookbook typos

### DIFF
--- a/cookbook/getting-started/automatic-retries-on-failures.md
+++ b/cookbook/getting-started/automatic-retries-on-failures.md
@@ -2,7 +2,7 @@
 
 A sudden timeout or error could harm the user experience and hurt your service's reputation if your application relies on an LLM for a critical feature. To prevent this, it's crucial to have a reliable retry mechanism in place. This will ensure that users are not left frustrated and can depend on your service.
 
-Retrying Requests to Large Langauge Models (LLMs) can significantly increase your Gen AI app's reliability.
+Retrying Requests to Large Language Models (LLMs) can significantly increase your Gen AI app's reliability.
 
 It can help you handle cases such as:
 

--- a/cookbook/getting-started/writing-your-first-gateway-config.md
+++ b/cookbook/getting-started/writing-your-first-gateway-config.md
@@ -291,7 +291,7 @@ console.log(chatCompletion.choices[0].message.content);
 
 Those are three ways to use Gateway Configs in your requests.
 
-In the cases where you want to specifically add a config for a specific request instead of all, Portkey allows you to pass `config` argument as seperate objects right at the time of chat completions call instead of `Portkey({..})` instantiation.
+In the cases where you want to specifically add a config for a specific request instead of all, Portkey allows you to pass `config` argument as separate objects right at the time of chat completions call instead of `Portkey({..})` instantiation.
 
 ```js
 const response = await portkey.chat.completions.create(


### PR DESCRIPTION
## Problem
Two Gateway cookbook pages contain visible spelling mistakes: "Langauge" and "seperate".

## Solution
Correct those terms to "Language" and "separate" in the getting-started cookbook docs.

## Validation
- `git diff --check`
- `grep` assertion that touched files no longer contain `Langauge` or `seperate`

Confidence: 85/100 (docs/typo).