### PR TITLE
Add jittered retry backoff controls

### DIFF
--- a/cookbook/getting-started/automatic-retries-on-failures.md
+++ b/cookbook/getting-started/automatic-retries-on-failures.md
@@ -26,7 +26,7 @@ Import `Portkey` and instantiate it using the Portkey API Key
 ```js
 const portkey = new Portkey({
   apiKey: 'xxxxrk',
-  virtualKey: 'maixxx4d'
+  virtualKey: 'maixxx4d',
 });
 ```
 
@@ -51,6 +51,21 @@ A typical Gateway Config to automatically retry three times when you hit rate-li
 
 You created a `retry` object with `attempts` and `on_status_codes` keys. The value of `attempts` can be bumped up to `5` times to retry automatically, while `on_status_codes` is an optional key. By default, Portkey will attempt to retry on the status codes `[429, 500, 502, 503, 504]`.
 
+Retries use randomized exponential backoff by default so that many requests hitting a transient provider 5xx or 429 do not retry on the same fixed schedule. You can tune the retry delay window when a workload needs tighter tail-latency control:
+
+```js
+{
+   retry: {
+      attempts: 3,
+      on_status_codes: [429, 500, 502, 503, 504],
+      min_timeout: 250,
+      max_timeout: 2000,
+      factor: 1.5,
+      randomize: true
+    }
+}
+```
+
 Refer to the [101 on Gateway Configs](https://github.com/Portkey-AI/portkey-cookbook/blob/main/product/101-portkey-gateway-configs.md#a-reference-gateway-configs-from-the-ui) and [Automatic Retries](https://portkey.ai/docs/product/ai-gateway-streamline-llm-integrations/automatic-retries).
 
 ## 3. Make API calls using Portkey Client SDK
@@ -64,17 +79,17 @@ let response = await portkey.chat.completions.create(
     messages: [
       {
         role: 'user',
-        content: 'What are 7 wonders of the world?'
-      }
-    ]
+        content: 'What are 7 wonders of the world?',
+      },
+    ],
   },
   {
     config: JSON.stringify({
       retry: {
         attempts: 3,
-        on_status_codes: [429]
-      }
-    })
+        on_status_codes: [429],
+      },
+    }),
   }
 );
 
@@ -104,7 +119,7 @@ import { Portkey } from 'portkey-ai';
 
 const portkey = new Portkey({
   apiKey: xxxx,
-  virtualKey: 'xaixxxxxxx2xx4d'
+  virtualKey: 'xaixxxxxxx2xx4d',
 });
 
 let response = await portkey.chat.completions.create(
@@ -113,16 +128,16 @@ let response = await portkey.chat.completions.create(
     messages: [
       {
         role: 'user',
-        content: 'What are 7 wonders of the world?'
-      }
-    ]
+        content: 'What are 7 wonders of the world?',
+      },
+    ],
   },
   {
     config: JSON.stringify({
       retry: {
-        attempts: 3
-      }
-    })
+        attempts: 3,
+      },
+    }),
   }
 );
 

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -1221,7 +1221,8 @@ export async function recursiveAfterRequestHookHandler(
     retry.onStatusCodes,
     requestTimeout,
     requestHandler,
-    retry.useRetryAfterHeader
+    retry.useRetryAfterHeader,
+    retry
   ));
 
   // Check if sync hooks are available

--- a/src/handlers/retryHandler.ts
+++ b/src/handlers/retryHandler.ts
@@ -1,5 +1,11 @@
 import retry from 'async-retry';
 import { MAX_RETRY_LIMIT_MS, POSSIBLE_RETRY_STATUS_HEADERS } from '../globals';
+import type { RetrySettings } from '../types/requestBody';
+
+type RetryBackoffOptions = Pick<
+  RetrySettings,
+  'minTimeout' | 'maxTimeout' | 'factor' | 'randomize'
+>;
 
 async function fetchWithTimeout(
   url: string,
@@ -69,7 +75,8 @@ export const retryRequest = async (
   statusCodesToRetry: number[],
   timeout: number | null,
   requestHandler?: () => Promise<Response>,
-  followProviderRetry?: boolean
+  followProviderRetry?: boolean,
+  retryBackoffOptions?: RetryBackoffOptions
 ): Promise<{
   response: Response;
   attempt: number | undefined;
@@ -176,7 +183,16 @@ export const retryRequest = async (
         onRetry: (error: Error, attempt: number) => {
           lastAttempt = attempt;
         },
-        randomize: false,
+        randomize: retryBackoffOptions?.randomize ?? true,
+        ...(retryBackoffOptions?.minTimeout !== undefined && {
+          minTimeout: retryBackoffOptions.minTimeout,
+        }),
+        ...(retryBackoffOptions?.maxTimeout !== undefined && {
+          maxTimeout: retryBackoffOptions.maxTimeout,
+        }),
+        ...(retryBackoffOptions?.factor !== undefined && {
+          factor: retryBackoffOptions.factor,
+        }),
       }
     );
   } catch (error: any) {

--- a/src/handlers/services/requestContext.ts
+++ b/src/handlers/services/requestContext.ts
@@ -146,13 +146,28 @@ export class RequestContext {
   }
 
   private normalizeRetryConfig(retry?: RetrySettings): RetrySettings {
-    return {
+    const normalizedRetryConfig: RetrySettings = {
       attempts: retry?.attempts ?? 0,
       onStatusCodes: retry?.attempts
         ? retry?.onStatusCodes ?? RETRY_STATUS_CODES
         : [],
       useRetryAfterHeader: retry?.useRetryAfterHeader,
     };
+
+    if (retry?.minTimeout !== undefined) {
+      normalizedRetryConfig.minTimeout = retry.minTimeout;
+    }
+    if (retry?.maxTimeout !== undefined) {
+      normalizedRetryConfig.maxTimeout = retry.maxTimeout;
+    }
+    if (retry?.factor !== undefined) {
+      normalizedRetryConfig.factor = retry.factor;
+    }
+    if (retry?.randomize !== undefined) {
+      normalizedRetryConfig.randomize = retry.randomize;
+    }
+
+    return normalizedRetryConfig;
   }
 
   get retryConfig(): RetrySettings {

--- a/src/middlewares/requestValidator/schema/config.ts
+++ b/src/middlewares/requestValidator/schema/config.ts
@@ -69,6 +69,10 @@ export const configSchema: any = z
         attempts: z.number(),
         on_status_codes: z.array(z.number()).optional(),
         use_retry_after_header: z.boolean().optional(),
+        min_timeout: z.number().nonnegative().optional(),
+        max_timeout: z.number().positive().optional(),
+        factor: z.number().positive().optional(),
+        randomize: z.boolean().optional(),
       })
       .refine((value) => value.attempts !== undefined, {
         message: "'retry.attempts' must be defined",

--- a/src/types/requestBody.ts
+++ b/src/types/requestBody.ts
@@ -12,6 +12,14 @@ export interface RetrySettings {
   onStatusCodes: number[];
   /** Whether to use the provider's retry wait. */
   useRetryAfterHeader?: boolean;
+  /** Initial retry delay in milliseconds. */
+  minTimeout?: number;
+  /** Maximum retry delay in milliseconds. */
+  maxTimeout?: number;
+  /** Exponential backoff factor. */
+  factor?: number;
+  /** Whether to randomize retry delays to avoid synchronized retries. */
+  randomize?: boolean;
 }
 
 export interface CacheSettings {

--- a/tests/unit/src/handlers/retryHandler.test.ts
+++ b/tests/unit/src/handlers/retryHandler.test.ts
@@ -1,0 +1,65 @@
+import retry from 'async-retry';
+import { retryRequest } from '../../../../src/handlers/retryHandler';
+
+jest.mock('async-retry', () => ({
+  __esModule: true,
+  default: jest.fn(async (handler) => {
+    await handler(jest.fn(), 1, { _timeouts: [] });
+  }),
+}));
+
+const mockedRetry = retry as jest.Mock;
+
+describe('retryRequest retry backoff options', () => {
+  beforeEach(() => {
+    mockedRetry.mockClear();
+  });
+
+  it('randomizes retry backoff by default to avoid synchronized retry bursts', async () => {
+    await retryRequest(
+      'https://api.example.com',
+      {},
+      2,
+      [503],
+      null,
+      jest.fn().mockResolvedValue(new Response('ok', { status: 200 }))
+    );
+
+    expect(mockedRetry).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        retries: 2,
+        randomize: true,
+      })
+    );
+  });
+
+  it('passes bounded retry backoff settings through to async-retry', async () => {
+    await retryRequest(
+      'https://api.example.com',
+      {},
+      3,
+      [429, 503],
+      null,
+      jest.fn().mockResolvedValue(new Response('ok', { status: 200 })),
+      false,
+      {
+        minTimeout: 250,
+        maxTimeout: 2_000,
+        factor: 1.5,
+        randomize: false,
+      }
+    );
+
+    expect(mockedRetry).toHaveBeenCalledWith(
+      expect.any(Function),
+      expect.objectContaining({
+        retries: 3,
+        minTimeout: 250,
+        maxTimeout: 2_000,
+        factor: 1.5,
+        randomize: false,
+      })
+    );
+  });
+});


### PR DESCRIPTION
## Summary
- default gateway retries to randomized exponential backoff so transient 5xx/429 bursts do not retry on a fixed synchronized schedule
- add retry config knobs for `min_timeout`, `max_timeout`, `factor`, and `randomize`, wired through validation, request context, and `retryRequest`
- document the bounded backoff config in the automatic retries cookbook

## Why
Issue #1404 reports retry-induced p95/p99 tail amplification during upstream turbulence. The previous `retryRequest` path passed `randomize: false` to `async-retry`, which can make many retrying requests fire again on the same deterministic cadence. This gives operators a small, backwards-compatible way to jitter and bound retry delays while preserving the existing attempts/status-code behavior.

## Validation
- `npx jest tests/unit/src/handlers/retryHandler.test.ts --runInBand`
- `npx prettier --check cookbook/getting-started/automatic-retries-on-failures.md src/handlers/retryHandler.ts src/handlers/handlerUtils.ts src/handlers/services/requestContext.ts src/middlewares/requestValidator/schema/config.ts src/types/requestBody.ts tests/unit/src/handlers/retryHandler.test.ts`
- `git diff --check`
- `npm run build` (passes; existing repo warnings about external deps/circular deps and pre-existing provider type warnings still appear)

Closes #1404