### PR TITLE
feat(lakera): add Lakera Guard plugin with Anthropic and apiBase support

### DIFF
--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -66,6 +66,7 @@ import { handler as javelinguardrails } from './javelin/guardrails';
 import { handler as f5GuardrailsScan } from './f5-guardrails/scan';
 import { handler as azureShieldPrompt } from './azure/shieldPrompt';
 import { handler as azureProtectedMaterial } from './azure/protectedMaterial';
+import { handler as lakeraguard } from './lakera/guard';
 import { handler as crowdstrikeAidrGuardChatCompletions } from './crowdstrike-aidr/guardChatCompletion';
 
 export const plugins = {
@@ -176,6 +177,9 @@ export const plugins = {
   },
   'f5-guardrails': {
     scan: f5GuardrailsScan,
+  },
+  lakera: {
+    guard: lakeraguard,
   },
   'crowdstrike-aidr': {
     guardChatCompletions: crowdstrikeAidrGuardChatCompletions,

--- a/plugins/lakera/guard.test.ts
+++ b/plugins/lakera/guard.test.ts
@@ -1,0 +1,333 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import {
+  applyMasksToMessages,
+  applyPayloadMasksToString,
+  dedupePayloadItems,
+  isOnlyPiiViolation,
+  mergeOverlappingIntervals,
+  normalizeSpan,
+} from './redaction';
+import { handler, resolveGuardUrl, extractScreeningMessages } from './guard';
+
+global.fetch = jest.fn() as any;
+
+const baseContext = {
+  request: {
+    json: { messages: [{ role: 'user', content: 'hello world' }] },
+    text: 'hello world',
+  },
+  requestType: 'chatComplete' as const,
+};
+
+const baseParams = {
+  credentials: { apiKey: 'test-api-key' },
+};
+
+function mockFetchResponse(body: object, ok = true) {
+  (global.fetch as any).mockResolvedValueOnce({
+    ok,
+    status: ok ? 200 : 400,
+    statusText: ok ? 'OK' : 'Bad Request',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  });
+}
+
+describe('lakera redaction helpers', () => {
+  it('mergeOverlappingIntervals merges overlap and adjacent', () => {
+    expect(
+      mergeOverlappingIntervals([
+        [0, 3],
+        [2, 5],
+      ])
+    ).toEqual([[0, 5]]);
+    expect(
+      mergeOverlappingIntervals([
+        [0, 2],
+        [2, 4],
+      ])
+    ).toEqual([[0, 4]]);
+    expect(
+      mergeOverlappingIntervals([
+        [0, 1],
+        [5, 6],
+      ])
+    ).toEqual([
+      [0, 1],
+      [5, 6],
+    ]);
+  });
+
+  it('dedupePayloadItems', () => {
+    const items = [
+      { message_id: 0, start: 1, end: 2, detector_type: 'pii/a' },
+      { message_id: 0, start: 1, end: 2, detector_type: 'pii/a' },
+    ];
+    expect(dedupePayloadItems(items)).toHaveLength(1);
+  });
+
+  it('normalizeSpan half-open', () => {
+    expect(normalizeSpan(0, 3, 10, false)).toEqual([0, 3]);
+    expect(normalizeSpan(0, 11, 10, false)).toBeNull();
+  });
+
+  it('two non-overlapping spans', () => {
+    const text = 'hello SECRET1 world SECRET2 end';
+    const payload = [
+      { message_id: 0, start: 6, end: 13, detector_type: 'pii/foo' },
+      { message_id: 0, start: 20, end: 27, detector_type: 'pii/bar' },
+    ];
+    const { text: out } = applyPayloadMasksToString(text, payload, 0, false);
+    expect(out).not.toContain('SECRET1');
+    expect(out).not.toContain('SECRET2');
+    expect(out).toContain('[MASKED_');
+  });
+
+  it('overlapping spans merged once', () => {
+    const text = '0123456789';
+    const payload = [
+      { message_id: 0, start: 2, end: 5, detector_type: 'pii/a' },
+      { message_id: 0, start: 4, end: 7, detector_type: 'pii/b' },
+    ];
+    const { text: out } = applyPayloadMasksToString(text, payload, 0, false);
+    expect(out.split('[MASKED_').length - 1).toBe(1);
+  });
+
+  it('unicode emoji index', () => {
+    const text = 'hi 👋 there';
+    const i = text.indexOf('👋');
+    const payload = [
+      { message_id: 0, start: i, end: i + 1, detector_type: 'pii/x' },
+    ];
+    const { text: out } = applyPayloadMasksToString(text, payload, 0, false);
+    expect(out).not.toContain('👋');
+    expect(out).toContain('[MASKED_');
+  });
+
+  it('invalid span skipped', () => {
+    const text = 'short';
+    const payload = [
+      { message_id: 0, start: 0, end: 99, detector_type: 'pii/x' },
+    ];
+    const { text: out, warnings } = applyPayloadMasksToString(
+      text,
+      payload,
+      0,
+      false
+    );
+    expect(out).toBe(text);
+    expect(warnings.length).toBeGreaterThan(0);
+  });
+
+  it('message_id isolation', () => {
+    const msgs = [
+      { role: 'user', content: 'aaa' },
+      { role: 'user', content: 'bbb' },
+    ];
+    const payload = [
+      { message_id: 1, start: 0, end: 1, detector_type: 'pii/x' },
+    ];
+    const { messages: out } = applyMasksToMessages(msgs, payload, false);
+    expect(out[0].content).toBe('aaa');
+    expect(out[1].content).not.toBe('bbb');
+  });
+
+  it('isOnlyPiiViolation', () => {
+    expect(isOnlyPiiViolation([])).toBe(false);
+    expect(
+      isOnlyPiiViolation([{ detected: true, detector_type: 'prompt_attack' }])
+    ).toBe(false);
+    expect(
+      isOnlyPiiViolation([{ detected: true, detector_type: 'pii/email' }])
+    ).toBe(true);
+  });
+});
+
+describe('lakera guard handler', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns verdict=true when flagged=false', async () => {
+    mockFetchResponse({ flagged: false, breakdown: [], payload: [] });
+    const result = await handler(baseContext, baseParams, 'beforeRequestHook');
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(true);
+    expect(result.transformed).toBeFalsy();
+  });
+
+  it('returns verdict=false when non-PII policy fires', async () => {
+    mockFetchResponse({
+      flagged: true,
+      breakdown: [{ detected: true, detector_type: 'prompt_attack' }],
+      payload: [],
+    });
+    const result = await handler(baseContext, baseParams, 'beforeRequestHook');
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(false);
+    expect(result.transformed).toBeFalsy();
+  });
+
+  it('redacts and transforms when only pii/* detectors fire', async () => {
+    const content = 'my email is test@example.com';
+    const context = {
+      request: {
+        json: { messages: [{ role: 'user', content }] },
+        text: content,
+      },
+      requestType: 'chatComplete' as const,
+    };
+    mockFetchResponse({
+      flagged: true,
+      breakdown: [{ detected: true, detector_type: 'pii/email' }],
+      payload: [
+        { message_id: 0, start: 12, end: 28, detector_type: 'pii/email' },
+      ],
+    });
+    const result = await handler(context, baseParams, 'beforeRequestHook');
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(true);
+    expect(result.transformed).toBe(true);
+    expect(
+      result.transformedData?.request?.json?.messages?.[0]?.content
+    ).not.toContain('test@example.com');
+  });
+
+  it('returns error when apiKey is missing', async () => {
+    const result = await handler(
+      baseContext,
+      { credentials: {} },
+      'beforeRequestHook'
+    );
+    expect(result.verdict).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('returns verdict=true with explanation when there is no text to screen', async () => {
+    const emptyContext = {
+      request: {
+        json: { messages: [{ role: 'user', content: '' }] },
+        text: '',
+      },
+      requestType: 'chatComplete' as const,
+    };
+    const result = await handler(emptyContext, baseParams, 'beforeRequestHook');
+    expect(result.verdict).toBe(true);
+    expect(result.data?.explanation).toBe('no messages to screen');
+  });
+
+  it('handles fetch errors gracefully', async () => {
+    (global.fetch as any).mockRejectedValueOnce(new Error('network failure'));
+    const result = await handler(baseContext, baseParams, 'beforeRequestHook');
+    expect(result.verdict).toBe(false);
+    expect(result.error).toBeDefined();
+  });
+
+  it('redacts PII in Anthropic messages format', async () => {
+    mockFetchResponse({
+      flagged: true,
+      breakdown: [{ detected: true, detector_type: 'pii/email' }],
+      payload: [
+        { message_id: 1, start: 12, end: 28, detector_type: 'pii/email' },
+      ],
+    });
+    const result = await handler(
+      {
+        requestType: 'messages',
+        request: {
+          json: {
+            system: 'You are helpful.',
+            messages: [
+              {
+                role: 'user',
+                content: [
+                  { type: 'text', text: 'my email is test@example.com' },
+                ],
+              },
+            ],
+          },
+        },
+      },
+      baseParams,
+      'beforeRequestHook'
+    );
+    expect(result.verdict).toBe(true);
+    expect(result.transformed).toBe(true);
+    expect(
+      result.transformedData?.request?.json?.messages?.[0]?.content?.[0]?.text
+    ).not.toContain('test@example.com');
+  });
+
+  it('sends full conversation history for Anthropic requests', async () => {
+    mockFetchResponse({ flagged: false, breakdown: [], payload: [] });
+    await handler(
+      {
+        requestType: 'messages',
+        request: {
+          json: {
+            system: 'System prompt',
+            messages: [
+              { role: 'user', content: 'first turn' },
+              { role: 'user', content: 'second turn' },
+            ],
+          },
+        },
+      },
+      baseParams,
+      'beforeRequestHook'
+    );
+    const body = JSON.parse((global.fetch as any).mock.calls[0][1].body);
+    expect(body.messages).toHaveLength(3);
+    expect(body.messages[0]).toEqual({
+      role: 'system',
+      content: 'System prompt',
+    });
+  });
+
+  it('strips /v2/guard from apiBase when user pastes the full endpoint', async () => {
+    mockFetchResponse({ flagged: false, breakdown: [], payload: [] });
+    await handler(
+      baseContext,
+      {
+        credentials: {
+          apiKey: 'test-api-key',
+          apiBase: 'https://api.lakera.ai/v2/guard',
+        },
+      },
+      'beforeRequestHook'
+    );
+    expect((global.fetch as any).mock.calls[0][0]).toBe(
+      'https://api.lakera.ai/v2/guard'
+    );
+  });
+});
+
+describe('lakera guard helpers', () => {
+  it('resolveGuardUrl normalizes apiBase', () => {
+    expect(resolveGuardUrl('https://api.lakera.ai/v2/guard')).toBe(
+      'https://api.lakera.ai/v2/guard'
+    );
+    expect(resolveGuardUrl('api.lakera.ai')).toBe(
+      'https://api.lakera.ai/v2/guard'
+    );
+  });
+
+  it('extractScreeningMessages maps Anthropic system field', () => {
+    const extracted = extractScreeningMessages(
+      {
+        requestType: 'messages',
+        request: {
+          json: {
+            system: 'You are helpful.',
+            messages: [{ role: 'user', content: 'Hi' }],
+          },
+        },
+      },
+      'beforeRequestHook'
+    );
+    expect(extracted?.messages[0]).toEqual({
+      role: 'system',
+      content: 'You are helpful.',
+    });
+  });
+});

--- a/plugins/lakera/guard.ts
+++ b/plugins/lakera/guard.ts
@@ -1,0 +1,480 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+} from '../types';
+import { HttpError, post } from '../utils';
+import {
+  applyMasksToMessages,
+  isOnlyPiiViolation,
+  type PayloadItem,
+} from './redaction';
+
+type ScreeningMessage = { role: string; content: string };
+
+/**
+ * Tracks where each screening message came from so PII redaction can be written
+ * back into the correct field (Anthropic system, request.messages[i], response, …).
+ */
+type MessageSource =
+  | { type: 'anthropic_system'; originalContent: unknown }
+  | { type: 'request_message'; index: number; originalContent: unknown }
+  | { type: 'request_text' }
+  | { type: 'response_openai'; originalContent: unknown }
+  | { type: 'response_anthropic'; originalContent: unknown };
+
+export function contentToScreeningText(content: unknown): string {
+  if (content == null) return '';
+  if (typeof content === 'string') return content;
+
+  if (Array.isArray(content)) {
+    const textParts: string[] = [];
+    for (const item of content) {
+      // Only text blocks are screened; images/tools are skipped (no text to send).
+      if (item?.type === 'text' && item.text != null) {
+        textParts.push(String(item.text));
+      }
+    }
+    // Join blocks with newline — matches how Lakera indexes span offsets.
+    return textParts.join('\n');
+  }
+
+  if (typeof content === 'object') {
+    try {
+      return JSON.stringify(content);
+    } catch {
+      return '';
+    }
+  }
+
+  return String(content);
+}
+
+/** Build the Lakera Guard endpoint URL from an optional apiBase credential. */
+export function resolveGuardUrl(apiBase?: string): string {
+  const defaultBase = 'https://api.lakera.ai';
+  // Trim whitespace and trailing slashes from user input.
+  let base = String(apiBase ?? defaultBase)
+    .trim()
+    .replace(/\/+$/, '');
+
+  // User may paste the full endpoint; strip /v2/guard so we do not double it.
+  if (/\/v2\/guard$/i.test(base)) {
+    base = base.replace(/\/v2\/guard$/i, '');
+  }
+
+  // Allow bare hostnames like "api.lakera.ai" without a scheme.
+  if (!/^https?:\/\//i.test(base)) {
+    base = `https://${base}`;
+  }
+
+  return `${base.replace(/\/+$/, '')}/v2/guard`;
+}
+
+/**
+ * Write masked plain text back into the original content shape.
+ * Strings stay strings; content block arrays update the first text block.
+ */
+function setContentFromMasked(
+  originalContent: unknown,
+  maskedText: string
+): unknown {
+  if (originalContent == null || typeof originalContent === 'string') {
+    return maskedText;
+  }
+
+  if (Array.isArray(originalContent)) {
+    const textBlockIndexes = originalContent
+      .map((item, index) => (item?.type === 'text' ? index : -1))
+      .filter((index) => index >= 0);
+
+    if (textBlockIndexes.length === 0) {
+      return [{ type: 'text', text: maskedText }];
+    }
+
+    const updated = originalContent.map((item) => ({ ...item }));
+    updated[textBlockIndexes[0]].text = maskedText;
+    // Clear extra text blocks — spans were computed on the joined string.
+    for (let i = 1; i < textBlockIndexes.length; i++) {
+      updated[textBlockIndexes[i]].text = '';
+    }
+    return updated;
+  }
+
+  return maskedText;
+}
+
+/**
+ * Build the messages[] payload for Lakera and a parallel source map for redaction.
+ * Returns null when there is nothing to screen.
+ */
+export function extractScreeningMessages(
+  context: PluginContext,
+  eventType: HookEventType
+): { messages: ScreeningMessage[]; sources: MessageSource[] } | null {
+  const reqJson = context.request?.json || {};
+  const messages: ScreeningMessage[] = [];
+  const sources: MessageSource[] = [];
+
+  // Anthropic keeps system prompt outside messages[] — Lakera wants role "system".
+  if (reqJson.system != null) {
+    const text = contentToScreeningText(reqJson.system);
+    if (text) {
+      messages.push({ role: 'system', content: text });
+      sources.push({
+        type: 'anthropic_system',
+        originalContent: reqJson.system,
+      });
+    }
+  }
+
+  if (Array.isArray(reqJson.messages)) {
+    for (let i = 0; i < reqJson.messages.length; i++) {
+      const msg = reqJson.messages[i];
+      messages.push({
+        role: msg?.role || 'user',
+        content: contentToScreeningText(msg?.content),
+      });
+      sources.push({
+        type: 'request_message',
+        index: i,
+        originalContent: msg?.content,
+      });
+    }
+  }
+
+  // After-hook: append the model response so Lakera can screen output too.
+  if (eventType === 'afterRequestHook') {
+    appendAssistantResponse(context, messages, sources);
+  }
+
+  // Fallback when the body has no messages[] (plain text hooks).
+  if (messages.length === 0) {
+    appendPlainTextFallback(context, eventType, messages, sources);
+  }
+
+  return messages.length ? { messages, sources } : null;
+}
+
+/** Append assistant text from the response JSON (Anthropic or OpenAI shape). */
+function appendAssistantResponse(
+  context: PluginContext,
+  messages: ScreeningMessage[],
+  sources: MessageSource[]
+): void {
+  const respJson = context.response?.json || {};
+
+  if (context.requestType === 'messages' && Array.isArray(respJson.content)) {
+    const text = contentToScreeningText(respJson.content);
+    if (text) {
+      messages.push({ role: 'assistant', content: text });
+      sources.push({
+        type: 'response_anthropic',
+        originalContent: respJson.content,
+      });
+    }
+    return;
+  }
+
+  const firstChoice = respJson.choices?.[0];
+  if (firstChoice?.message?.content != null) {
+    messages.push({
+      role: firstChoice.message.role || 'assistant',
+      content: contentToScreeningText(firstChoice.message.content),
+    });
+    sources.push({
+      type: 'response_openai',
+      originalContent: firstChoice.message.content,
+    });
+  } else if (firstChoice?.text != null) {
+    messages.push({ role: 'assistant', content: String(firstChoice.text) });
+    sources.push({
+      type: 'response_openai',
+      originalContent: firstChoice.text,
+    });
+  }
+}
+
+/** Last-resort extraction from request.text / response.text. */
+function appendPlainTextFallback(
+  context: PluginContext,
+  eventType: HookEventType,
+  messages: ScreeningMessage[],
+  sources: MessageSource[]
+): void {
+  const text = context.request?.text;
+  if (typeof text === 'string' && text.trim()) {
+    messages.push({ role: 'user', content: text.trim() });
+    sources.push({ type: 'request_text' });
+  }
+
+  if (eventType === 'afterRequestHook') {
+    const respText = context.response?.text;
+    if (typeof respText === 'string' && respText.trim()) {
+      messages.push({ role: 'assistant', content: respText.trim() });
+      sources.push({
+        type: 'response_anthropic',
+        originalContent: respText.trim(),
+      });
+    }
+  }
+}
+
+/** Write Lakera PII masks back into the original Portkey request/response. */
+function applyMaskedToContext(
+  context: PluginContext,
+  eventType: HookEventType,
+  sources: MessageSource[],
+  maskedMessages: Array<Record<string, unknown>>,
+  transformedData: Record<string, any>
+): boolean {
+  if (sources.length !== maskedMessages.length) {
+    return false;
+  }
+
+  const reqJson = context.request?.json
+    ? JSON.parse(JSON.stringify(context.request.json))
+    : {};
+  const respJson = context.response?.json
+    ? JSON.parse(JSON.stringify(context.response.json))
+    : {};
+  let requestChanged = false;
+  let responseChanged = false;
+
+  for (let i = 0; i < sources.length; i++) {
+    const source = sources[i];
+    const maskedContent = String(maskedMessages[i].content ?? '');
+
+    switch (source.type) {
+      case 'anthropic_system':
+        reqJson.system = setContentFromMasked(
+          source.originalContent,
+          maskedContent
+        );
+        requestChanged = true;
+        break;
+      case 'request_message':
+        if (source.index >= 0 && Array.isArray(reqJson.messages)) {
+          reqJson.messages[source.index] = {
+            ...reqJson.messages[source.index],
+            content: setContentFromMasked(
+              source.originalContent,
+              maskedContent
+            ),
+          };
+          requestChanged = true;
+        }
+        break;
+      case 'request_text':
+        transformedData.request.text = maskedContent;
+        requestChanged = true;
+        break;
+      case 'response_openai':
+        if (respJson.choices?.[0]?.message) {
+          respJson.choices[0].message = {
+            ...respJson.choices[0].message,
+            content: setContentFromMasked(
+              source.originalContent,
+              maskedContent
+            ),
+          };
+          responseChanged = true;
+        } else if (respJson.choices?.[0]) {
+          respJson.choices[0].text = maskedContent;
+          responseChanged = true;
+        }
+        break;
+      case 'response_anthropic':
+        respJson.content = setContentFromMasked(
+          source.originalContent,
+          maskedContent
+        );
+        responseChanged = true;
+        break;
+    }
+  }
+
+  if (requestChanged) {
+    transformedData.request.json = reqJson;
+  }
+  if (responseChanged && eventType === 'afterRequestHook') {
+    transformedData.response.json = respJson;
+  }
+
+  return requestChanged || responseChanged;
+}
+
+function portkeyMetadataToLakera(
+  meta: Record<string, unknown> | undefined
+): Record<string, unknown> | undefined {
+  if (!meta || typeof meta !== 'object') return undefined;
+  const out: Record<string, unknown> = {};
+  const u = meta._user ?? meta.user_id;
+  if (u != null) out.user_id = String(u);
+  if (meta.session_id != null) out.session_id = String(meta.session_id);
+  if (meta.ip_address != null) out.ip_address = String(meta.ip_address);
+  return Object.keys(out).length ? out : undefined;
+}
+
+function formatHttpError(error: HttpError, url: string): Error {
+  if (error.response?.status === 404) {
+    return new Error(
+      `Lakera Guard endpoint not found (${url}). Set apiBase to the host only (e.g. https://api.lakera.ai), not the /v2/guard path.`
+    );
+  }
+  return error;
+}
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+) => {
+  let error: any = null;
+  let verdict = false;
+  let data: any = null;
+  let transformed = false;
+  const transformedData: Record<string, any> = {
+    request: { json: null, text: null },
+    response: { json: null, text: null },
+  };
+
+  const url = resolveGuardUrl(
+    parameters.credentials?.apiBase as string | undefined
+  );
+
+  try {
+    const apiKey = parameters.credentials?.apiKey as string | undefined;
+    if (!apiKey) {
+      throw new Error(
+        'Missing Lakera apiKey: set credentials.apiKey in the guardrail config'
+      );
+    }
+    const projectID = parameters.project_id ?? parameters.projectID;
+
+    const extracted = extractScreeningMessages(context, eventType);
+    if (
+      !extracted?.messages.length ||
+      !extracted.messages.some((m) => m.content.trim())
+    ) {
+      return {
+        error: null,
+        verdict: true,
+        data: { explanation: 'no messages to screen' },
+      };
+    }
+
+    const { messages, sources } = extracted;
+
+    const body: Record<string, unknown> = {
+      messages,
+      payload: true,
+      breakdown: true,
+    };
+    if (projectID) {
+      body.project_id = projectID;
+    }
+    const lm = portkeyMetadataToLakera(
+      context.metadata as Record<string, unknown>
+    );
+    if (lm) body.metadata = lm;
+
+    const lakeraResp: any = await post(
+      url,
+      body,
+      {
+        headers: {
+          Authorization: `Bearer ${apiKey}`,
+          'Content-Type': 'application/json',
+        },
+      },
+      parameters.timeout || 30000
+    );
+
+    const flagged = Boolean(lakeraResp.flagged);
+    const breakdown = lakeraResp.breakdown || [];
+    const payload = (lakeraResp.payload || []) as PayloadItem[];
+
+    const safeLog = { ...lakeraResp };
+    delete safeLog.payload;
+    delete safeLog.breakdown;
+    data = {
+      lakera: {
+        ...safeLog,
+        detectedTypes: breakdown
+          .filter((b: any) => b.detected)
+          .map((b: any) => b.detector_type),
+      },
+    };
+
+    if (!flagged) {
+      verdict = true;
+      return { error, verdict, data };
+    }
+
+    const endInclusive = Boolean(parameters.endInclusive);
+
+    if (isOnlyPiiViolation(breakdown) && payload.length > 0) {
+      const { messages: maskedMsgs, warnings } = applyMasksToMessages(
+        messages,
+        payload,
+        endInclusive
+      );
+
+      if (warnings.some((w) => w.includes('multimodal'))) {
+        verdict = false;
+        return {
+          error,
+          verdict,
+          data: {
+            ...data,
+            warnings,
+            explanation:
+              'multimodal content cannot be masked in this plugin build',
+          },
+        };
+      }
+
+      transformed = applyMaskedToContext(
+        context,
+        eventType,
+        sources,
+        maskedMsgs,
+        transformedData
+      );
+
+      if (!transformed) {
+        verdict = false;
+        return {
+          error,
+          verdict,
+          data: {
+            ...data,
+            warnings,
+            explanation: 'PII detected but content could not be redacted',
+          },
+        };
+      }
+
+      verdict = true;
+      return {
+        error,
+        verdict,
+        data: { ...data, warnings },
+        transformedData,
+        transformed,
+      };
+    }
+
+    verdict = false;
+    return { error, verdict, data };
+  } catch (e: any) {
+    error = e instanceof HttpError ? formatHttpError(e, url) : e;
+    verdict = false;
+    if (e instanceof HttpError) {
+      data = { httpStatus: e.response?.status, body: e.response?.body, url };
+    }
+    return { error, verdict, data };
+  }
+};

--- a/plugins/lakera/manifest.json
+++ b/plugins/lakera/manifest.json
@@ -1,0 +1,66 @@
+{
+  "id": "lakera",
+  "description": "Lakera Guard — screen prompts and responses via POST /v2/guard. Supports blocking and PII redaction (payload) when only pii/* detectors fire.",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "label": "Lakera API key",
+        "description": "Create at platform.lakera.ai (Guard API key)",
+        "encrypted": true
+      },
+      "apiBase": {
+        "type": "string",
+        "label": "API base URL (optional)",
+        "description": "Host only, e.g. https://api.lakera.ai — do not include /v2/guard (appended automatically). Use a regional host if required."
+      }
+    },
+    "required": ["apiKey"]
+  },
+  "functions": [
+    {
+      "name": "Guard — screen content",
+      "id": "guard",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "type": "guardrail",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "Calls Lakera Guard /v2/guard with payload+breakdown. Blocks on policy hits; redacts PII spans when breakdown shows only pii/* detectors."
+        }
+      ],
+      "parameters": {
+        "type": "object",
+        "properties": {
+          "projectID": {
+            "type": "string",
+            "label": "Lakera project ID",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Project whose policy defines detectors (recommended)"
+              }
+            ]
+          },
+          "endInclusive": {
+            "type": "boolean",
+            "label": "Payload end offset is inclusive",
+            "description": [
+              {
+                "type": "subHeading",
+                "text": "Leave false unless your Lakera tier emits inclusive end indices"
+              }
+            ]
+          },
+          "timeout": {
+            "type": "number",
+            "label": "HTTP timeout (ms)",
+            "description": [{ "type": "subHeading", "text": "Default 30000" }]
+          }
+        },
+        "required": []
+      }
+    }
+  ]
+}

--- a/plugins/lakera/redaction.ts
+++ b/plugins/lakera/redaction.ts
@@ -1,0 +1,200 @@
+/**
+ * Multi-span PII masking from Lakera `payload` (message_id, start, end, detector_type).
+ * Half-open [start, end) unless endInclusive.
+ */
+
+export interface PayloadItem {
+  message_id?: number;
+  start?: number;
+  end?: number;
+  detector_type?: string;
+  [key: string]: unknown;
+}
+
+export function dedupePayloadItems(items: PayloadItem[]): PayloadItem[] {
+  const seen = new Set<string>();
+  const out: PayloadItem[] = [];
+  for (const it of items) {
+    const key = `${it.message_id}\0${it.start}\0${it.end}\0${it.detector_type}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    out.push(it);
+  }
+  return out;
+}
+
+export function mergeOverlappingIntervals(
+  spans: [number, number][]
+): [number, number][] {
+  if (spans.length === 0) return [];
+  const sorted = [...spans].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: [number, number][] = [];
+  let [curS, curE] = sorted[0];
+  for (let i = 1; i < sorted.length; i++) {
+    const [s, e] = sorted[i];
+    if (s <= curE) {
+      curE = Math.max(curE, e);
+    } else {
+      merged.push([curS, curE]);
+      curS = s;
+      curE = e;
+    }
+  }
+  merged.push([curS, curE]);
+  return merged;
+}
+
+export function normalizeSpan(
+  start: number,
+  end: number,
+  length: number,
+  endInclusive: boolean
+): [number, number] | null {
+  let e = endInclusive ? end + 1 : end;
+  if (start < 0 || e < 0 || start >= length || e > length || start >= e)
+    return null;
+  return [start, e];
+}
+
+export function maskLabel(detectorType: string): string {
+  const raw = (detectorType || '').trim();
+  const base = raw.includes('/') ? raw.split('/').pop() || 'PII' : raw || 'PII';
+  const safe =
+    base
+      .replace(/[^a-zA-Z0-9]+/g, '_')
+      .replace(/^_|_$/g, '')
+      .toUpperCase() || 'PII';
+  return `[MASKED_${safe}]`;
+}
+
+export type SpanLabel = [number, number, string];
+
+export function mergeSpansWithLabels(raw: SpanLabel[]): SpanLabel[] {
+  if (raw.length === 0) return [];
+  const sorted = [...raw].sort((a, b) => a[0] - b[0] || a[1] - b[1]);
+  const merged: SpanLabel[] = [];
+  let [curS, curE, curL] = sorted[0];
+  for (let i = 1; i < sorted.length; i++) {
+    const [s, e, lab] = sorted[i];
+    if (s <= curE) {
+      curE = Math.max(curE, e);
+    } else {
+      merged.push([curS, curE, curL]);
+      curS = s;
+      curE = e;
+      curL = lab;
+    }
+  }
+  merged.push([curS, curE, curL]);
+  return merged;
+}
+
+function collectNormalizedSpans(
+  items: PayloadItem[],
+  messageId: number,
+  textLen: number,
+  endInclusive: boolean
+): { spans: SpanLabel[]; warnings: string[] } {
+  const warnings: string[] = [];
+  const spans: SpanLabel[] = [];
+  const forMsg = dedupePayloadItems(
+    items.filter((p) => p.message_id === messageId)
+  );
+  for (const p of forMsg) {
+    if (p.start === undefined || p.end === undefined) {
+      warnings.push(`skip span missing start/end: ${JSON.stringify(p)}`);
+      continue;
+    }
+    const start = Number(p.start);
+    const end = Number(p.end);
+    const norm = normalizeSpan(start, end, textLen, endInclusive);
+    if (!norm) {
+      warnings.push(
+        `skip out-of-range span start=${start} end=${end} len=${textLen}`
+      );
+      continue;
+    }
+    const [a, b] = norm;
+    spans.push([a, b, String(p.detector_type || '')]);
+  }
+  return { spans, warnings };
+}
+
+export function applyPayloadMasksToString(
+  text: string,
+  payloadItems: PayloadItem[],
+  messageId: number,
+  endInclusive: boolean
+): { text: string; warnings: string[] } {
+  const { spans, warnings } = collectNormalizedSpans(
+    payloadItems,
+    messageId,
+    text.length,
+    endInclusive
+  );
+  const merged = mergeSpansWithLabels(spans);
+  let out = text;
+  for (const [start, end, dt] of merged.sort((a, b) => b[0] - a[0])) {
+    out = out.slice(0, start) + maskLabel(dt) + out.slice(end);
+  }
+  return { text: out, warnings };
+}
+
+export function isOnlyPiiViolation(
+  breakdown:
+    | Array<{ detected?: boolean; detector_type?: string }>
+    | null
+    | undefined
+): boolean {
+  if (!breakdown || breakdown.length === 0) return false;
+  let any = false;
+  for (const item of breakdown) {
+    if (!item.detected) continue;
+    any = true;
+    const dt = (item.detector_type || '').trim();
+    if (!dt.startsWith('pii/')) return false;
+  }
+  return any;
+}
+
+export function applyMasksToMessages(
+  messages: Array<Record<string, unknown>>,
+  payload: PayloadItem[] | null | undefined,
+  endInclusive: boolean
+): { messages: Array<Record<string, unknown>>; warnings: string[] } {
+  const warnings: string[] = [];
+  if (!payload || payload.length === 0) {
+    return { messages: messages.map((m) => ({ ...m })), warnings };
+  }
+  const out = messages.map((m) => ({ ...m, content: m.content }));
+  const indices = new Set(
+    payload
+      .map((p) => p.message_id)
+      .filter((id) => id !== undefined && id !== null)
+  );
+  for (const idx of indices) {
+    const i = Number(idx);
+    if (i < 0 || i >= out.length) {
+      warnings.push(
+        `payload references message_id=${i} but only ${out.length} messages`
+      );
+      continue;
+    }
+    const msg = out[i];
+    const content = msg.content;
+    if (Array.isArray(content)) {
+      warnings.push(
+        `message ${i}: multimodal content array — redaction skipped for PoC`
+      );
+      continue;
+    }
+    if (typeof content !== 'string') {
+      warnings.push(`message ${i}: non-string content — skipped`);
+      continue;
+    }
+    const r = applyPayloadMasksToString(content, payload, i, endInclusive);
+    warnings.push(...r.warnings);
+    msg.content = r.text;
+  }
+  return { messages: out, warnings };
+}


### PR DESCRIPTION
## Summary

- Adds Lakera Guard as a native guardrail provider via `/v2/guard`
- Supports `beforeRequestHook` (prompt screening) and `afterRequestHook` (response screening)
- Automatically redacts PII when only `pii/*` detectors fire; blocks on other policy hits

## PR fixes
- Anthropic `messages` format support (system field, content blocks, response shape)
- Normalizes `apiBase` when users paste the full `/v2/guard` endpoint path

Related to #1647 / closes #1636

## Test plan

- [x] `npx jest plugins/lakera` — 20 tests (redaction helpers + handler + Anthropic/apiBase)
- [x] `npm run format:check` on changed files
- [x] Manual test with a valid Lakera API key and project ID


Made with [Cursor](https://cursor.com)