### PR TITLE
feat(plugins/lasso): send source.type=portkey for Used By attribution

### DIFF
--- a/src/plugins/lasso/classify.ts
+++ b/src/plugins/lasso/classify.ts
@@ -48,11 +48,17 @@ enum LassoMessageType {
   COMPLETION = 'COMPLETION',
 }
 
+interface LassoSource {
+  type: string;
+  [key: string]: unknown;
+}
+
 interface LassoV3ClassifyRequest {
   messages: LassoMessage[];
   messageType: LassoMessageType;
   sessionId?: string;
   userId?: string;
+  source?: LassoSource;
 }
 
 interface LassoV3ClassifyResponse {
@@ -181,6 +187,9 @@ export const handler: PluginHandler = async (
     const payload: LassoV3ClassifyRequest = {
       messages,
       messageType,
+      // Drives the "Used By" badge on Lasso Application API Keys: every call from this
+      // integration is attributed as "portkey" on the keys list.
+      source: { type: 'portkey' },
     };
 
     // Map conversationId to sessionId

--- a/src/plugins/lasso/lasso.test.ts
+++ b/src/plugins/lasso/lasso.test.ts
@@ -283,7 +283,10 @@ describe('Lasso Security Deputies API v3', () => {
 
     expect(mockedPost).toHaveBeenCalledWith(
       expect.any(String),
-      expect.objectContaining({ messageType: 'PROMPT' }),
+      expect.objectContaining({
+        messageType: 'PROMPT',
+        source: { type: 'portkey' },
+      }),
       expect.any(Object),
       undefined
     );


### PR DESCRIPTION
## Summary
The Lasso plugin now stamps `source.type = "portkey"` on every
`/gateway/v3/classify` payload. This drives the new "Used By" badge on
the customer's Application API Keys list — without it, all Portkey
traffic through this plugin shows as "N/A" on the keys page.

Backwards compatible: `source` is an optional opaque object on the
Lasso side. Older Lasso servers ignore it.

## Changes
- `LassoV3ClassifyRequest` interface gains an optional `source` field.
- The plugin handler now sets `source: { type: "portkey" }` on every
  payload before calling Lasso.
- Existing test (`should send messageType PROMPT for beforeRequestHook`)
  extended to assert the new field.