### PR TITLE
fix(azure-ai-inference): route Responses API to native /v1/responses

### DIFF
--- a/src/providers/azure-ai-inference/api.ts
+++ b/src/providers/azure-ai-inference/api.ts
@@ -32,6 +32,10 @@ const AzureAIInferenceAPI: ProviderAPIConfig = {
       return new URL(azureFoundryUrl ?? '').origin + '/openai';
     }
 
+    if (fn === 'createModelResponse') {
+      return new URL(azureFoundryUrl ?? '').origin + '/openai';
+    }
+
     if (provider === GITHUB) {
       return 'https://models.inference.ai.azure.com';
     }
@@ -186,6 +190,7 @@ const AzureAIInferenceAPI: ProviderAPIConfig = {
     const ENDPOINT_MAPPING: Record<string, string> = {
       complete: '/completions',
       chatComplete: isAnthropicModel ? '/v1/messages' : '/chat/completions',
+      createModelResponse: '/v1/responses',
       messages: '/v1/messages',
       embed: '/embeddings',
       realtime: '/realtime',
@@ -229,6 +234,9 @@ const AzureAIInferenceAPI: ProviderAPIConfig = {
         return isGithub
           ? ENDPOINT_MAPPING[mappedFn]
           : `${ENDPOINT_MAPPING[mappedFn]}?${searchParamsString}`;
+      }
+      case 'createModelResponse': {
+        return `${ENDPOINT_MAPPING[mappedFn]}?${searchParamsString}`;
       }
       case 'messages': {
         return `${ENDPOINT_MAPPING[mappedFn]}`;

--- a/src/providers/azure-ai-inference/index.ts
+++ b/src/providers/azure-ai-inference/index.ts
@@ -34,6 +34,10 @@ import {
   AzureAIInferenceMessagesConfig,
   AzureAIInferenceMessagesResponseTransform,
 } from './messages';
+import {
+  createModelResponseParams,
+  OpenAICreateModelResponseTransformer,
+} from '../open-ai-base';
 
 const AzureAIInferenceAPIConfig: ProviderConfigs = {
   api: AzureAIInferenceAPI,
@@ -60,6 +64,7 @@ const AzureAIInferenceAPIConfig: ProviderConfigs = {
       realtime: {},
       cancelBatch: {},
       createBatch: AzureOpenAICreateBatchConfig,
+      createModelResponse: createModelResponseParams([]),
       cancelFinetune: {},
       requestHandlers: {
         getBatchOutput: AzureAIInferenceGetBatchOutputRequestHandler,
@@ -74,6 +79,8 @@ const AzureAIInferenceAPIConfig: ProviderConfigs = {
             getAnthropicStreamChunkTransform(AZURE_AI_INFERENCE),
         }),
         chatComplete: chatCompleteResponseTransform,
+        createModelResponse:
+          OpenAICreateModelResponseTransformer(AZURE_AI_INFERENCE),
         messages: AzureAIInferenceMessagesResponseTransform,
         embed: AzureAIInferenceEmbedResponseTransform(AZURE_AI_INFERENCE),
         imageGenerate: AzureAIInferenceResponseTransform,


### PR DESCRIPTION
## Summary

The `azure-ai-inference` provider has no `createModelResponse` config, so a `/v1/responses` request targeting an `azure-ai` virtual key does **not** error — it silently falls back to the `chatComplete` translation path. Any Responses-API field without a 1:1 `chatComplete` equivalent (`reasoning`, `instructions`, `truncation`, `previous_response_id`, ...) is dropped without warning, and the caller gets a plausible-looking `200` with the request not handled as intended.

`reasoning` is the most visible symptom (`reasoning_tokens: 0`), but the data loss is general.

## Root cause

`getConfig()` in `azure-ai-inference/index.ts` returns no `createModelResponse` key, so `transformUsingProviderConfig` (a strict whitelist) either errors or, on the hosted path, degrades to `chatComplete` and strips the unmapped fields.

## Fix

Azure AI Foundry exposes a **native, OpenAI-compatible** `/openai/v1/responses` endpoint, so no field translation is needed — the gateway just needs to route to it (the same pattern `azure-openai` already uses).

- **`index.ts`** — register `createModelResponse` using `open-ai-base`'s `createModelResponseParams([])` + `OpenAICreateModelResponseTransformer`. Bare form (no `model` transform) because the deployment travels via the `azureml-model-deployment` header, not the `model` field.
- **`api.ts`** — resolve the base URL to the `<origin>/openai` root (not the `/deployments/<name>` inference path) and map `createModelResponse` → `/v1/responses`.

With this in place `reasoning: { effort: "high" }` and all other Responses fields pass through to Azure AI Foundry's native endpoint unchanged.

## Testing

Validated locally without a live Azure key:

- **Transform** — the request transform preserves all Responses-only fields (`reasoning`, `instructions`, `truncation`, `previous_response_id`); no silent fallback to `chatComplete` (no `messages` injected).
- **Routing** — the endpoint resolves to `<origin>/openai/v1/responses` (not the `/deployments/<name>` inference path), and `chat/completions` routing is unchanged.
- **End-to-end against a mock Foundry server** — a request built exactly the way the gateway builds it arrives at `/openai/v1/responses` with `reasoning: { effort: "high" }` intact and `Authorization` set, reproducing the issue scenario and confirming the field is no longer dropped.

Fixes #1672