### PR TITLE
fix(bedrock): use system message content in Cohere/AI21 prompt builder

### DIFF
--- a/src/providers/bedrock/chatComplete.test.ts
+++ b/src/providers/bedrock/chatComplete.test.ts
@@ -1,0 +1,58 @@
+// `../../utils/env` uses a top-level await that ts-jest (CommonJS) cannot
+// transpile. It is unrelated to these pure prompt transforms, so stub it out.
+jest.mock('../../utils/env', () => ({
+  Environment: () => ({}),
+  getValueOrFileContents: (value?: string) => value,
+}));
+
+import { Params } from '../../types/requestBody';
+import { ParameterConfig, ProviderConfig } from '../types';
+import {
+  BedrockAI21ChatCompleteConfig,
+  BedrockCohereChatCompleteConfig,
+} from './chatComplete';
+
+const transformMessages = (config: ProviderConfig) => {
+  const messagesConfig = config.messages as ParameterConfig;
+  return (params: Params): string =>
+    messagesConfig.transform!(params, {} as any);
+};
+
+const configs = {
+  'Bedrock Cohere': BedrockCohereChatCompleteConfig,
+  'Bedrock AI21': BedrockAI21ChatCompleteConfig,
+};
+
+describe.each(Object.entries(configs))(
+  '%s chatComplete messages transform',
+  (_name, config) => {
+    const transform = transformMessages(config);
+
+    it('renders the system message content instead of the raw messages array', () => {
+      const prompt = transform({
+        messages: [
+          { role: 'system', content: 'You are a helpful assistant.' },
+          { role: 'user', content: 'Hello there' },
+        ],
+      } as Params);
+
+      // Regression guard: `${messages}` used to interpolate the whole array.
+      expect(prompt).not.toContain('[object Object]');
+      expect(prompt).toContain('system: You are a helpful assistant.');
+      expect(prompt).toContain('user: Hello there');
+    });
+
+    it('still renders user and assistant turns', () => {
+      const prompt = transform({
+        messages: [
+          { role: 'user', content: 'What is 2 + 2?' },
+          { role: 'assistant', content: '4' },
+        ],
+      } as Params);
+
+      expect(prompt).not.toContain('[object Object]');
+      expect(prompt).toContain('user: What is 2 + 2?');
+      expect(prompt).toContain('assistant: 4');
+    });
+  }
+);

--- a/src/providers/bedrock/chatComplete.ts
+++ b/src/providers/bedrock/chatComplete.ts
@@ -868,7 +868,7 @@ export const BedrockCohereChatCompleteConfig: ProviderConfig = {
         let messages: Message[] = params.messages;
         messages.forEach((msg, index) => {
           if (index === 0 && SYSTEM_MESSAGE_ROLES.includes(msg.role)) {
-            prompt += `system: ${messages}\n`;
+            prompt += `system: ${msg.content}\n`;
           } else if (msg.role == 'user') {
             prompt += `user: ${msg.content}\n`;
           } else if (msg.role == 'assistant') {
@@ -1070,7 +1070,7 @@ export const BedrockAI21ChatCompleteConfig: ProviderConfig = {
         let messages: Message[] = params.messages;
         messages.forEach((msg, index) => {
           if (index === 0 && SYSTEM_MESSAGE_ROLES.includes(msg.role)) {
-            prompt += `system: ${messages}\n`;
+            prompt += `system: ${msg.content}\n`;
           } else if (msg.role == 'user') {
             prompt += `user: ${msg.content}\n`;
           } else if (msg.role == 'assistant') {


### PR DESCRIPTION
## What

The non-Converse prompt builders for **Bedrock Cohere** (`BedrockCohereChatCompleteConfig`) and **Bedrock AI21** (`BedrockAI21ChatCompleteConfig`) in `src/providers/bedrock/chatComplete.ts` interpolate the entire `messages` array into the prompt when the first message is a system message:

```ts
messages.forEach((msg, index) => {
  if (index === 0 && SYSTEM_MESSAGE_ROLES.includes(msg.role)) {
    prompt += `system: ${messages}\n`;   // ⬅️ `messages` is the whole Message[]
  } else if (msg.role == 'user') {
    prompt += `user: ${msg.content}\n`;   // correct
  } ...
```

`${messages}` stringifies the whole `Message[]`, so the rendered prompt becomes:

```
system: [object Object],[object Object]
user: Hello there
Assistant:
```

The actual system instruction is silently dropped for **every** Bedrock Cohere/AI21 request that begins with a system message. Every other branch (`user`, `assistant`, fallback) already uses `msg.content`.

## Fix

Interpolate `msg.content` in the system branch, matching the sibling branches. Two one-word changes (lines ~871 and ~1073).

## Tests

Added `src/providers/bedrock/chatComplete.test.ts` — the first unit coverage for these config transforms. It asserts, for both configs, that:
- the system message content is rendered (not `[object Object]`)
- user/assistant turns still render correctly

Verified the test **fails** on the old code (`system: [object Object],[object Object]`) and **passes** with the fix.

```
$ npx jest src/providers/bedrock/chatComplete.test.ts
PASS src/providers/bedrock/chatComplete.test.ts
  ✓ Bedrock Cohere renders the system message content ...
  ✓ Bedrock AI21 renders the system message content ...
```

`npm run format:check` passes.