### PR TITLE
fix(qdrant): send raw api key without Bearer prefix

### DIFF
--- a/src/providers/qdrant/api.test.ts
+++ b/src/providers/qdrant/api.test.ts
@@ -1,0 +1,16 @@
+import QdrantAPIConfig from './api';
+
+describe('Qdrant API config', () => {
+  it('sends the raw api key without a Bearer prefix', () => {
+    const headers = QdrantAPIConfig.headers({
+      providerOptions: { apiKey: 'my-secret-key' },
+      fn: 'chatComplete',
+      transformedRequestBody: {},
+      transformedRequestUrl: '',
+      gatewayRequestBody: {},
+    } as any);
+
+    // Qdrant expects the raw key in `api-key`; a `Bearer ` prefix 401s.
+    expect(headers).toEqual({ 'api-key': 'my-secret-key' });
+  });
+});

--- a/src/providers/qdrant/api.ts
+++ b/src/providers/qdrant/api.ts
@@ -5,7 +5,7 @@ const QdrantAPIConfig: ProviderAPIConfig = {
     return providerOptions.customHost || '';
   },
   headers: ({ providerOptions }) => {
-    return { 'api-key': `Bearer ${providerOptions.apiKey}` };
+    return { 'api-key': `${providerOptions.apiKey}` };
   },
   getEndpoint: ({ fn }) => {
     switch (fn) {


### PR DESCRIPTION
## What

The Qdrant provider builds its auth header as:

```ts
return { 'api-key': `Bearer ${providerOptions.apiKey}` };
```

Qdrant authenticates via the `api-key` header, which must contain the **raw** key — it does not use the `Bearer` scheme. With the `Bearer ` prefix, Qdrant receives `api-key: Bearer <key>` and rejects **every** request with 401/403.

For reference, the sibling `milvus` provider correctly uses `Authorization: Bearer <key>` — the two schemes got crossed here.

## Fix

Send the raw key in the `api-key` header, and add a unit test asserting the header shape.

```
$ npx jest src/providers/qdrant/api.test.ts
PASS  ✓ sends the raw api key without a Bearer prefix
```

`npm run format:check` passes.