### PR TITLE
fix(handlers): return computed error status/message instead of generic 500

### DIFF
--- a/src/handlers/completionsHandler.ts
+++ b/src/handlers/completionsHandler.ts
@@ -43,10 +43,10 @@ export async function completionsHandler(c: Context): Promise<Response> {
     return new Response(
       JSON.stringify({
         status: 'failure',
-        message: 'Something went wrong',
+        message: errorMessage,
       }),
       {
-        status: 500,
+        status: statusCode,
         headers: {
           'content-type': 'application/json',
         },

--- a/src/handlers/embeddingsHandler.ts
+++ b/src/handlers/embeddingsHandler.ts
@@ -43,10 +43,10 @@ export async function embeddingsHandler(c: Context): Promise<Response> {
     return new Response(
       JSON.stringify({
         status: 'failure',
-        message: 'Something went wrong',
+        message: errorMessage,
       }),
       {
-        status: 500,
+        status: statusCode,
         headers: {
           'content-type': 'application/json',
         },

--- a/src/handlers/imageEditsHandler.ts
+++ b/src/handlers/imageEditsHandler.ts
@@ -42,10 +42,10 @@ export async function imageEditsHandler(c: Context): Promise<Response> {
     return new Response(
       JSON.stringify({
         status: 'failure',
-        message: 'Something went wrong',
+        message: errorMessage,
       }),
       {
-        status: 500,
+        status: statusCode,
         headers: {
           'content-type': 'application/json',
         },

--- a/src/handlers/imageGenerationsHandler.ts
+++ b/src/handlers/imageGenerationsHandler.ts
@@ -42,10 +42,10 @@ export async function imageGenerationsHandler(c: Context): Promise<Response> {
     return new Response(
       JSON.stringify({
         status: 'failure',
-        message: 'Something went wrong',
+        message: errorMessage,
       }),
       {
-        status: 500,
+        status: statusCode,
         headers: {
           'content-type': 'application/json',
         },


### PR DESCRIPTION
## What

Four handlers — `completionsHandler`, `embeddingsHandler`, `imageGenerationsHandler`, `imageEditsHandler` — compute the correct error status and message in their `catch` block, then throw it away:

```ts
let statusCode = 500;
let errorMessage = 'Something went wrong';

if (err instanceof RouterError) {
  statusCode = 400;
  errorMessage = err.message;
}

return new Response(
  JSON.stringify({
    status: 'failure',
    message: 'Something went wrong', // ⬅️ hardcoded, ignores errorMessage
  }),
  {
    status: 500,                     // ⬅️ hardcoded, ignores statusCode
    ...
  }
);
```

So a conditional-routing failure (`RouterError`) that should return **400 + the real reason** instead returns an opaque **500 "Something went wrong"**, making these failures hard to diagnose for callers.

## Fix

Use the already-computed `errorMessage` and `statusCode` in the response. This matches the sibling handlers that already do the right thing: `chatCompletionsHandler`, `messagesHandler`, `messagesCountTokensHandler`, `proxyHandler`.

8-line change across the four files; no behavior change for non-`RouterError` errors (still 500 + "Something went wrong"). `npm run format:check` passes.