### PR TITLE
fix(streaming): handle boundary-not-found in multipart stream transformers

### DIFF
--- a/src/handlers/streamHandlerUtils.ts
+++ b/src/handlers/streamHandlerUtils.ts
@@ -173,7 +173,7 @@ export const getFormdataToFormdataStreamTransformer = (
 
         const boundaryIndex = buffer.indexOf(boundary);
 
-        const safeLength = boundaryIndex ?? buffer.length;
+        const safeLength = boundaryIndex === -1 ? buffer.length : boundaryIndex;
 
         const content = buffer.slice(0, safeLength);
         if (isFileContent) {
@@ -268,7 +268,7 @@ export const formDataToOctetStreamTransformer = (
 
         const boundaryIndex = buffer.indexOf(boundary);
 
-        const safeLength = boundaryIndex ?? buffer.length;
+        const safeLength = boundaryIndex === -1 ? buffer.length : boundaryIndex;
         // if (safeLength <= 0) break;
 
         const content = buffer.slice(0, safeLength);


### PR DESCRIPTION
## What

In `getFormdataToFormdataStreamTransformer` and `formDataToOctetStreamTransformer`:

```ts
const boundaryIndex = buffer.indexOf(boundary);
const safeLength = boundaryIndex ?? buffer.length;
const content = buffer.slice(0, safeLength);
```

`String.prototype.indexOf` returns `-1` when the boundary isn't found. `-1` is **not nullish**, so `?? buffer.length` never triggers and `safeLength` becomes `-1`.

When a file chunk arrives before its closing boundary — the normal case for large uploads streamed across multiple reads — this means:
- `buffer.slice(0, -1)` emits the content minus its **last byte**, and
- the non-file branch does `buffer = buffer.slice(-1)`, discarding almost the **entire** buffer.

The result is corrupted chunked file uploads.

## Fix

Only fall back to `buffer.length` when the boundary is genuinely absent:

```ts
const safeLength = boundaryIndex === -1 ? buffer.length : boundaryIndex;
```

Applied at both sites. `npm run format:check` passes.

> Note: these transformers operate on a `ReadableStream`/`TransformStream` pipeline, so I did not add a unit test (would require standing up the full stream harness). Happy to add one if you'd prefer — the change itself is a self-contained correctness fix.