### PR TITLE
fix(streaming): prevent stream-transform crashes for Perplexity and Google

### DIFF
--- a/src/providers/google/chatComplete.test.ts
+++ b/src/providers/google/chatComplete.test.ts
@@ -1,0 +1,54 @@
+import { GoogleChatCompleteStreamChunkTransform } from './chatComplete';
+
+describe('GoogleChatCompleteStreamChunkTransform', () => {
+  const chunkObject = {
+    modelVersion: 'gemini-1.5-flash',
+    candidates: [
+      {
+        content: { role: 'model', parts: [{ text: 'Hello' }] },
+        finishReason: 'STOP',
+        index: 0,
+      },
+    ],
+    usageMetadata: {
+      promptTokenCount: 5,
+      candidatesTokenCount: 1,
+      totalTokenCount: 6,
+    },
+  };
+
+  it('parses the terminal chunk of a streamed JSON array (trailing "]")', () => {
+    // Google (AI Studio) streams a JSON array; the final element arrives as
+    // `{...}]`. Only the `]` should be stripped, not the closing `}`.
+    const terminalChunk = `${JSON.stringify(chunkObject)}]`;
+
+    let out = '';
+    expect(() => {
+      out = GoogleChatCompleteStreamChunkTransform(
+        terminalChunk,
+        'fallback-id',
+        {},
+        false
+      );
+    }).not.toThrow();
+
+    // Before the fix, `}` was also stripped and JSON.parse threw on the
+    // final chunk (the one carrying finishReason / usageMetadata).
+    const parsed = JSON.parse(out.replace(/^data: /, '').trim());
+    expect(parsed.choices[0].delta.content).toBe('Hello');
+    expect(parsed.choices[0].finish_reason).toBeTruthy();
+    expect(parsed.usage.total_tokens).toBe(6);
+  });
+
+  it('still handles a middle chunk with a trailing comma', () => {
+    const middleChunk = `${JSON.stringify(chunkObject)},`;
+    expect(() =>
+      GoogleChatCompleteStreamChunkTransform(
+        middleChunk,
+        'fallback-id',
+        {},
+        false
+      )
+    ).not.toThrow();
+  });
+});

--- a/src/providers/google/chatComplete.ts
+++ b/src/providers/google/chatComplete.ts
@@ -754,7 +754,7 @@ export const GoogleChatCompleteStreamChunkTransform: (
     chunk = chunk.slice(0, chunk.length - 1);
   }
   if (chunk.endsWith(']')) {
-    chunk = chunk.slice(0, chunk.length - 2);
+    chunk = chunk.slice(0, chunk.length - 1);
   }
   chunk = chunk.replace(/^data: /, '');
   chunk = chunk.trim();

--- a/src/providers/perplexity-ai/chatComplete.test.ts
+++ b/src/providers/perplexity-ai/chatComplete.test.ts
@@ -1,0 +1,44 @@
+import { PerplexityAIChatCompleteStreamChunkTransform } from './chatComplete';
+
+describe('PerplexityAIChatCompleteStreamChunkTransform', () => {
+  it('passes through the [DONE] sentinel without throwing', () => {
+    expect(() =>
+      PerplexityAIChatCompleteStreamChunkTransform(
+        'data: [DONE]',
+        'fallback-id',
+        {},
+        false
+      )
+    ).not.toThrow();
+
+    const out = PerplexityAIChatCompleteStreamChunkTransform(
+      'data: [DONE]',
+      'fallback-id',
+      {},
+      false
+    );
+    expect(out).toBe('data: [DONE]\n\n');
+  });
+
+  it('transforms a normal content chunk', () => {
+    const upstream = JSON.stringify({
+      id: 'abc',
+      object: 'chat.completion.chunk',
+      model: 'sonar',
+      choices: [
+        { delta: { role: 'assistant', content: 'Hi' }, finish_reason: null },
+      ],
+    });
+
+    const out = PerplexityAIChatCompleteStreamChunkTransform(
+      `data: ${upstream}`,
+      'fallback-id',
+      {},
+      false
+    );
+
+    expect(out.startsWith('data: ')).toBe(true);
+    const parsed = JSON.parse(out.replace(/^data: /, '').trim());
+    expect(parsed.choices[0].delta.content).toBe('Hi');
+  });
+});

--- a/src/providers/perplexity-ai/chatComplete.ts
+++ b/src/providers/perplexity-ai/chatComplete.ts
@@ -207,6 +207,10 @@ export const PerplexityAIChatCompleteStreamChunkTransform: (
   chunk = chunk.replace(/^data: /, '');
   chunk = chunk.trim();
 
+  if (chunk === '[DONE]') {
+    return `data: ${chunk}\n\n`;
+  }
+
   const parsedChunk: PerplexityAIChatCompletionStreamChunk = JSON.parse(chunk);
   let returnChunk =
     `data: ${JSON.stringify({


### PR DESCRIPTION
## What

Two independent streaming crashes, both on the final chunk of a stream.

### Perplexity
`PerplexityAIChatCompleteStreamChunkTransform` emits its own `data: [DONE]` terminator but has **no guard** before `JSON.parse(chunk)`:

```ts
chunk = chunk.replace(/^data: /, '');
chunk = chunk.trim();
const parsedChunk = JSON.parse(chunk); // JSON.parse('[DONE]') throws
```

When the upstream `data: [DONE]` line arrives, `JSON.parse('[DONE]')` throws a `SyntaxError` and breaks the stream. Every sibling transform (e.g. `groq`) already guards this.

### Google (AI Studio)
`streamGenerateContent` is called without `alt=sse`, so responses arrive as a streamed JSON **array** and the final chunk looks like `{...}]`. The trailing-`]` branch stripped **two** characters:

```ts
if (chunk.endsWith(']')) {
  chunk = chunk.slice(0, chunk.length - 2); // removes `}` too
}
```

removing the closing `}` as well, leaving invalid JSON — so `JSON.parse` throws on the last chunk (the one carrying `finishReason` / `usageMetadata`). The sibling trailing-`,` branch correctly strips a single char.

## Fix

- Perplexity: add the `if (chunk === '[DONE]') return 'data: [DONE]\n\n';` guard before parsing.
- Google: strip only the `]` (`chunk.length - 1`).

## Tests

Added unit tests for both transforms:
- `src/providers/perplexity-ai/chatComplete.test.ts`
- `src/providers/google/chatComplete.test.ts`

Verified each **fails before** the fix (Perplexity throws on `[DONE]`; Google throws parsing the terminal `{...}]` chunk) and **passes after**.

```
$ npx jest src/providers/perplexity-ai/chatComplete.test.ts src/providers/google/chatComplete.test.ts
Test Suites: 2 passed, 2 total
Tests:       4 passed, 4 total
```

`npm run format:check` passes.