### PR TITLE
fix(x-ai): preserve structured error fields in response transform

### DIFF
--- a/src/providers/x-ai/index.ts
+++ b/src/providers/x-ai/index.ts
@@ -23,12 +23,14 @@ interface XAIErrorResponse {
 const xAIResponseTransform = <T>(response: T) => {
   let _response = response as XAIErrorResponse;
   if ('error' in _response) {
+    const error = _response.error;
+    const isStructuredError = typeof error === 'object' && error !== null;
     return {
       error: {
-        message: _response.error as string,
-        code: _response.code ?? null,
-        param: null,
-        type: null,
+        message: isStructuredError ? error.message : (error as string),
+        code: (isStructuredError ? error.code : _response.code) ?? null,
+        param: isStructuredError ? error.param : null,
+        type: isStructuredError ? error.type : null,
       },
       provider: X_AI,
     };


### PR DESCRIPTION
## What

`xAIResponseTransform` casts the provider error straight to a string:

```ts
error: {
  message: _response.error as string,  // error can be an object
  code: _response.code ?? null,
  param: null,
  type: null,
},
```

x.ai is OpenAI-compatible and returns errors as an **object** (`{ message, code, param, type }`) — the local `XAIErrorResponse` type already models `error` as `object | string`. For the object shape:
- `message` receives the whole object (serializes to `[object Object]`), and
- `code` / `param` / `type` are silently dropped (`code` is read from the wrong place, `_response.code` instead of `error.code`).

So callers lose the real error message and metadata.

## Fix

Detect whether `error` is structured and map its fields accordingly, keeping the plain-string fallback:

```ts
const error = _response.error;
const isStructuredError = typeof error === 'object' && error !== null;
error: {
  message: isStructuredError ? error.message : (error as string),
  code: (isStructuredError ? error.code : _response.code) ?? null,
  param: isStructuredError ? error.param : null,
  type: isStructuredError ? error.type : null,
}
```

`tsc` and `npm run format:check` pass.