### PR TITLE
fix(reka-ai): guard first-message access in chat transform

### DIFF
--- a/src/providers/reka-ai/chatComplete.test.ts
+++ b/src/providers/reka-ai/chatComplete.test.ts
@@ -1,0 +1,33 @@
+import { Params } from '../../types/requestBody';
+import { ParameterConfig, ProviderConfig } from '../types';
+import { RekaAIChatCompleteConfig } from './chatComplete';
+
+const transformMessages = (config: ProviderConfig) => {
+  const messagesConfig = config.messages as ParameterConfig;
+  return (params: Params) => messagesConfig.transform!(params, {} as any);
+};
+
+describe('RekaAIChatCompleteConfig messages transform', () => {
+  const transform = transformMessages(RekaAIChatCompleteConfig);
+
+  it('does not throw when the first message is an image', () => {
+    expect(() =>
+      transform({
+        messages: [
+          {
+            role: 'user',
+            content: [
+              { type: 'image_url', image_url: { url: 'https://x/y.png' } },
+            ],
+          },
+        ],
+      } as Params)
+    ).not.toThrow();
+  });
+
+  it('does not throw when there are no messages', () => {
+    expect(() =>
+      transform({ messages: [] } as unknown as Params)
+    ).not.toThrow();
+  });
+});

--- a/src/providers/reka-ai/chatComplete.ts
+++ b/src/providers/reka-ai/chatComplete.ts
@@ -38,7 +38,7 @@ export const RekaAIChatCompleteConfig: ProviderConfig = {
         media_url?: string;
       }) => {
         // NOTE: can't have more than one image in conversation history
-        if (media_url && messages[0].media_url) {
+        if (media_url && messages[0]?.media_url) {
           return;
         }
 
@@ -76,7 +76,7 @@ export const RekaAIChatCompleteConfig: ProviderConfig = {
         }
       });
 
-      if (messages[0].type !== 'human') {
+      if (messages[0]?.type !== 'human') {
         messages.unshift({
           type: 'human',
           text: 'Placeholder for alternation',


### PR DESCRIPTION
## What

The `conversation_history` transform in `RekaAIChatCompleteConfig` dereferences `messages[0]` (a local accumulator array) before anything is pushed to it:

```ts
const messages: RekaMessageItem[] = [];
...
if (media_url && messages[0].media_url) { ... }  // messages still empty
...
if (messages[0].type !== 'human') { ... }        // empty / fully-filtered list
```

- The first check throws `TypeError: Cannot read properties of undefined` when the **first message is an image** (`media_url` truthy, `messages` still empty).
- The second throws when the resulting message list is **empty** (e.g. no messages, or all filtered out).

## Fix

Optional-chain both accesses (`messages[0]?.media_url`, `messages[0]?.type`), so an image-first or empty message list is handled gracefully.

## Tests

Added `src/providers/reka-ai/chatComplete.test.ts` covering both cases. Verified each **fails before** the fix (throws) and **passes after**.

`npm run format:check` passes.