### PR TITLE
fix(guardrails/azure): guard undefined systemMessages in shieldPrompt

### DIFF
--- a/plugins/azure/shieldPrompt.ts
+++ b/plugins/azure/shieldPrompt.ts
@@ -79,7 +79,9 @@ export const handler = async (
 
   const request = {
     userPrompt,
-    ...(systemMessages.length > 0 ? { documents: textArray } : {}), // If system message, add user prompt as documents
+    ...(Array.isArray(systemMessages) && systemMessages.length > 0
+      ? { documents: textArray }
+      : {}), // If system message, add user prompt as documents
   };
 
   const apiVersion = parameters.apiVersion || '2024-09-01';


### PR DESCRIPTION
## What

In the Azure `shieldPrompt` guardrail:

```ts
const systemMessages = context.request?.json?.messages?.filter(
  (message) => message.role === 'system'
);
...
// guarded correctly here:
if (Array.isArray(systemMessages) && systemMessages.length > 0) { ... }
...
const request = {
  userPrompt,
  ...(systemMessages.length > 0 ? { documents: textArray } : {}), // NOT guarded
};
```

`systemMessages` is `undefined` whenever the request has no `messages` array (e.g. a completion-style payload). The `documents` spread uses a bare `systemMessages.length`, throwing `TypeError: Cannot read properties of undefined (reading 'length')` — and this line is outside the surrounding `try`, so the handler rejects instead of returning a clean verdict.

## Fix

Apply the same `Array.isArray(systemMessages)` guard already used a few lines above.

`npm run format:check` passes.