### PR TITLE
fix(bedrock): use correct month/day in STS RoleSessionName

### DIFF
--- a/plugins/bedrock/util.ts
+++ b/plugins/bedrock/util.ts
@@ -198,7 +198,7 @@ export async function getAssumedRoleCredentials(
     sha256: Sha256,
   });
   const date = new Date();
-  const sessionName = `${date.getFullYear()}${date.getMonth()}${date.getDay()}`;
+  const sessionName = `${date.getFullYear()}${date.getMonth() + 1}${date.getDate()}`;
   const url = `https://${hostname}?Action=AssumeRole&Version=2011-06-15&RoleArn=${awsRoleArn}&RoleSessionName=${sessionName}${awsExternalId ? `&ExternalId=${awsExternalId}` : ''}`;
   const urlObj = new URL(url);
   const requestHeaders = { host: hostname };

--- a/src/providers/bedrock/utils.ts
+++ b/src/providers/bedrock/utils.ts
@@ -280,7 +280,7 @@ export async function getAssumedRoleCredentials(
     sha256: Sha256,
   });
   const date = new Date();
-  const sessionName = `${date.getFullYear()}${date.getMonth()}${date.getDay()}`;
+  const sessionName = `${date.getFullYear()}${date.getMonth() + 1}${date.getDate()}`;
   const url = `https://${hostname}?Action=AssumeRole&Version=2011-06-15&RoleArn=${awsRoleArn}&RoleSessionName=${sessionName}${awsExternalId ? `&ExternalId=${awsExternalId}` : ''}`;
   const urlObj = new URL(url);
   const requestHeaders = { host: hostname };


### PR DESCRIPTION
The AssumeRole session name was built with `getMonth()` (0-indexed) and `getDay()` (day of week, 0-6) instead of the calendar month/day, so the generated `RoleSessionName` did not reflect the actual date (e.g. it embedded a weekday number rather than the day of month).

Use `getMonth() + 1` and `getDate()`. Applied in both the gateway (src/providers/bedrock/utils.ts) and the guardrail plugin (plugins/bedrock/util.ts), which carried identical copies.

**Description:** (required)
- Detailed change 1
- Detailed change 2

**Tests Run/Test cases added:** (required)
- [ ] Description of test case

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)