### PR TITLE
fix(together-ai): use a valid Together embedding model as default

### DIFF
--- a/src/providers/together-ai/embed.ts
+++ b/src/providers/together-ai/embed.ts
@@ -11,7 +11,7 @@ export const TogetherAIEmbedConfig: ProviderConfig = {
   model: {
     param: 'model',
     required: true,
-    default: 'mistral-embed',
+    default: 'BAAI/bge-large-en-v1.5',
   },
   input: {
     param: 'input',


### PR DESCRIPTION
## What

The Together AI embed config defaults the model to `mistral-embed`:

```ts
model: {
  param: 'model',
  required: true,
  default: 'mistral-embed',
},
```

This is copy-pasted from `mistral-ai/embed.ts`. Together AI does not serve `mistral-embed`, so an embeddings request that relies on the default (omits `model`) is sent an invalid model id and fails.

## Fix

Default to `BAAI/bge-large-en-v1.5` — the embedding model used in Together's own [Create Embedding API docs](https://docs.together.ai/reference/embeddings-2) example.

> Note: Together's hosted model list shifts over time. I picked the model from their official docs example; maintainers may prefer a different supported default (e.g. `togethercomputer/m2-bert-80M-8k-retrieval`) — happy to change it.

`npm run format:check` passes.