### PR TITLE
feat: add native Valkey integration for vector search and caching

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -147,3 +147,4 @@ plugins/**/creds.json
 plugins/**/.parameters.json
 src/handlers/tests/.creds.json
 .cursor/
+dump.rdb

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Works with Claude Desktop, Cursor, VS Code, and any MCP-compatible client. [Get 
 - <a href="https://portkey.wiki/gh-47">**Compliance & Data Privacy**</a>: The AI gateway is SOC2, HIPAA, GDPR, and CCPA compliant.
 
 ### Cost Management
-- [**Smart caching**](https://portkey.wiki/gh-48): Cache responses from LLMs to reduce costs and improve latency. Supports simple and semantic* caching.
+- [**Smart caching**](https://portkey.wiki/gh-48): Cache responses from LLMs to reduce costs and improve latency. Supports simple and semantic* caching. Set `VALKEY_CONNECTION_STRING` to back the cache with Valkey (Node.js only).
 - [**Usage analytics**](https://portkey.wiki/gh-49): Monitor and analyze your AI and LLM usage, including request volume, latency, costs and error rates.
 - [**Provider optimization***](https://portkey.wiki/gh-89): Automatically switch to the most cost-effective provider based on usage patterns and pricing models.
 

--- a/docs/installation-deployments.md
+++ b/docs/installation-deployments.md
@@ -70,6 +70,46 @@ node build/start-server.js
 
 <br>
 
+#### Valkey Integration (Node.js only)
+
+**Cache backend**
+
+Set `VALKEY_CONNECTION_STRING` to use Valkey (via `@valkey/valkey-glide`) instead of the default in-memory cache. Supported schemes: `valkey://`, `valkeys://` (TLS), `redis://`, `rediss://`.
+
+```sh
+VALKEY_CONNECTION_STRING="valkey://localhost:6379" node build/start-server.js
+```
+
+This initializes all five cache stores (default, session, config, OAuth, MCP) backed by Valkey. `REDIS_CONNECTION_STRING` (ioredis) is also supported and takes effect when `VALKEY_CONNECTION_STRING` is not set.
+
+**Vector search provider**
+
+The `valkey-search` provider routes vector index and search operations directly to a Valkey Search instance over RESP using GLIDE. No HTTP upstream is required.
+
+```sh
+# Create an index
+curl -X POST http://localhost:8787/v1/indexes \
+  -H "Content-Type: application/json" \
+  -H "x-portkey-provider: valkey-search" \
+  -H "x-portkey-custom-host: valkey://localhost:6379" \
+  -d '{"name":"docs","schema":{"vec":{"type":"VECTOR","algorithm":"HNSW","dims":1536,"distance":"COSINE"},"text":{"type":"TEXT"}},"prefix":"doc:"}'
+```
+
+Supported endpoints:
+
+| Method | Path | Operation |
+| ------ | ---- | --------- |
+| `POST` | `/v1/indexes` | Create index (`FT.CREATE`) |
+| `GET` | `/v1/indexes/:name` | Index info (`FT.INFO`) |
+| `DELETE` | `/v1/indexes/:name` | Drop index (`FT.DROPINDEX`) |
+| `POST` | `/v1/indexes/:name/upsert` | Upsert documents (`HSET`) |
+| `POST` | `/v1/indexes/:name/search` | KNN vector search (`FT.SEARCH`) |
+| `DELETE` | `/v1/indexes/:name/documents` | Delete documents (`DEL`) |
+
+Requires Node.js deployment - not available on Cloudflare Workers.
+
+<br>
+
 ---
 
 ### Deploy to App Stack

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,6 +17,7 @@
         "@portkey-ai/mustache": "^2.1.3",
         "@smithy/signature-v4": "^2.1.1",
         "@types/mustache": "^4.2.5",
+        "@valkey/valkey-glide": "^1.0.0",
         "async-retry": "^1.3.3",
         "avsc": "^5.7.7",
         "hono": "^4.9.7",
@@ -1822,6 +1823,72 @@
       "resolved": "https://registry.npmjs.org/@portkey-ai/mustache/-/mustache-2.1.3.tgz",
       "integrity": "sha512-K9C+dn1bz1H6cUh/WeoF+1lB3dbzwYbyYVC+AHjfjgCHYq9USz9tFyVuaGTfWFXLFyRD9TgIiQ/3NI9DjbQrdg=="
     },
+    "node_modules/@protobufjs/aspromise": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
+      "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/base64": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
+      "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/codegen": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
+      "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/eventemitter": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
+      "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/fetch": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
+      "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.1"
+      }
+    },
+    "node_modules/@protobufjs/float": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
+      "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/path": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
+      "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/pool": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
+      "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
+    "node_modules/@protobufjs/utf8": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
+      "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
+      "license": "BSD-3-Clause",
+      "optional": true
+    },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
       "resolved": "https://registry.npmjs.org/@rollup/plugin-json/-/plugin-json-6.1.0.tgz",
@@ -2434,7 +2501,7 @@
       "version": "20.8.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.3.tgz",
       "integrity": "sha512-jxiZQFpb+NlH5kjW49vXxvxTjeeqlbsnTAdBTKpzEdPs9itay7MscYXz3Fo9VYFEsfQ6LJFitHad3faerLAjCw==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",
@@ -2698,6 +2765,180 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/typescript-eslint"
+      }
+    },
+    "node_modules/@valkey/valkey-glide": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide/-/valkey-glide-1.3.4.tgz",
+      "integrity": "sha512-EXjpGEeTjs2uhJm8ZNkHEK8d3qCQmppmxsv+553S6L9fArZTBvKMmfh7P2H7nxletHx6sxs+fc2UFFw9M5k5SQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "optionalDependencies": {
+        "@valkey/valkey-glide-darwin-arm64": "1.3.4",
+        "@valkey/valkey-glide-darwin-x64": "1.3.4",
+        "@valkey/valkey-glide-linux-arm64": "1.3.4",
+        "@valkey/valkey-glide-linux-musl-arm64": "1.3.4",
+        "@valkey/valkey-glide-linux-musl-x64": "1.3.4",
+        "@valkey/valkey-glide-linux-x64": "1.3.4"
+      }
+    },
+    "node_modules/@valkey/valkey-glide-darwin-arm64": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-darwin-arm64/-/valkey-glide-darwin-arm64-1.3.4.tgz",
+      "integrity": "sha512-Ry8PEWdMtENju/thkqMEDCcf9wJSz5JavpwTJ8+NEaTVeYUSNK7PJ91ZrgxTWyDr51YAdA8e5MjyK2+p2X1HiQ==",
+      "bundleDependencies": [
+        "glide-rs"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "glide-rs": "file:rust-client",
+        "long": "5",
+        "protobufjs": "7"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@valkey/valkey-glide-darwin-arm64/node_modules/glide-rs": {
+      "version": "0.1.0",
+      "inBundle": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "engines": {
+        "node": ">= 10"
+      }
+    },
+    "node_modules/@valkey/valkey-glide-darwin-x64": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-darwin-x64/-/valkey-glide-darwin-x64-1.3.4.tgz",
+      "integrity": "sha512-Jl/x1WovhwiP7lWUcA99tw68Usb3GCHZ/ISD/1F23cVErXJ9qB4ZNCFI8Y1QrmwEPSeojKsxSpqylrsInuv1ng==",
+      "bundleDependencies": [
+        "glide-rs"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "dependencies": {
+        "glide-rs": "file:rust-client",
+        "long": "5",
+        "protobufjs": "7"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@valkey/valkey-glide-linux-arm64": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-arm64/-/valkey-glide-linux-arm64-1.3.4.tgz",
+      "integrity": "sha512-ubTZDaEqlwS8NNuIggWt36I1BbtUNE17uHrCaBvUfc+aR1870r4xqvQNyvpQhT/VezfJisSBGKudFdLKeFrIjg==",
+      "bundleDependencies": [
+        "glide-rs"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "deprecated": "This package will be replaced by @valkey/valkey-glide-linux-arm64-gnu in v2.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "glide-rs": "file:rust-client",
+        "long": "5",
+        "protobufjs": "7"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@valkey/valkey-glide-linux-musl-arm64": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-musl-arm64/-/valkey-glide-linux-musl-arm64-1.3.4.tgz",
+      "integrity": "sha512-zNkmKXrT9ebe/XWtevzFleRrXycrzsLtmDjdQJGVUC96gUA3DcczK/gfu2rgvgH84C5s5jKbSM7oeo8f8eX4Vw==",
+      "bundleDependencies": [
+        "glide-rs"
+      ],
+      "cpu": [
+        "arm64"
+      ],
+      "deprecated": "This package will be replaced by @valkey/valkey-glide-linux-arm64-musl in v2.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "glide-rs": "file:rust-client",
+        "long": "5",
+        "protobufjs": "7"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@valkey/valkey-glide-linux-musl-x64": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-musl-x64/-/valkey-glide-linux-musl-x64-1.3.4.tgz",
+      "integrity": "sha512-QSaLTp81V0agKcGXsr3LUF+Vl4nTHrf5eBNV7/2GwbA4Pwed2x8TzORAjv+aS368hWR/9zftbVA1Xjn8TAND3w==",
+      "bundleDependencies": [
+        "glide-rs"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "deprecated": "This package will be replaced by @valkey/valkey-glide-linux-x64-musl in v2.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "glide-rs": "file:rust-client",
+        "long": "5",
+        "protobufjs": "7"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/@valkey/valkey-glide-linux-x64": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-x64/-/valkey-glide-linux-x64-1.3.4.tgz",
+      "integrity": "sha512-j9acGMsr7T1oY377xBsIkY4rjtDqb78/OSH3CFcdntcJZU6u6fvcqGXG5Co/iRDvsm+q9uuYd/H5ITnGx60kng==",
+      "bundleDependencies": [
+        "glide-rs"
+      ],
+      "cpu": [
+        "x64"
+      ],
+      "deprecated": "This package will be replaced by @valkey/valkey-glide-linux-x64-gnu in v2.0",
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "dependencies": {
+        "glide-rs": "file:rust-client",
+        "long": "5",
+        "protobufjs": "7"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@yarnpkg/lockfile": {
@@ -3467,6 +3708,15 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
+      }
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -5680,6 +5930,13 @@
       "dev": true,
       "peer": true
     },
+    "node_modules/long": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
+      "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
+      "license": "Apache-2.0",
+      "optional": true
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -6455,6 +6712,30 @@
       },
       "engines": {
         "node": ">= 6"
+      }
+    },
+    "node_modules/protobufjs": {
+      "version": "7.6.4",
+      "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-7.6.4.tgz",
+      "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
+      "hasInstallScript": true,
+      "license": "BSD-3-Clause",
+      "optional": true,
+      "dependencies": {
+        "@protobufjs/aspromise": "^1.1.2",
+        "@protobufjs/base64": "^1.1.2",
+        "@protobufjs/codegen": "^2.0.5",
+        "@protobufjs/eventemitter": "^1.1.1",
+        "@protobufjs/fetch": "^1.1.1",
+        "@protobufjs/float": "^1.0.2",
+        "@protobufjs/path": "^1.1.2",
+        "@protobufjs/pool": "^1.1.0",
+        "@protobufjs/utf8": "^1.1.1",
+        "@types/node": ">=13.7.0",
+        "long": "^5.3.2"
+      },
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/punycode": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,7 @@
         "@portkey-ai/mustache": "^2.1.3",
         "@smithy/signature-v4": "^2.1.1",
         "@types/mustache": "^4.2.5",
-        "@valkey/valkey-glide": "^1.0.0",
+        "@valkey/valkey-glide": "2.4.2",
         "async-retry": "^1.3.3",
         "avsc": "^5.7.7",
         "hono": "^4.9.7",
@@ -1827,36 +1827,31 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/aspromise/-/aspromise-1.1.2.tgz",
       "integrity": "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/base64": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/base64/-/base64-1.1.2.tgz",
       "integrity": "sha512-AZkcAA5vnN/v4PDqKyMR5lx7hZttPDgClv83E//FMNhR2TMcLUhfRUBHCmSl0oi9zMgDDqRUJkSxO3wm85+XLg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/codegen": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@protobufjs/codegen/-/codegen-2.0.5.tgz",
       "integrity": "sha512-zgXFLzW3Ap33e6d0Wlj4MGIm6Ce8O89n/apUaGNB/jx+hw+ruWEp7EwGUshdLKVRCxZW12fp9r40E1mQrf/34g==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/eventemitter": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/eventemitter/-/eventemitter-1.1.1.tgz",
       "integrity": "sha512-vW1GmwMZNnL+gMRaovlh9yZX74kc+TTU3FObkkurpMaRtBfLP3ldjS9KQWlwZgraRE0+dheEEoAxdzcJQ8eXZg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/fetch": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/fetch/-/fetch-1.1.1.tgz",
       "integrity": "sha512-GpptLrs57adMSuHi3VNj0mAF8dwh36LMaYF6XyJ6JMWlVsc+t42tm1HSEDmOs3A8fC9yyeisgLhsTVQokOZ0zw==",
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.1"
       }
@@ -1865,29 +1860,25 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/float/-/float-1.0.2.tgz",
       "integrity": "sha512-Ddb+kVXlXst9d+R9PfTIxh1EdNkgoRe5tOX6t01f1lYWOvJnSPDBlG241QLzcyPdoNTsblLUdujGSE4RzrTZGQ==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/path": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@protobufjs/path/-/path-1.1.2.tgz",
       "integrity": "sha512-6JOcJ5Tm08dOHAbdR3GrvP+yUUfkjG5ePsHYczMFLq3ZmMkAD98cDgcT2iA1lJ9NVwFd4tH/iSSoe44YWkltEA==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/pool": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/@protobufjs/pool/-/pool-1.1.0.tgz",
       "integrity": "sha512-0kELaGSIDBKvcgS4zkjz1PeddatrjYcmMWOlAuAPwAeccUrPHdUqo/J6LiymHHEiJT5NrF1UVwxY14f+fy4WQw==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@protobufjs/utf8": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@protobufjs/utf8/-/utf8-1.1.1.tgz",
       "integrity": "sha512-oOAWABowe8EAbMyWKM0tYDKi8Yaox52D+HWZhAIJqQXbqe0xI/GV7FhLWqlEKreMkfDjshR5FKgi3mnle0h6Eg==",
-      "license": "BSD-3-Clause",
-      "optional": true
+      "license": "BSD-3-Clause"
     },
     "node_modules/@rollup/plugin-json": {
       "version": "6.1.0",
@@ -2500,8 +2491,7 @@
     "node_modules/@types/node": {
       "version": "20.8.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.8.3.tgz",
-      "integrity": "sha512-jxiZQFpb+NlH5kjW49vXxvxTjeeqlbsnTAdBTKpzEdPs9itay7MscYXz3Fo9VYFEsfQ6LJFitHad3faerLAjCw==",
-      "devOptional": true
+      "integrity": "sha512-jxiZQFpb+NlH5kjW49vXxvxTjeeqlbsnTAdBTKpzEdPs9itay7MscYXz3Fo9VYFEsfQ6LJFitHad3faerLAjCw=="
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.12",
@@ -2768,29 +2758,30 @@
       }
     },
     "node_modules/@valkey/valkey-glide": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide/-/valkey-glide-1.3.4.tgz",
-      "integrity": "sha512-EXjpGEeTjs2uhJm8ZNkHEK8d3qCQmppmxsv+553S6L9fArZTBvKMmfh7P2H7nxletHx6sxs+fc2UFFw9M5k5SQ==",
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide/-/valkey-glide-2.4.2.tgz",
+      "integrity": "sha512-ugE9hxB+0QoXhix2PgmtJZqWAEFqS8iJsWRqn8dgqdBrOwKUv9LidWuEzF/WBGyYZDj9Ji/g8CvaskA2fHZvTw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "detect-libc": "^2.0.3"
+        "long": "5",
+        "protobufjs": "7"
+      },
+      "engines": {
+        "node": ">=16"
       },
       "optionalDependencies": {
-        "@valkey/valkey-glide-darwin-arm64": "1.3.4",
-        "@valkey/valkey-glide-darwin-x64": "1.3.4",
-        "@valkey/valkey-glide-linux-arm64": "1.3.4",
-        "@valkey/valkey-glide-linux-musl-arm64": "1.3.4",
-        "@valkey/valkey-glide-linux-musl-x64": "1.3.4",
-        "@valkey/valkey-glide-linux-x64": "1.3.4"
+        "@valkey/valkey-glide-darwin-arm64": "2.4.2",
+        "@valkey/valkey-glide-darwin-x64": "2.4.2",
+        "@valkey/valkey-glide-linux-arm64-gnu": "2.4.2",
+        "@valkey/valkey-glide-linux-arm64-musl": "2.4.2",
+        "@valkey/valkey-glide-linux-x64-gnu": "2.4.2",
+        "@valkey/valkey-glide-linux-x64-musl": "2.4.2"
       }
     },
     "node_modules/@valkey/valkey-glide-darwin-arm64": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-darwin-arm64/-/valkey-glide-darwin-arm64-1.3.4.tgz",
-      "integrity": "sha512-Ry8PEWdMtENju/thkqMEDCcf9wJSz5JavpwTJ8+NEaTVeYUSNK7PJ91ZrgxTWyDr51YAdA8e5MjyK2+p2X1HiQ==",
-      "bundleDependencies": [
-        "glide-rs"
-      ],
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-darwin-arm64/-/valkey-glide-darwin-arm64-2.4.2.tgz",
+      "integrity": "sha512-ILJt4/nGWvzWbrNTUFCvOmUnUoLhOHDKAdCQBTTZtt61JRv4z1ctS8kSkHXtdiwWYCPZIsqjjIsb43HdujkuKQ==",
       "cpu": [
         "arm64"
       ],
@@ -2798,32 +2789,12 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "dependencies": {
-        "glide-rs": "file:rust-client",
-        "long": "5",
-        "protobufjs": "7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
-    },
-    "node_modules/@valkey/valkey-glide-darwin-arm64/node_modules/glide-rs": {
-      "version": "0.1.0",
-      "inBundle": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "engines": {
-        "node": ">= 10"
-      }
+      ]
     },
     "node_modules/@valkey/valkey-glide-darwin-x64": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-darwin-x64/-/valkey-glide-darwin-x64-1.3.4.tgz",
-      "integrity": "sha512-Jl/x1WovhwiP7lWUcA99tw68Usb3GCHZ/ISD/1F23cVErXJ9qB4ZNCFI8Y1QrmwEPSeojKsxSpqylrsInuv1ng==",
-      "bundleDependencies": [
-        "glide-rs"
-      ],
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-darwin-x64/-/valkey-glide-darwin-x64-2.4.2.tgz",
+      "integrity": "sha512-qd68iRRAdQ3maWJMgf44JE6v4dk9S5mCWXcRwBa6BzjqzLNoqiHa13lf+YOzaEj4EQEPKz6leBIfQEqIs1ZNMw==",
       "cpu": [
         "x64"
       ],
@@ -2831,115 +2802,59 @@
       "optional": true,
       "os": [
         "darwin"
-      ],
-      "dependencies": {
-        "glide-rs": "file:rust-client",
-        "long": "5",
-        "protobufjs": "7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
+      ]
     },
-    "node_modules/@valkey/valkey-glide-linux-arm64": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-arm64/-/valkey-glide-linux-arm64-1.3.4.tgz",
-      "integrity": "sha512-ubTZDaEqlwS8NNuIggWt36I1BbtUNE17uHrCaBvUfc+aR1870r4xqvQNyvpQhT/VezfJisSBGKudFdLKeFrIjg==",
-      "bundleDependencies": [
-        "glide-rs"
-      ],
+    "node_modules/@valkey/valkey-glide-linux-arm64-gnu": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-arm64-gnu/-/valkey-glide-linux-arm64-gnu-2.4.2.tgz",
+      "integrity": "sha512-zzstOJvpXHHZSnwBdkk3J0fz8v3+HjPGa/4PktldBTR5VZ3ZfS5+HFuXdRR6/nNpww5fcTQ0KRYdAONUWDiWsw==",
       "cpu": [
         "arm64"
       ],
-      "deprecated": "This package will be replaced by @valkey/valkey-glide-linux-arm64-gnu in v2.0",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "dependencies": {
-        "glide-rs": "file:rust-client",
-        "long": "5",
-        "protobufjs": "7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
+      ]
     },
-    "node_modules/@valkey/valkey-glide-linux-musl-arm64": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-musl-arm64/-/valkey-glide-linux-musl-arm64-1.3.4.tgz",
-      "integrity": "sha512-zNkmKXrT9ebe/XWtevzFleRrXycrzsLtmDjdQJGVUC96gUA3DcczK/gfu2rgvgH84C5s5jKbSM7oeo8f8eX4Vw==",
-      "bundleDependencies": [
-        "glide-rs"
-      ],
+    "node_modules/@valkey/valkey-glide-linux-arm64-musl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-arm64-musl/-/valkey-glide-linux-arm64-musl-2.4.2.tgz",
+      "integrity": "sha512-Li7htG1mAikPRN2v9IggIuFED6zGjMRlcYS+42qbNeXRjyYG/V4M4Y0TjAhS2qte6jRqpgCbuyEQSIVt5JSWEQ==",
       "cpu": [
         "arm64"
       ],
-      "deprecated": "This package will be replaced by @valkey/valkey-glide-linux-arm64-musl in v2.0",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "dependencies": {
-        "glide-rs": "file:rust-client",
-        "long": "5",
-        "protobufjs": "7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
+      ]
     },
-    "node_modules/@valkey/valkey-glide-linux-musl-x64": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-musl-x64/-/valkey-glide-linux-musl-x64-1.3.4.tgz",
-      "integrity": "sha512-QSaLTp81V0agKcGXsr3LUF+Vl4nTHrf5eBNV7/2GwbA4Pwed2x8TzORAjv+aS368hWR/9zftbVA1Xjn8TAND3w==",
-      "bundleDependencies": [
-        "glide-rs"
-      ],
+    "node_modules/@valkey/valkey-glide-linux-x64-gnu": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-x64-gnu/-/valkey-glide-linux-x64-gnu-2.4.2.tgz",
+      "integrity": "sha512-3cJfKpJSzXgsVwhNdeQcHO73L5K42V1iZaLGpLsXPwtuEO8olSu/tslN24AYgjwTM3QghOQb0k66x6JonB+3rA==",
       "cpu": [
         "x64"
       ],
-      "deprecated": "This package will be replaced by @valkey/valkey-glide-linux-x64-musl in v2.0",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "dependencies": {
-        "glide-rs": "file:rust-client",
-        "long": "5",
-        "protobufjs": "7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
+      ]
     },
-    "node_modules/@valkey/valkey-glide-linux-x64": {
-      "version": "1.3.4",
-      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-x64/-/valkey-glide-linux-x64-1.3.4.tgz",
-      "integrity": "sha512-j9acGMsr7T1oY377xBsIkY4rjtDqb78/OSH3CFcdntcJZU6u6fvcqGXG5Co/iRDvsm+q9uuYd/H5ITnGx60kng==",
-      "bundleDependencies": [
-        "glide-rs"
-      ],
+    "node_modules/@valkey/valkey-glide-linux-x64-musl": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/@valkey/valkey-glide-linux-x64-musl/-/valkey-glide-linux-x64-musl-2.4.2.tgz",
+      "integrity": "sha512-YBPVVW84VSOFfIME6jqE6DAQKiV688oWkhjNmakJ/xm4Pxae78QWNBI0s2Rbwpfy7PQ59gJ/ZfwPVbMHOXp/vw==",
       "cpu": [
         "x64"
       ],
-      "deprecated": "This package will be replaced by @valkey/valkey-glide-linux-x64-gnu in v2.0",
       "license": "Apache-2.0",
       "optional": true,
       "os": [
         "linux"
-      ],
-      "dependencies": {
-        "glide-rs": "file:rust-client",
-        "long": "5",
-        "protobufjs": "7"
-      },
-      "engines": {
-        "node": ">=16"
-      }
+      ]
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -3708,15 +3623,6 @@
       "license": "Apache-2.0",
       "engines": {
         "node": ">=0.10"
-      }
-    },
-    "node_modules/detect-libc": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
-      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
-      "license": "Apache-2.0",
-      "engines": {
-        "node": ">=8"
       }
     },
     "node_modules/detect-newline": {
@@ -5934,8 +5840,7 @@
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/long/-/long-5.3.2.tgz",
       "integrity": "sha512-mNAgZ1GmyNhD7AuqnTG3/VQ26o760+ZYBPKjPvugO8+nLbYfX6TVpJPseBvopbdY+qpZ/lKUnmEc1LeZYS3QAA==",
-      "license": "Apache-2.0",
-      "optional": true
+      "license": "Apache-2.0"
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -6720,7 +6625,6 @@
       "integrity": "sha512-RJJPTTpvFfHcWLkIa2JFWK4XvtSzS0yEWDmunqHXli1h3JlkbcQZXDZdcWxv+JK3Xsl5/UFDPZ0iGm7DAengYw==",
       "hasInstallScript": true,
       "license": "BSD-3-Clause",
-      "optional": true,
       "dependencies": {
         "@protobufjs/aspromise": "^1.1.2",
         "@protobufjs/base64": "^1.1.2",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,8 @@
     "jose": "^6.0.11",
     "patch-package": "^8.0.1",
     "ws": "^8.18.0",
-    "zod": "^3.22.4"
+    "zod": "^3.22.4",
+    "@valkey/valkey-glide": "1.3.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",

--- a/package.json
+++ b/package.json
@@ -48,15 +48,15 @@
     "@portkey-ai/mustache": "^2.1.3",
     "@smithy/signature-v4": "^2.1.1",
     "@types/mustache": "^4.2.5",
+    "@valkey/valkey-glide": "2.4.2",
     "async-retry": "^1.3.3",
     "avsc": "^5.7.7",
-    "ioredis": "^5.8.0",
     "hono": "^4.9.7",
+    "ioredis": "^5.8.0",
     "jose": "^6.0.11",
     "patch-package": "^8.0.1",
     "ws": "^8.18.0",
-    "zod": "^3.22.4",
-    "@valkey/valkey-glide": "1.3.4"
+    "zod": "^3.22.4"
   },
   "devDependencies": {
     "@cloudflare/workers-types": "^4.20230518.0",

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -113,6 +113,7 @@ export const ORACLE: string = 'oracle';
 export const IO_INTELLIGENCE: string = 'iointelligence';
 export const AIBADGR: string = 'aibadgr';
 export const OVHCLOUD: string = 'ovhcloud';
+export const VALKEY_SEARCH: string = 'valkey-search';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -189,6 +190,7 @@ export const VALID_PROVIDERS = [
   IO_INTELLIGENCE,
   AIBADGR,
   OVHCLOUD,
+  VALKEY_SEARCH,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/handlers/handlerUtils.ts
+++ b/src/handlers/handlerUtils.ts
@@ -1148,6 +1148,7 @@ export function constructConfigFromRequestHeaders(
   return {
     provider: requestHeaders[`x-${POWERED_BY}-provider`],
     apiKey: requestHeaders['authorization']?.replace('Bearer ', ''),
+    customHost: requestHeaders[`x-${POWERED_BY}-custom-host`],
     defaultInputGuardrails: defaultsConfig.input_guardrails,
     defaultOutputGuardrails: defaultsConfig.output_guardrails,
     ...(requestHeaders[`x-${POWERED_BY}-provider`] === AZURE_OPEN_AI &&

--- a/src/index.ts
+++ b/src/index.ts
@@ -40,13 +40,25 @@ import modelResponsesHandler from './handlers/modelResponsesHandler';
 import { logger } from './apm';
 // Config
 import conf from '../conf.json';
-import { createCacheBackendsRedis } from './shared/services/cache';
+import {
+  createCacheBackendsRedis,
+  createCacheBackendsValkey,
+} from './shared/services/cache';
 
 // Create a new Hono server instance
 const app = new Hono();
 const runtime = getRuntimeKey();
 
-if (runtime === 'node' && process.env.REDIS_CONNECTION_STRING) {
+if (runtime === 'node' && process.env.VALKEY_CONNECTION_STRING) {
+  createCacheBackendsValkey(process.env.VALKEY_CONNECTION_STRING).catch(
+    (err) => {
+      console.error(
+        '[gateway] Failed to initialize Valkey cache backends:',
+        err
+      );
+    }
+  );
+} else if (runtime === 'node' && process.env.REDIS_CONNECTION_STRING) {
   createCacheBackendsRedis(process.env.REDIS_CONNECTION_STRING);
 }
 /**

--- a/src/middlewares/cache/index.ts
+++ b/src/middlewares/cache/index.ts
@@ -1,4 +1,18 @@
 import { Context } from 'hono';
+import { getDefaultCache } from '../../shared/services/cache/index';
+
+let defaultCacheService: any = null;
+
+function getLLMCache() {
+  if (!defaultCacheService) {
+    try {
+      defaultCacheService = getDefaultCache();
+    } catch {
+      // Cache not initialized yet - fall through to in-memory
+    }
+  }
+  return defaultCacheService;
+}
 
 const inMemoryCache: any = {};
 
@@ -40,7 +54,17 @@ export const getFromCache = async (
   }
   try {
     const cacheKey = await getCacheKey(requestBody, url);
+    const cache = getLLMCache();
 
+    if (cache) {
+      const cached = await cache.get(cacheKey, 'llm-responses');
+      if (cached) {
+        return [cached, CACHE_STATUS.HIT, cacheKey];
+      }
+      return [null, CACHE_STATUS.MISS, null];
+    }
+
+    // Fallback: in-memory
     if (cacheKey in inMemoryCache) {
       const cacheObject = inMemoryCache[cacheKey];
       if (cacheObject.maxAge && cacheObject.maxAge < Date.now()) {
@@ -68,16 +92,27 @@ export const putInCache = async (
   cacheMaxAge: number | null
 ) => {
   if (requestBody.stream) {
-    // Does not support caching of streams
     return;
   }
 
   const cacheKey = await getCacheKey(requestBody, url);
+  const responseString = JSON.stringify(responseBody);
+  const cache = getLLMCache();
 
-  inMemoryCache[cacheKey] = {
-    responseBody: JSON.stringify(responseBody),
-    maxAge: cacheMaxAge,
-  };
+  if (cache) {
+    const ttl = cacheMaxAge ? cacheMaxAge - Date.now() : 24 * 60 * 60 * 1000;
+    if (ttl <= 0) return;
+    await cache.set(cacheKey, responseString, {
+      namespace: 'llm-responses',
+      ttl,
+    });
+  } else {
+    // Fallback: in-memory
+    inMemoryCache[cacheKey] = {
+      responseBody: responseString,
+      maxAge: cacheMaxAge,
+    };
+  }
 };
 
 export const memoryCache = () => {
@@ -92,7 +127,7 @@ export const memoryCache = () => {
       requestOptions &&
       Array.isArray(requestOptions) &&
       requestOptions.length > 0 &&
-      requestOptions[0].requestParams.stream === (false || undefined)
+      !requestOptions[0].requestParams?.stream
     ) {
       requestOptions = requestOptions[0];
       if (requestOptions.cacheMode === 'simple') {

--- a/src/middlewares/cache/index.ts
+++ b/src/middlewares/cache/index.ts
@@ -1,17 +1,12 @@
 import { Context } from 'hono';
 import { getDefaultCache } from '../../shared/services/cache/index';
 
-let defaultCacheService: any = null;
-
 function getLLMCache() {
-  if (!defaultCacheService) {
-    try {
-      defaultCacheService = getDefaultCache();
-    } catch {
-      // Cache not initialized yet - fall through to in-memory
-    }
+  try {
+    return getDefaultCache();
+  } catch {
+    return null;
   }
-  return defaultCacheService;
 }
 
 const inMemoryCache: any = {};

--- a/src/middlewares/log/index.ts
+++ b/src/middlewares/log/index.ts
@@ -119,7 +119,7 @@ async function processLog(c: Context, start: number) {
   }
 
   try {
-    const response = requestOptionsArray[0].requestParams.stream
+    const response = requestOptionsArray[0].requestParams?.stream
       ? { message: 'The response was a stream.' }
       : await c.res.clone().json();
 

--- a/src/middlewares/requestValidator/index.ts
+++ b/src/middlewares/requestValidator/index.ts
@@ -275,12 +275,28 @@ export function isValidCustomHost(customHost: string, c?: Context) {
     const url = new URL(customHost);
     const protocol = url.protocol;
 
-    // Allow only HTTP(S)
-    if (protocol !== 'http:' && protocol !== 'https:') return false;
+    // Allow HTTP(S) and Valkey/Redis protocols (for valkey-search provider)
+    const allowedProtocols = [
+      'http:',
+      'https:',
+      'valkey:',
+      'valkeys:',
+      'redis:',
+      'rediss:',
+    ];
+    if (!allowedProtocols.includes(protocol)) return false;
 
-    // Disallow credentials and obfuscation
-    if (url.username || url.password) return false;
-    if (customHost.includes('@')) return false;
+    // Disallow credentials and obfuscation (except for valkey/redis where password-in-URL is standard)
+    const isValkeyScheme = [
+      'valkey:',
+      'valkeys:',
+      'redis:',
+      'rediss:',
+    ].includes(protocol);
+    if (!isValkeyScheme) {
+      if (url.username || url.password) return false;
+      if (customHost.includes('@')) return false;
+    }
 
     const host = url.hostname;
 

--- a/src/middlewares/requestValidator/index.ts
+++ b/src/middlewares/requestValidator/index.ts
@@ -339,39 +339,15 @@ export function isValidCustomHost(customHost: string, c?: Context) {
     // Block obvious internal/unsafe hosts and cloud metadata endpoints
     if (BLOCKED_HOSTS.includes(host as any)) return false;
 
-    // Block AWS IMDSv2 endpoint variations
-    if (host.startsWith('169.254.169.') || host.startsWith('fd00:ec2::')) {
-      return false;
-    }
+    // Private IP / reserved host checks apply to ALL schemes (including valkey://)
+    // to prevent SSRF against internal infrastructure via any protocol.
+    if (isPrivateOrReservedHost(host)) return false;
 
     // Block internal/special-use TLDs often used in SSRF attempts
     if (
       BLOCKED_TLDS.some((tld) => host.endsWith(tld) && host !== 'localhost')
     ) {
       return false;
-    }
-
-    // Block private/reserved IPs (IPv4)
-    if (isIPv4(hostParts) && (isPrivateIPv4(host) || isReservedIPv4(host))) {
-      return false;
-    }
-
-    // Check for alternative IP representations (decimal, hex, octal)
-    if (isAlternativeIPRepresentation(host, hostParts)) return false;
-
-    // Block private/reserved IPv6 and IPv4-mapped IPv6
-    if (host.includes(':')) {
-      if (isLocalOrPrivateIPv6(host)) return false;
-
-      // Check both IPv6-mapped and embedded IPv4 patterns
-      const ipv4Match =
-        host.match(VALIDATION_PATTERNS.IPV6_MAPPED_IPV4) ||
-        host.match(VALIDATION_PATTERNS.IPV6_EMBEDDED_IPV4);
-
-      if (ipv4Match) {
-        const ip4 = ipv4Match[1];
-        if (isPrivateIPv4(ip4) || isReservedIPv4(ip4)) return false;
-      }
     }
 
     // Validate port if present
@@ -487,6 +463,44 @@ function isAlternativeIPRepresentation(host: string, parts: string[]): boolean {
     ) {
       // Looks like a shortened IP format - block it
       return true;
+    }
+  }
+
+  return false;
+}
+
+/**
+ * Consolidated private/reserved host check for use across all protocols.
+ * Returns true if the hostname resolves to (or is) a private, reserved,
+ * loopback, or metadata IP address.
+ */
+function isPrivateOrReservedHost(host: string): boolean {
+  // Block AWS IMDS
+  if (host.startsWith('169.254.169.') || host.startsWith('fd00:ec2::')) {
+    return true;
+  }
+
+  const hostParts = host.split('.');
+
+  // Block private/reserved IPv4
+  if (isIPv4(hostParts) && (isPrivateIPv4(host) || isReservedIPv4(host))) {
+    return true;
+  }
+
+  // Block alternative IP representations (decimal, hex, octal)
+  if (isAlternativeIPRepresentation(host, hostParts)) return true;
+
+  // Block private/reserved IPv6 and IPv4-mapped IPv6
+  if (host.includes(':')) {
+    if (isLocalOrPrivateIPv6(host)) return true;
+
+    const ipv4Match =
+      host.match(VALIDATION_PATTERNS.IPV6_MAPPED_IPV4) ||
+      host.match(VALIDATION_PATTERNS.IPV6_EMBEDDED_IPV4);
+
+    if (ipv4Match) {
+      const ip4 = ipv4Match[1];
+      if (isPrivateIPv4(ip4) || isReservedIPv4(ip4)) return true;
     }
   }
 

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,6 +74,7 @@ import OracleConfig from './oracle';
 import IOIntelligenceConfig from './iointelligence';
 import AIBadgrConfig from './aibadgr';
 import OVHcloudConfig from './ovhcloud';
+import ValkeySearchConfig from './valkey-search';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -148,6 +149,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   iointelligence: IOIntelligenceConfig,
   aibadgr: AIBadgrConfig,
   ovhcloud: OVHcloudConfig,
+  'valkey-search': ValkeySearchConfig,
 };
 
 export default Providers;

--- a/src/providers/types.ts
+++ b/src/providers/types.ts
@@ -117,7 +117,13 @@ export type endpointStrings =
   | 'deleteModelResponse'
   | 'listResponseInputItems'
   | 'messages'
-  | 'messagesCountTokens';
+  | 'messagesCountTokens'
+  | 'createIndex'
+  | 'dropIndex'
+  | 'getIndex'
+  | 'upsertDocs'
+  | 'searchIndex'
+  | 'deleteDocs';
 
 /**
  * A collection of API configurations for multiple AI providers.

--- a/src/providers/valkey-search/api.ts
+++ b/src/providers/valkey-search/api.ts
@@ -1,0 +1,26 @@
+/**
+ * @file src/providers/valkey-search/api.ts
+ * Provider API config for the valkey-search provider.
+ *
+ * This provider uses the requestHandlers pattern (native RESP commands via
+ * valkey-glide) rather than HTTP proxying, so getBaseURL and getEndpoint are
+ * stubs - they are never called for endpoints that have a requestHandler.
+ */
+import { ProviderAPIConfig } from '../types';
+
+const ValkeySearchAPIConfig: ProviderAPIConfig = {
+  getBaseURL: ({ providerOptions }) => {
+    // customHost is the Valkey server address, e.g. "my-valkey.cache.amazonaws.com:6379"
+    return providerOptions.customHost || '';
+  },
+  headers: () => {
+    // No HTTP headers needed - GLIDE communicates over RESP protocol
+    return {};
+  },
+  getEndpoint: () => {
+    // All routing is handled via requestHandlers; this stub is required by the interface
+    return '';
+  },
+};
+
+export default ValkeySearchAPIConfig;

--- a/src/providers/valkey-search/handlers.ts
+++ b/src/providers/valkey-search/handlers.ts
@@ -1,0 +1,552 @@
+/**
+ * @file src/providers/valkey-search/handlers.ts
+ * Request handlers for the valkey-search provider.
+ *
+ * Each handler maps to a Valkey FT.* or hash command executed natively via
+ * @valkey/valkey-glide over the RESP protocol. No HTTP proxying is involved.
+ *
+ * Endpoint mapping:
+ *  POST   /v1/indexes                       -> createIndex   (FT.CREATE)
+ *  DELETE /v1/indexes/:name                 -> dropIndex     (FT.DROPINDEX)
+ *  GET    /v1/indexes/:name                 -> getIndex      (FT.INFO)
+ *  POST   /v1/indexes/:name/upsert          -> upsertDocs    (HSET per document)
+ *  POST   /v1/indexes/:name/search          -> searchIndex   (FT.SEARCH with KNN)
+ *  POST   /v1/indexes/:name/documents/delete -> deleteDocs   (DEL array of keys)
+ */
+import {
+  GlideClient,
+  GlideClusterClient,
+  GlideFt,
+  Decoder,
+  Field,
+} from '@valkey/valkey-glide';
+import {
+  createValkeyClient,
+  parseValkeyConnectionString,
+} from '../../shared/services/valkey/client';
+import { RequestHandler } from '../types';
+
+type AnyGlideClient = GlideClient | GlideClusterClient;
+
+// ---------------------------------------------------------------------------
+// Client cache - reuse connections keyed by address string
+// ---------------------------------------------------------------------------
+const clientCache = new Map<string, Promise<AnyGlideClient>>();
+
+function getClient(customHost: string): Promise<AnyGlideClient> {
+  const address = customHost.includes('://')
+    ? customHost
+    : `valkey://${customHost}`;
+
+  if (!clientCache.has(address)) {
+    const { addresses, options } = parseValkeyConnectionString(address);
+    const p = createValkeyClient(addresses, options).catch((err) => {
+      clientCache.delete(address);
+      throw err;
+    });
+    clientCache.set(address, p);
+  }
+  return clientCache.get(address)!;
+}
+
+// Graceful shutdown: close all cached GLIDE connections
+if (typeof process !== 'undefined') {
+  const closeAll = async () => {
+    for (const [, p] of clientCache) {
+      try {
+        (await p).close();
+      } catch {}
+    }
+    clientCache.clear();
+  };
+  process.once('SIGTERM', closeAll);
+  process.once('SIGINT', closeAll);
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+function jsonResponse(body: unknown, status = 200): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  });
+}
+
+function errorResponse(message: string, status = 400): Response {
+  return jsonResponse(
+    { error: { message, type: 'valkey_error', param: null, code: null } },
+    status
+  );
+}
+
+/**
+ * Extract the index name from the request URL.
+ * URLs follow the pattern /v1/indexes/:name[/...]
+ */
+function extractIndexName(url: string): string | null {
+  const match = url.match(/\/v1\/indexes\/([^/]+)/);
+  return match ? decodeURIComponent(match[1]) : null;
+}
+
+// Allowlist: alphanumeric, underscore, hyphen only; max 128 chars
+function validateIndexName(name: string): string | null {
+  if (!/^[a-zA-Z0-9_-]{1,128}$/.test(name)) {
+    return 'index name must contain only alphanumeric characters, underscores, and hyphens (max 128 chars)';
+  }
+  return null;
+}
+
+// Allowlist for document IDs: alphanumeric, underscore, colon, dot, hyphen; max 256 chars
+function validateDocId(id: string): boolean {
+  return typeof id === 'string' && /^[a-zA-Z0-9_:.-]{1,256}$/.test(id);
+}
+
+/**
+ * Security guard: reject filter strings containing "=>" to prevent KNN-clause injection.
+ * A filter containing "=>" could allow an attacker to append their own KNN clause.
+ */
+function validateFilter(filter: unknown): string | null {
+  if (filter === undefined || filter === null) return null;
+  if (typeof filter !== 'string') return 'filter must be a string';
+  if (filter.includes('=>')) {
+    return 'filter expression must not contain "=>" (KNN-clause injection risk)';
+  }
+  return null;
+}
+
+/**
+ * Distinguish "index not found" errors from connection/other errors.
+ * GLIDE throws with message containing "Unknown index" for missing indexes.
+ */
+function isIndexNotFoundError(err: any): boolean {
+  const msg = err?.message ?? '';
+  return msg.includes('Unknown index') || msg.includes('no such index');
+}
+
+const MAX_BATCH_SIZE = 1000;
+
+// ---------------------------------------------------------------------------
+// Schema conversion helper
+// ---------------------------------------------------------------------------
+/**
+ * Convert the request body's schema object (keyed by field name) into the
+ * typed Field[] array required by GlideFt.create.
+ *
+ * Request format:
+ *   { "vector": { "type": "VECTOR", "algorithm": "HNSW", "dims": 1536, "distance": "COSINE" },
+ *     "content": { "type": "TEXT" },
+ *     "source":  { "type": "TAG" } }
+ *
+ * The user may pass either the GLIDE key names (dimensions, distanceMetric) or
+ * the shorthand aliases used in our API (dims, distance).
+ */
+function buildFields(schema: Record<string, any>): Field[] {
+  return Object.entries(schema).map(([fieldName, config]) => {
+    const type = (config.type as string).toUpperCase();
+    if (type === 'VECTOR') {
+      const algorithm = (config.algorithm ?? 'HNSW') as 'HNSW' | 'FLAT';
+      const dimensions = config.dims ?? config.dimensions;
+      const distanceMetric = (config.distance ?? config.distanceMetric) as
+        | 'L2'
+        | 'IP'
+        | 'COSINE';
+      return {
+        type: 'VECTOR' as const,
+        name: fieldName,
+        attributes: { algorithm, dimensions, distanceMetric },
+      };
+    }
+    if (type === 'TAG') return { type: 'TAG' as const, name: fieldName };
+    if (type === 'NUMERIC')
+      return { type: 'NUMERIC' as const, name: fieldName };
+    // default to TEXT
+    return { type: 'TEXT' as const, name: fieldName };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// POST /v1/indexes  ->  FT.CREATE
+// ---------------------------------------------------------------------------
+export const createIndexHandler: RequestHandler = async ({
+  providerOptions,
+  requestBody,
+}) => {
+  const body = requestBody as any;
+  const { name, schema, options: indexOptions } = body;
+
+  if (!name || typeof name !== 'string') {
+    return errorResponse('name is required and must be a string');
+  }
+  const nameError = validateIndexName(name);
+  if (nameError) return errorResponse(nameError);
+  if (!schema || typeof schema !== 'object') {
+    return errorResponse('schema is required and must be an object');
+  }
+
+  const customHost = providerOptions.customHost || '';
+  if (!customHost) {
+    return errorResponse(
+      'customHost is required for valkey-search provider',
+      400
+    );
+  }
+
+  let client: AnyGlideClient;
+  try {
+    client = await getClient(customHost);
+  } catch (err: any) {
+    console.error('[valkey-search] Connection failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+
+  // Check if index already exists
+  try {
+    await GlideFt.info(client, name);
+    return errorResponse(`Index "${name}" already exists`, 409);
+  } catch (err: any) {
+    if (!isIndexNotFoundError(err)) {
+      console.error('[valkey-search] FT.INFO failed:', err.message);
+      return errorResponse('Service temporarily unavailable', 503);
+    }
+    // Index does not exist - proceed
+  }
+
+  try {
+    const fields = buildFields(schema);
+    const ftOptions = indexOptions
+      ? {
+          dataType: (indexOptions.dataType ?? 'HASH') as 'HASH' | 'JSON',
+          prefixes: indexOptions.prefix
+            ? [indexOptions.prefix]
+            : indexOptions.prefixes ?? [],
+        }
+      : undefined;
+    await GlideFt.create(client, name, fields, ftOptions);
+    return jsonResponse({ object: 'index', name, status: 'created' }, 201);
+  } catch (err: any) {
+    console.error('[valkey-search] FT.CREATE failed:', err.message);
+    return errorResponse('Failed to create index', 500);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// DELETE /v1/indexes/:name  ->  FT.DROPINDEX
+// ---------------------------------------------------------------------------
+export const dropIndexHandler: RequestHandler = async ({
+  providerOptions,
+  requestURL,
+}) => {
+  const name = extractIndexName(requestURL);
+  if (!name) return errorResponse('Could not parse index name from URL');
+  const nameError = validateIndexName(name);
+  if (nameError) return errorResponse(nameError);
+
+  const customHost = providerOptions.customHost || '';
+  if (!customHost) {
+    return errorResponse(
+      'customHost is required for valkey-search provider',
+      400
+    );
+  }
+
+  let client: AnyGlideClient;
+  try {
+    client = await getClient(customHost);
+  } catch (err: any) {
+    console.error('[valkey-search] Connection failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+
+  // Pre-validate: raise if index missing
+  try {
+    await GlideFt.info(client, name);
+  } catch (err: any) {
+    if (isIndexNotFoundError(err)) {
+      return errorResponse(`Index "${name}" not found`, 404);
+    }
+    console.error('[valkey-search] FT.INFO failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+
+  try {
+    await GlideFt.dropindex(client, name);
+    return jsonResponse({ object: 'index', name, deleted: true });
+  } catch (err: any) {
+    console.error('[valkey-search] FT.DROPINDEX failed:', err.message);
+    return errorResponse('Failed to drop index', 500);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// GET /v1/indexes/:name  ->  FT.INFO
+// ---------------------------------------------------------------------------
+export const getIndexHandler: RequestHandler = async ({
+  providerOptions,
+  requestURL,
+}) => {
+  const name = extractIndexName(requestURL);
+  if (!name) return errorResponse('Could not parse index name from URL');
+  const nameError = validateIndexName(name);
+  if (nameError) return errorResponse(nameError);
+
+  const customHost = providerOptions.customHost || '';
+  if (!customHost) {
+    return errorResponse(
+      'customHost is required for valkey-search provider',
+      400
+    );
+  }
+
+  let client: AnyGlideClient;
+  try {
+    client = await getClient(customHost);
+  } catch (err: any) {
+    console.error('[valkey-search] Connection failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+
+  try {
+    const info = await GlideFt.info(client, name);
+    return jsonResponse({ object: 'index', name, info });
+  } catch (err: any) {
+    if (isIndexNotFoundError(err)) {
+      return errorResponse(`Index "${name}" not found`, 404);
+    }
+    console.error('[valkey-search] FT.INFO failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// POST /v1/indexes/:name/upsert  ->  HSET per document
+// ---------------------------------------------------------------------------
+export const upsertDocsHandler: RequestHandler = async ({
+  providerOptions,
+  requestURL,
+  requestBody,
+}) => {
+  const indexName = extractIndexName(requestURL);
+  if (!indexName) return errorResponse('Could not parse index name from URL');
+  const nameError = validateIndexName(indexName);
+  if (nameError) return errorResponse(nameError);
+
+  const body = requestBody as any;
+  const documents: Array<{
+    id: string;
+    fields: Record<string, any>;
+    vector?: number[];
+  }> = body?.documents;
+
+  if (!Array.isArray(documents) || documents.length === 0) {
+    return errorResponse('documents must be a non-empty array');
+  }
+  if (documents.length > MAX_BATCH_SIZE) {
+    return errorResponse(
+      `documents array exceeds maximum batch size of ${MAX_BATCH_SIZE}`
+    );
+  }
+
+  const customHost = providerOptions.customHost || '';
+  if (!customHost) {
+    return errorResponse(
+      'customHost is required for valkey-search provider',
+      400
+    );
+  }
+
+  let client: AnyGlideClient;
+  try {
+    client = await getClient(customHost);
+  } catch (err: any) {
+    console.error('[valkey-search] Connection failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+
+  const results: Array<{ id: string; status: string; error?: string }> = [];
+
+  for (const doc of documents) {
+    if (!doc.id || typeof doc.id !== 'string') {
+      results.push({
+        id: String(doc.id ?? ''),
+        status: 'error',
+        error: 'id must be a non-empty string',
+      });
+      continue;
+    }
+    if (!validateDocId(doc.id)) {
+      results.push({
+        id: String(doc.id),
+        status: 'error',
+        error:
+          'id contains invalid characters (allowed: alphanumeric, _ : . -)',
+      });
+      continue;
+    }
+
+    const key = `${indexName}:${doc.id}`;
+    const fieldMap: Record<string, any> = { ...(doc.fields || {}) };
+
+    // Serialize vector as raw Float32 bytes - NEVER call .toString() on the buffer
+    if (Array.isArray(doc.vector)) {
+      const float32 = new Float32Array(doc.vector);
+      fieldMap['vector'] = Buffer.from(float32.buffer);
+    }
+
+    try {
+      await client.hset(key, fieldMap);
+      results.push({ id: doc.id, status: 'upserted' });
+    } catch (err: any) {
+      results.push({ id: doc.id, status: 'error', error: 'write failed' });
+    }
+  }
+
+  const hasErrors = results.some((r) => r.status === 'error');
+  return jsonResponse({ object: 'list', data: results }, hasErrors ? 207 : 200);
+};
+
+// ---------------------------------------------------------------------------
+// POST /v1/indexes/:name/search  ->  FT.SEARCH with KNN query
+// ---------------------------------------------------------------------------
+export const searchIndexHandler: RequestHandler = async ({
+  providerOptions,
+  requestURL,
+  requestBody,
+}) => {
+  const indexName = extractIndexName(requestURL);
+  if (!indexName) return errorResponse('Could not parse index name from URL');
+  const nameError = validateIndexName(indexName);
+  if (nameError) return errorResponse(nameError);
+
+  const body = requestBody as any;
+  const { vector, top_k = 10, filter, return_fields } = body;
+
+  if (!Array.isArray(vector) || vector.length === 0) {
+    return errorResponse('vector must be a non-empty array of numbers');
+  }
+
+  const k =
+    typeof top_k === 'number' &&
+    Number.isInteger(top_k) &&
+    top_k >= 1 &&
+    top_k <= 10000
+      ? top_k
+      : null;
+  if (k === null)
+    return errorResponse('top_k must be an integer between 1 and 10000');
+
+  const filterError = validateFilter(filter);
+  if (filterError) return errorResponse(filterError);
+
+  const customHost = providerOptions.customHost || '';
+  if (!customHost) {
+    return errorResponse(
+      'customHost is required for valkey-search provider',
+      400
+    );
+  }
+
+  let client: AnyGlideClient;
+  try {
+    client = await getClient(customHost);
+  } catch (err: any) {
+    console.error('[valkey-search] Connection failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+
+  // Pre-validate index exists
+  try {
+    await GlideFt.info(client, indexName);
+  } catch (err: any) {
+    if (isIndexNotFoundError(err)) {
+      return errorResponse(`Index "${indexName}" not found`, 404);
+    }
+    console.error('[valkey-search] FT.INFO failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+
+  // Build KNN query: (filter)=>[KNN k @vector $BLOB AS __score]
+  const filterClause = filter ? `(${filter})` : '*';
+  const query = `${filterClause}=>[KNN ${k} @vector $BLOB AS __score]`;
+
+  // Encode vector as Float32 bytes
+  const float32 = new Float32Array(vector);
+  const vectorBytes = Buffer.from(float32.buffer);
+
+  const searchParams: any = {
+    params: [{ key: 'BLOB', value: vectorBytes }],
+    decoder: Decoder.Bytes,
+  };
+
+  if (Array.isArray(return_fields) && return_fields.length > 0) {
+    searchParams.returnFields = return_fields;
+  }
+
+  try {
+    const results = await GlideFt.search(
+      client,
+      indexName,
+      query,
+      searchParams
+    );
+    return jsonResponse({ object: 'list', data: results });
+  } catch (err: any) {
+    console.error('[valkey-search] FT.SEARCH failed:', err.message);
+    return errorResponse('Search failed', 500);
+  }
+};
+
+// ---------------------------------------------------------------------------
+// POST /v1/indexes/:name/documents/delete  ->  DEL array of keys
+// ---------------------------------------------------------------------------
+export const deleteDocsHandler: RequestHandler = async ({
+  providerOptions,
+  requestURL,
+  requestBody,
+}) => {
+  const indexName = extractIndexName(requestURL);
+  if (!indexName) return errorResponse('Could not parse index name from URL');
+  const nameError = validateIndexName(indexName);
+  if (nameError) return errorResponse(nameError);
+
+  const body = requestBody as any;
+  const ids: string[] = body?.ids;
+
+  if (!Array.isArray(ids) || ids.length === 0) {
+    return errorResponse('ids must be a non-empty array of strings');
+  }
+
+  const invalidId = ids.find((id) => !validateDocId(id));
+  if (invalidId !== undefined) {
+    return errorResponse(
+      `Invalid document id: "${String(invalidId).slice(0, 64)}"`
+    );
+  }
+
+  const customHost = providerOptions.customHost || '';
+  if (!customHost) {
+    return errorResponse(
+      'customHost is required for valkey-search provider',
+      400
+    );
+  }
+
+  let client: AnyGlideClient;
+  try {
+    client = await getClient(customHost);
+  } catch (err: any) {
+    console.error('[valkey-search] Connection failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+
+  const keys = ids.map((id) => `${indexName}:${id}`);
+
+  try {
+    // GLIDE del() takes an array, not variadic args
+    const deleted = await client.del(keys);
+    return jsonResponse({ object: 'delete', deleted });
+  } catch (err: any) {
+    console.error('[valkey-search] DEL failed:', err.message);
+    return errorResponse('Delete failed', 500);
+  }
+};

--- a/src/providers/valkey-search/handlers.ts
+++ b/src/providers/valkey-search/handlers.ts
@@ -20,6 +20,7 @@ import {
   Decoder,
   Field,
 } from '@valkey/valkey-glide';
+import { createHash } from 'crypto';
 import {
   createValkeyClient,
   parseValkeyConnectionString,
@@ -39,11 +40,14 @@ function getClient(customHost: string): Promise<AnyGlideClient> {
     ? customHost
     : `valkey://${customHost}`;
 
-  if (clientCache.has(address)) {
+  // Hash the address to avoid storing credentials in Map keys (heap dump safety)
+  const cacheKey = createHash('sha256').update(address).digest('hex');
+
+  if (clientCache.has(cacheKey)) {
     // Move to end (most recently used)
-    const existing = clientCache.get(address)!;
-    clientCache.delete(address);
-    clientCache.set(address, existing);
+    const existing = clientCache.get(cacheKey)!;
+    clientCache.delete(cacheKey);
+    clientCache.set(cacheKey, existing);
     return existing;
   }
 
@@ -57,23 +61,22 @@ function getClient(customHost: string): Promise<AnyGlideClient> {
 
   const { addresses, options } = parseValkeyConnectionString(address);
   const p = createValkeyClient(addresses, options).catch((err) => {
-    clientCache.delete(address);
+    clientCache.delete(cacheKey);
     throw err;
   });
-  clientCache.set(address, p);
+  clientCache.set(cacheKey, p);
   return p;
 }
 
 // Graceful shutdown: close all cached GLIDE connections
 if (typeof process !== 'undefined') {
   const closeAll = async () => {
-    for (const [addr, p] of clientCache) {
+    for (const [, p] of clientCache) {
       try {
         (await p).close();
       } catch (e) {
         console.warn(
-          '[valkey-search] Error closing client:',
-          addr.replace(/\/\/[^@]*@/, '//***@'),
+          '[valkey-search] Error closing client during shutdown:',
           e
         );
       }

--- a/src/providers/valkey-search/handlers.ts
+++ b/src/providers/valkey-search/handlers.ts
@@ -71,7 +71,11 @@ if (typeof process !== 'undefined') {
       try {
         (await p).close();
       } catch (e) {
-        console.warn('[valkey-search] Error closing client:', addr, e);
+        console.warn(
+          '[valkey-search] Error closing client:',
+          addr.replace(/\/\/[^@]*@/, '//***@'),
+          e
+        );
       }
     }
     clientCache.clear();
@@ -162,6 +166,28 @@ function isIndexNotFoundError(err: any): boolean {
 
 const MAX_BATCH_SIZE = 1000;
 
+/**
+ * Shared connection boilerplate: validate customHost, acquire a GLIDE client.
+ * Returns the client on success or a pre-built error Response on failure.
+ */
+async function requireClient(providerOptions: {
+  customHost?: string;
+}): Promise<AnyGlideClient | Response> {
+  const customHost = providerOptions.customHost || '';
+  if (!customHost) {
+    return errorResponse(
+      'customHost is required for valkey-search provider',
+      400
+    );
+  }
+  try {
+    return await getClient(customHost);
+  } catch (err: any) {
+    console.error('[valkey-search] Connection failed:', err.message);
+    return errorResponse('Service temporarily unavailable', 503);
+  }
+}
+
 // ---------------------------------------------------------------------------
 // Schema conversion helper
 // ---------------------------------------------------------------------------
@@ -177,9 +203,14 @@ const MAX_BATCH_SIZE = 1000;
  * The user may pass either the GLIDE key names (dimensions, distanceMetric) or
  * the shorthand aliases used in our API (dims, distance).
  */
-function buildFields(schema: Record<string, any>): Field[] {
-  return Object.entries(schema).map(([fieldName, config]) => {
+function buildFields(schema: Record<string, any>): Field[] | string {
+  const ALLOWED_TYPES = new Set(['VECTOR', 'TAG', 'NUMERIC', 'TEXT']);
+  const fields: Field[] = [];
+  for (const [fieldName, config] of Object.entries(schema)) {
     const type = (config.type as string).toUpperCase();
+    if (!ALLOWED_TYPES.has(type)) {
+      return `Unsupported field type "${type}" for field "${fieldName}". Allowed: VECTOR, TAG, NUMERIC, TEXT`;
+    }
     if (type === 'VECTOR') {
       const algorithm = (config.algorithm ?? 'HNSW') as 'HNSW' | 'FLAT';
       const dimensions = config.dims ?? config.dimensions;
@@ -187,18 +218,20 @@ function buildFields(schema: Record<string, any>): Field[] {
         | 'L2'
         | 'IP'
         | 'COSINE';
-      return {
+      fields.push({
         type: 'VECTOR' as const,
         name: fieldName,
         attributes: { algorithm, dimensions, distanceMetric },
-      };
+      });
+    } else if (type === 'TAG') {
+      fields.push({ type: 'TAG' as const, name: fieldName });
+    } else if (type === 'NUMERIC') {
+      fields.push({ type: 'NUMERIC' as const, name: fieldName });
+    } else {
+      fields.push({ type: 'TEXT' as const, name: fieldName });
     }
-    if (type === 'TAG') return { type: 'TAG' as const, name: fieldName };
-    if (type === 'NUMERIC')
-      return { type: 'NUMERIC' as const, name: fieldName };
-    // default to TEXT
-    return { type: 'TEXT' as const, name: fieldName };
-  });
+  }
+  return fields;
 }
 
 // ---------------------------------------------------------------------------
@@ -220,21 +253,9 @@ export const createIndexHandler: RequestHandler = async ({
     return errorResponse('schema is required and must be an object');
   }
 
-  const customHost = providerOptions.customHost || '';
-  if (!customHost) {
-    return errorResponse(
-      'customHost is required for valkey-search provider',
-      400
-    );
-  }
-
-  let client: AnyGlideClient;
-  try {
-    client = await getClient(customHost);
-  } catch (err: any) {
-    console.error('[valkey-search] Connection failed:', err.message);
-    return errorResponse('Service temporarily unavailable', 503);
-  }
+  const clientOrError = await requireClient(providerOptions);
+  if (clientOrError instanceof Response) return clientOrError;
+  const client = clientOrError;
 
   // Check if index already exists
   try {
@@ -249,7 +270,11 @@ export const createIndexHandler: RequestHandler = async ({
   }
 
   try {
-    const fields = buildFields(schema);
+    const fieldsOrError = buildFields(schema);
+    if (typeof fieldsOrError === 'string') {
+      return errorResponse(fieldsOrError);
+    }
+    const fields = fieldsOrError;
     const ftOptions = indexOptions
       ? {
           dataType: (indexOptions.dataType ?? 'HASH') as 'HASH' | 'JSON',
@@ -278,21 +303,9 @@ export const dropIndexHandler: RequestHandler = async ({
   const nameError = validateIndexName(name);
   if (nameError) return errorResponse(nameError);
 
-  const customHost = providerOptions.customHost || '';
-  if (!customHost) {
-    return errorResponse(
-      'customHost is required for valkey-search provider',
-      400
-    );
-  }
-
-  let client: AnyGlideClient;
-  try {
-    client = await getClient(customHost);
-  } catch (err: any) {
-    console.error('[valkey-search] Connection failed:', err.message);
-    return errorResponse('Service temporarily unavailable', 503);
-  }
+  const clientOrError = await requireClient(providerOptions);
+  if (clientOrError instanceof Response) return clientOrError;
+  const client = clientOrError;
 
   // Pre-validate: raise if index missing
   try {
@@ -326,21 +339,9 @@ export const getIndexHandler: RequestHandler = async ({
   const nameError = validateIndexName(name);
   if (nameError) return errorResponse(nameError);
 
-  const customHost = providerOptions.customHost || '';
-  if (!customHost) {
-    return errorResponse(
-      'customHost is required for valkey-search provider',
-      400
-    );
-  }
-
-  let client: AnyGlideClient;
-  try {
-    client = await getClient(customHost);
-  } catch (err: any) {
-    console.error('[valkey-search] Connection failed:', err.message);
-    return errorResponse('Service temporarily unavailable', 503);
-  }
+  const clientOrError = await requireClient(providerOptions);
+  if (clientOrError instanceof Response) return clientOrError;
+  const client = clientOrError;
 
   try {
     const info = await GlideFt.info(client, name);
@@ -383,21 +384,9 @@ export const upsertDocsHandler: RequestHandler = async ({
     );
   }
 
-  const customHost = providerOptions.customHost || '';
-  if (!customHost) {
-    return errorResponse(
-      'customHost is required for valkey-search provider',
-      400
-    );
-  }
-
-  let client: AnyGlideClient;
-  try {
-    client = await getClient(customHost);
-  } catch (err: any) {
-    console.error('[valkey-search] Connection failed:', err.message);
-    return errorResponse('Service temporarily unavailable', 503);
-  }
+  const clientOrError = await requireClient(providerOptions);
+  if (clientOrError instanceof Response) return clientOrError;
+  const client = clientOrError;
 
   const results: Array<{ id: string; status: string; error?: string }> = [];
 
@@ -478,21 +467,9 @@ export const searchIndexHandler: RequestHandler = async ({
   const filterError = validateFilter(filter);
   if (filterError) return errorResponse(filterError);
 
-  const customHost = providerOptions.customHost || '';
-  if (!customHost) {
-    return errorResponse(
-      'customHost is required for valkey-search provider',
-      400
-    );
-  }
-
-  let client: AnyGlideClient;
-  try {
-    client = await getClient(customHost);
-  } catch (err: any) {
-    console.error('[valkey-search] Connection failed:', err.message);
-    return errorResponse('Service temporarily unavailable', 503);
-  }
+  const clientOrError = await requireClient(providerOptions);
+  if (clientOrError instanceof Response) return clientOrError;
+  const client = clientOrError;
 
   // Pre-validate index exists
   try {
@@ -531,7 +508,34 @@ export const searchIndexHandler: RequestHandler = async ({
       query,
       searchParams
     );
-    return jsonResponse({ object: 'list', data: results });
+    // results: [number, GlideRecord<GlideRecord<GlideString>>]
+    // GlideRecord is {key, value}[] — transform to consumer-friendly objects.
+    // With Decoder.Bytes, values are Buffer objects. Decode to UTF-8 where
+    // valid; skip fields that contain raw binary (e.g. vector embeddings).
+    const [totalCount, records] = results;
+    const hits = (records as any[]).map(({ key: docId, value: fields }) => {
+      const doc: Record<string, string> = {};
+      for (const { key: fieldName, value: fieldValue } of fields) {
+        const name = Buffer.isBuffer(fieldName)
+          ? fieldName.toString('utf8')
+          : String(fieldName);
+        // Skip binary vector fields — they cannot be meaningfully serialized as JSON strings
+        if (Buffer.isBuffer(fieldValue)) {
+          const str = fieldValue.toString('utf8');
+          // If decoding produces replacement chars, it's likely binary — omit
+          if (!str.includes('\ufffd') && fieldValue.length < 10000) {
+            doc[name] = str;
+          }
+        } else {
+          doc[name] = String(fieldValue);
+        }
+      }
+      return {
+        id: Buffer.isBuffer(docId) ? docId.toString('utf8') : String(docId),
+        fields: doc,
+      };
+    });
+    return jsonResponse({ object: 'list', total: totalCount, data: hits });
   } catch (err: any) {
     console.error('[valkey-search] FT.SEARCH failed:', err.message);
     return errorResponse('Search failed', 500);
@@ -557,6 +561,11 @@ export const deleteDocsHandler: RequestHandler = async ({
   if (!Array.isArray(ids) || ids.length === 0) {
     return errorResponse('ids must be a non-empty array of strings');
   }
+  if (ids.length > MAX_BATCH_SIZE) {
+    return errorResponse(
+      `ids array exceeds maximum batch size of ${MAX_BATCH_SIZE}`
+    );
+  }
 
   const invalidId = ids.find((id) => !validateDocId(id));
   if (invalidId !== undefined) {
@@ -565,21 +574,9 @@ export const deleteDocsHandler: RequestHandler = async ({
     );
   }
 
-  const customHost = providerOptions.customHost || '';
-  if (!customHost) {
-    return errorResponse(
-      'customHost is required for valkey-search provider',
-      400
-    );
-  }
-
-  let client: AnyGlideClient;
-  try {
-    client = await getClient(customHost);
-  } catch (err: any) {
-    console.error('[valkey-search] Connection failed:', err.message);
-    return errorResponse('Service temporarily unavailable', 503);
-  }
+  const clientOrError = await requireClient(providerOptions);
+  if (clientOrError instanceof Response) return clientOrError;
+  const client = clientOrError;
 
   const keys = ids.map((id) => `${indexName}:${id}`);
 

--- a/src/providers/valkey-search/handlers.ts
+++ b/src/providers/valkey-search/handlers.ts
@@ -31,6 +31,7 @@ type AnyGlideClient = GlideClient | GlideClusterClient;
 // ---------------------------------------------------------------------------
 // Client cache - reuse connections keyed by address string
 // ---------------------------------------------------------------------------
+const MAX_CLIENT_CACHE_SIZE = 50;
 const clientCache = new Map<string, Promise<AnyGlideClient>>();
 
 function getClient(customHost: string): Promise<AnyGlideClient> {
@@ -38,24 +39,40 @@ function getClient(customHost: string): Promise<AnyGlideClient> {
     ? customHost
     : `valkey://${customHost}`;
 
-  if (!clientCache.has(address)) {
-    const { addresses, options } = parseValkeyConnectionString(address);
-    const p = createValkeyClient(addresses, options).catch((err) => {
-      clientCache.delete(address);
-      throw err;
-    });
-    clientCache.set(address, p);
+  if (clientCache.has(address)) {
+    // Move to end (most recently used)
+    const existing = clientCache.get(address)!;
+    clientCache.delete(address);
+    clientCache.set(address, existing);
+    return existing;
   }
-  return clientCache.get(address)!;
+
+  // Evict oldest entry if at capacity
+  if (clientCache.size >= MAX_CLIENT_CACHE_SIZE) {
+    const oldest = clientCache.keys().next().value!;
+    const evicted = clientCache.get(oldest);
+    clientCache.delete(oldest);
+    evicted?.then((c) => c.close()).catch(() => {});
+  }
+
+  const { addresses, options } = parseValkeyConnectionString(address);
+  const p = createValkeyClient(addresses, options).catch((err) => {
+    clientCache.delete(address);
+    throw err;
+  });
+  clientCache.set(address, p);
+  return p;
 }
 
 // Graceful shutdown: close all cached GLIDE connections
 if (typeof process !== 'undefined') {
   const closeAll = async () => {
-    for (const [, p] of clientCache) {
+    for (const [addr, p] of clientCache) {
       try {
         (await p).close();
-      } catch {}
+      } catch (e) {
+        console.warn('[valkey-search] Error closing client:', addr, e);
+      }
     }
     clientCache.clear();
   };
@@ -103,14 +120,29 @@ function validateDocId(id: string): boolean {
 }
 
 /**
- * Security guard: reject filter strings containing "=>" to prevent KNN-clause injection.
- * A filter containing "=>" could allow an attacker to append their own KNN clause.
+ * Security guard: reject filter strings that could manipulate the query structure.
+ * Blocks "=>" (KNN-clause injection) and RediSearch control keywords/syntax
+ * that could alter query execution when interpolated into the filter clause.
  */
 function validateFilter(filter: unknown): string | null {
   if (filter === undefined || filter === null) return null;
   if (typeof filter !== 'string') return 'filter must be a string';
   if (filter.includes('=>')) {
     return 'filter expression must not contain "=>" (KNN-clause injection risk)';
+  }
+  // Block unbalanced parens that could break out of the (filter) wrapper
+  let depth = 0;
+  for (const ch of filter) {
+    if (ch === '(') depth++;
+    if (ch === ')') depth--;
+    if (depth < 0) return 'filter contains unbalanced parentheses';
+  }
+  if (depth !== 0) return 'filter contains unbalanced parentheses';
+  // Block RediSearch query modifiers that should not appear in a filter expression
+  const blocked =
+    /\b(SORTBY|LIMIT|RETURN|WITHSCORES|DIALECT|PARAMS|SUMMARIZE|HIGHLIGHT)\b/i;
+  if (blocked.test(filter)) {
+    return 'filter must not contain query modifiers (SORTBY, LIMIT, RETURN, etc.)';
   }
   return null;
 }
@@ -121,7 +153,11 @@ function validateFilter(filter: unknown): string | null {
  */
 function isIndexNotFoundError(err: any): boolean {
   const msg = err?.message ?? '';
-  return msg.includes('Unknown index') || msg.includes('no such index');
+  return (
+    msg.includes('Unknown index') ||
+    msg.includes('no such index') ||
+    msg.includes('not found')
+  );
 }
 
 const MAX_BATCH_SIZE = 1000;
@@ -397,7 +433,11 @@ export const upsertDocsHandler: RequestHandler = async ({
       await client.hset(key, fieldMap);
       results.push({ id: doc.id, status: 'upserted' });
     } catch (err: any) {
-      results.push({ id: doc.id, status: 'error', error: 'write failed' });
+      results.push({
+        id: doc.id,
+        status: 'error',
+        error: `write failed: ${(err.message ?? '').slice(0, 200)}`,
+      });
     }
   }
 
@@ -479,7 +519,9 @@ export const searchIndexHandler: RequestHandler = async ({
   };
 
   if (Array.isArray(return_fields) && return_fields.length > 0) {
-    searchParams.returnFields = return_fields;
+    searchParams.returnFields = return_fields.map((f: string) => ({
+      fieldIdentifier: f,
+    }));
   }
 
   try {

--- a/src/providers/valkey-search/index.ts
+++ b/src/providers/valkey-search/index.ts
@@ -1,0 +1,76 @@
+/**
+ * @file src/providers/valkey-search/index.ts
+ * Valkey-search provider configuration.
+ *
+ * This provider uses native RESP commands via @valkey/valkey-glide (not HTTP
+ * proxying). All six vector-search endpoints are wired via requestHandlers.
+ */
+import { ProviderConfigs, RequestHandler } from '../types';
+import ValkeySearchAPIConfig from './api';
+import {
+  createIndexHandler,
+  dropIndexHandler,
+  getIndexHandler,
+  upsertDocsHandler,
+  searchIndexHandler,
+  deleteDocsHandler,
+} from './handlers';
+
+/**
+ * Single proxy handler that dispatches to the correct vector-search handler
+ * based on HTTP method and URL path. The gateway routes all /v1/* wildcard
+ * requests through the 'proxy' endpoint string.
+ */
+const proxyDispatcher: RequestHandler = async (ctx) => {
+  const url = new URL(ctx.requestURL);
+  const path = url.pathname;
+  const method = ctx.c.req.method.toUpperCase();
+
+  // POST /v1/indexes/:name/upsert
+  if (method === 'POST' && /\/v1\/indexes\/[^/]+\/upsert$/.test(path)) {
+    return upsertDocsHandler(ctx);
+  }
+  // POST /v1/indexes/:name/search
+  if (method === 'POST' && /\/v1\/indexes\/[^/]+\/search$/.test(path)) {
+    return searchIndexHandler(ctx);
+  }
+  // POST /v1/indexes/:name/documents/delete
+  if (
+    method === 'POST' &&
+    /\/v1\/indexes\/[^/]+\/documents\/delete$/.test(path)
+  ) {
+    return deleteDocsHandler(ctx);
+  }
+  // GET /v1/indexes/:name
+  if (method === 'GET' && /\/v1\/indexes\/[^/]+$/.test(path)) {
+    return getIndexHandler(ctx);
+  }
+  // DELETE /v1/indexes/:name
+  if (method === 'DELETE' && /\/v1\/indexes\/[^/]+$/.test(path)) {
+    return dropIndexHandler(ctx);
+  }
+  // POST /v1/indexes
+  if (method === 'POST' && /\/v1\/indexes\/?$/.test(path)) {
+    return createIndexHandler(ctx);
+  }
+
+  return new Response(
+    JSON.stringify({
+      error: {
+        message: `Unknown valkey-search route: ${method} ${path}`,
+        type: 'invalid_request_error',
+      },
+    }),
+    { status: 404, headers: { 'Content-Type': 'application/json' } }
+  );
+};
+
+const ValkeySearchConfig: ProviderConfigs = {
+  api: ValkeySearchAPIConfig,
+  responseTransforms: {},
+  requestHandlers: {
+    proxy: proxyDispatcher,
+  },
+};
+
+export default ValkeySearchConfig;

--- a/src/shared/services/cache/backends/valkey.ts
+++ b/src/shared/services/cache/backends/valkey.ts
@@ -247,7 +247,7 @@ export class ValkeyCacheBackend implements CacheBackend {
 
   async close(): Promise<void> {
     try {
-      await this.client.close();
+      this.client.close();
       logger.debug('Valkey cache backend closed');
     } catch (error) {
       logger.error('Error closing Valkey connection:', error);

--- a/src/shared/services/cache/backends/valkey.ts
+++ b/src/shared/services/cache/backends/valkey.ts
@@ -1,0 +1,267 @@
+/**
+ * @file src/shared/services/cache/backends/valkey.ts
+ * Valkey cache backend implementation using @valkey/valkey-glide.
+ *
+ * API differences from ioredis that this implementation handles:
+ *  - Connection: await GlideClient.createClient(config) - async, no sync constructor
+ *  - SET + TTL: .set(key, val, { expiry: { type: 'seconds', count: sec } })
+ *  - DEL: .del([key]) - takes an array, not variadic
+ *  - EXISTS: .exists([key]) - takes an array
+ *  - KEYS: no .keys() method - use scan cursor loop instead
+ *  - Disconnect: .close() not .quit()
+ */
+import {
+  GlideClient,
+  GlideClusterClient,
+  ClusterScanCursor,
+  GlideString,
+  TimeUnit,
+} from '@valkey/valkey-glide';
+import { CacheBackend, CacheEntry, CacheOptions, CacheStats } from '../types';
+
+const logger = {
+  debug: (msg: string, ...args: any[]) =>
+    console.debug(`[ValkeyCache] ${msg}`, ...args),
+  info: (msg: string, ...args: any[]) =>
+    console.info(`[ValkeyCache] ${msg}`, ...args),
+  warn: (msg: string, ...args: any[]) =>
+    console.warn(`[ValkeyCache] ${msg}`, ...args),
+  error: (msg: string, ...args: any[]) =>
+    console.error(`[ValkeyCache] ${msg}`, ...args),
+};
+
+export class ValkeyCacheBackend implements CacheBackend {
+  private client: GlideClient | GlideClusterClient;
+  private dbName: string;
+
+  private stats: CacheStats = {
+    hits: 0,
+    misses: 0,
+    sets: 0,
+    deletes: 0,
+    size: 0,
+    expired: 0,
+  };
+
+  constructor(client: GlideClient | GlideClusterClient, dbName: string) {
+    this.client = client;
+    this.dbName = dbName;
+  }
+
+  private serializeEntry<T>(entry: CacheEntry<T>): string {
+    return JSON.stringify(entry);
+  }
+
+  private deserializeEntry<T>(data: string): CacheEntry<T> {
+    return JSON.parse(data);
+  }
+
+  private isExpired(entry: CacheEntry): boolean {
+    return entry.expiresAt !== undefined && entry.expiresAt <= Date.now();
+  }
+
+  getFullKey(key: string, namespace?: string): string {
+    return namespace
+      ? `${this.dbName}:${namespace}:${key}`
+      : `${this.dbName}:default:${key}`;
+  }
+
+  async get<T = any>(
+    key: string,
+    namespace?: string
+  ): Promise<CacheEntry<T> | null> {
+    try {
+      const fullKey = this.getFullKey(key, namespace);
+      const data = await this.client.get(fullKey);
+
+      if (data === null) {
+        this.stats.misses++;
+        return null;
+      }
+
+      const entry = this.deserializeEntry<T>(data as string);
+
+      if (this.isExpired(entry)) {
+        // TTL should handle this, but double-check
+        await this.client.del([fullKey]);
+        this.stats.expired++;
+        this.stats.misses++;
+        return null;
+      }
+
+      this.stats.hits++;
+      return entry;
+    } catch (error) {
+      logger.error('Valkey get error:', error);
+      this.stats.misses++;
+      return null;
+    }
+  }
+
+  async set<T = any>(
+    key: string,
+    value: T,
+    options: CacheOptions = {}
+  ): Promise<void> {
+    try {
+      const fullKey = this.getFullKey(key, options.namespace);
+      const now = Date.now();
+
+      const entry: CacheEntry<T> = {
+        value,
+        createdAt: now,
+        expiresAt: options.ttl ? now + options.ttl : undefined,
+        metadata: options.metadata,
+      };
+
+      const serialized = this.serializeEntry(entry);
+
+      if (options.ttl) {
+        const ttlSeconds = Math.ceil(options.ttl / 1000);
+        // GLIDE uses structured expiry options, not "EX" string flag
+        await this.client.set(fullKey, serialized, {
+          expiry: { type: TimeUnit.Seconds, count: ttlSeconds },
+        });
+      } else {
+        await this.client.set(fullKey, serialized);
+      }
+
+      this.stats.sets++;
+    } catch (error) {
+      logger.error('Valkey set error:', error);
+      throw error;
+    }
+  }
+
+  async delete(key: string, namespace?: string): Promise<boolean> {
+    try {
+      const fullKey = this.getFullKey(key, namespace);
+      // GLIDE del takes an array
+      const deleted = await this.client.del([fullKey]);
+      if (deleted > 0) {
+        this.stats.deletes++;
+        return true;
+      }
+      return false;
+    } catch (error) {
+      logger.error('Valkey delete error:', error);
+      return false;
+    }
+  }
+
+  async clear(namespace?: string): Promise<void> {
+    try {
+      const pattern = namespace
+        ? `${this.dbName}:${namespace}:*`
+        : `${this.dbName}:*`;
+      const keys = await this.scanKeys(pattern);
+      if (keys.length > 0) {
+        // GLIDE del takes an array
+        await this.client.del(keys);
+        this.stats.deletes += keys.length;
+      }
+    } catch (error) {
+      logger.error('Valkey clear error:', error);
+      throw error;
+    }
+  }
+
+  async has(key: string, namespace?: string): Promise<boolean> {
+    try {
+      const fullKey = this.getFullKey(key, namespace);
+      // GLIDE exists takes an array
+      const count = await this.client.exists([fullKey]);
+      return (count as number) > 0;
+    } catch (error) {
+      logger.error('Valkey has error:', error);
+      return false;
+    }
+  }
+
+  async keys(namespace?: string): Promise<string[]> {
+    try {
+      const pattern = namespace
+        ? `${this.dbName}:${namespace}:*`
+        : `${this.dbName}:default:*`;
+      const fullKeys = await this.scanKeys(pattern);
+      const prefix = namespace
+        ? `${this.dbName}:${namespace}:`
+        : `${this.dbName}:default:`;
+      return fullKeys.map((k) => k.substring(prefix.length));
+    } catch (error) {
+      logger.error('Valkey keys error:', error);
+      return [];
+    }
+  }
+
+  /**
+   * Cluster client uses ClusterScanCursor; standalone uses string cursor.
+   */
+  private async scanKeys(pattern: string): Promise<string[]> {
+    const result: string[] = [];
+
+    if (this.client instanceof GlideClusterClient) {
+      let cursor = new ClusterScanCursor();
+      while (!cursor.isFinished()) {
+        const [nextCursor, keys] = await (
+          this.client as GlideClusterClient
+        ).scan(cursor, {
+          match: pattern,
+          count: 100,
+        });
+        cursor = nextCursor;
+        result.push(...keys.map((k) => k.toString()));
+      }
+    } else {
+      let cursor: GlideString = '0';
+      do {
+        const scanResult = await (this.client as GlideClient).scan(cursor, {
+          match: pattern,
+          count: 100,
+        });
+        cursor = scanResult[0];
+        result.push(...scanResult[1].map((k) => k.toString()));
+      } while (cursor.toString() !== '0');
+    }
+
+    return result;
+  }
+
+  async getStats(namespace?: string): Promise<CacheStats> {
+    try {
+      const pattern = namespace
+        ? `${this.dbName}:${namespace}:*`
+        : `${this.dbName}:*`;
+      const keys = await this.scanKeys(pattern);
+      return { ...this.stats, size: keys.length };
+    } catch (error) {
+      logger.error('Valkey getStats error:', error);
+      return { ...this.stats };
+    }
+  }
+
+  async cleanup(): Promise<void> {
+    // Valkey TTL handles expiry automatically
+    logger.debug('Valkey cleanup - TTL handled automatically by Valkey');
+  }
+
+  async close(): Promise<void> {
+    try {
+      await this.client.close();
+      logger.debug('Valkey cache backend closed');
+    } catch (error) {
+      logger.error('Error closing Valkey connection:', error);
+    }
+  }
+}
+
+/**
+ * Factory function to create a ValkeyCacheBackend.
+ * The caller must supply an already-connected GlideClient (GLIDE init is async).
+ */
+export function createValkeyBackend(
+  client: GlideClient | GlideClusterClient,
+  dbName: string = 'cache'
+): ValkeyCacheBackend {
+  return new ValkeyCacheBackend(client, dbName);
+}

--- a/src/shared/services/cache/backends/valkey.ts
+++ b/src/shared/services/cache/backends/valkey.ts
@@ -196,8 +196,10 @@ export class ValkeyCacheBackend implements CacheBackend {
 
   /**
    * Cluster client uses ClusterScanCursor; standalone uses string cursor.
+   * Capped at MAX_SCAN_KEYS to prevent unbounded iteration on large keyspaces.
    */
   private async scanKeys(pattern: string): Promise<string[]> {
+    const MAX_SCAN_KEYS = 10_000;
     const result: string[] = [];
 
     if (this.client instanceof GlideClusterClient) {
@@ -211,6 +213,12 @@ export class ValkeyCacheBackend implements CacheBackend {
         });
         cursor = nextCursor;
         result.push(...keys.map((k) => k.toString()));
+        if (result.length >= MAX_SCAN_KEYS) {
+          logger.warn(
+            `scanKeys truncated at ${MAX_SCAN_KEYS} — pattern may match too broadly: ${pattern}`
+          );
+          break;
+        }
       }
     } else {
       let cursor: GlideString = '0';
@@ -221,6 +229,12 @@ export class ValkeyCacheBackend implements CacheBackend {
         });
         cursor = scanResult[0];
         result.push(...scanResult[1].map((k) => k.toString()));
+        if (result.length >= MAX_SCAN_KEYS) {
+          logger.warn(
+            `scanKeys truncated at ${MAX_SCAN_KEYS} — pattern may match too broadly: ${pattern}`
+          );
+          break;
+        }
       } while (cursor.toString() !== '0');
     }
 

--- a/src/shared/services/cache/index.ts
+++ b/src/shared/services/cache/index.ts
@@ -91,9 +91,32 @@ export class CacheService {
 
       case 'valkey':
         // Backend is injected post-construction by createCacheBackendsValkey()
-        // after the async GLIDE client is created. Return a memory placeholder
-        // that will be replaced before any requests are served.
-        return new MemoryCacheBackend();
+        // after the async GLIDE client is created. Operations throw until then.
+        return {
+          async get() {
+            throw new Error('Valkey cache not initialized yet');
+          },
+          async set() {
+            throw new Error('Valkey cache not initialized yet');
+          },
+          async delete() {
+            throw new Error('Valkey cache not initialized yet');
+          },
+          async clear() {
+            throw new Error('Valkey cache not initialized yet');
+          },
+          async has() {
+            throw new Error('Valkey cache not initialized yet');
+          },
+          async keys() {
+            throw new Error('Valkey cache not initialized yet');
+          },
+          async getStats() {
+            throw new Error('Valkey cache not initialized yet');
+          },
+          async cleanup() {},
+          async close() {},
+        } as CacheBackend;
 
       default:
         throw new Error(`Unsupported cache backend: ${config.backend}`);

--- a/src/shared/services/cache/index.ts
+++ b/src/shared/services/cache/index.ts
@@ -14,6 +14,7 @@ import { MemoryCacheBackend } from './backends/memory';
 import { FileCacheBackend } from './backends/file';
 import { createRedisBackend } from './backends/redis';
 import { createCloudflareKVBackend } from './backends/cloudflareKV';
+import { createValkeyBackend } from './backends/valkey';
 // Using console.log for now to avoid build issues
 const logger = {
   debug: (msg: string, ...args: any[]) =>
@@ -46,6 +47,12 @@ export class CacheService {
   constructor(config: CacheConfig) {
     this.defaultTtl = config.defaultTtl;
     this.backend = this.createBackend(config);
+  }
+
+  /** Replace the active backend, closing the previous one to prevent timer/resource leaks. */
+  setBackend(backend: CacheBackend): void {
+    this.backend.close?.();
+    this.backend = backend;
   }
 
   private createBackend(config: CacheConfig): CacheBackend {
@@ -81,6 +88,12 @@ export class CacheService {
           config.kvBindingName,
           config.dbName
         );
+
+      case 'valkey':
+        // Backend is injected post-construction by createCacheBackendsValkey()
+        // after the async GLIDE client is created. Return a memory placeholder
+        // that will be replaced before any requests are served.
+        return new MemoryCacheBackend();
 
       default:
         throw new Error(`Unsupported cache backend: ${config.backend}`);
@@ -435,6 +448,79 @@ export function createCacheBackendsRedis(redisUrl: string): void {
     dbName: 'mcp',
     defaultTtl: undefined,
   });
+}
+
+function redactConnectionString(url: string): string {
+  try {
+    const parsed = new URL(url);
+    if (parsed.password) parsed.password = '***';
+    return parsed.toString();
+  } catch {
+    return '<invalid url>';
+  }
+}
+
+/**
+ * Initialize all cache instances using Valkey (via @valkey/valkey-glide).
+ * Must be awaited before serving requests; GLIDE requires async connection setup.
+ */
+export async function createCacheBackendsValkey(
+  valkeyUrl: string
+): Promise<void> {
+  logger.info(
+    'Creating cache backends with Valkey',
+    redactConnectionString(valkeyUrl)
+  );
+
+  const { createValkeyClient, parseValkeyConnectionString } = await import(
+    '../valkey/client'
+  );
+  const { addresses, options } = parseValkeyConnectionString(valkeyUrl);
+
+  // One shared connection per set of backends
+  const sharedClient = await createValkeyClient(addresses, options);
+
+  const parseTtl = (envVar: string, fallback: number): number => {
+    const val = parseInt(process.env[envVar] ?? '', 10);
+    return val > 0 ? val : fallback;
+  };
+
+  const defaultTtl = parseTtl('VALKEY_DEFAULT_TTL_MS', MS['5_MINUTES']);
+  const sessionTtl = parseTtl('VALKEY_SESSION_TTL_MS', MS['30_MINUTES']);
+  const configTtl = parseTtl('VALKEY_CONFIG_TTL_MS', MS['30_DAYS']);
+
+  defaultCache = new CacheService({
+    backend: 'valkey',
+    defaultTtl,
+    cleanupInterval: MS['5_MINUTES'],
+    maxSize: 1000,
+  });
+  defaultCache.setBackend(createValkeyBackend(sharedClient, 'default'));
+
+  tokenCache = new CacheService({
+    backend: 'memory',
+    defaultTtl: MS['1_MINUTE'],
+    cleanupInterval: MS['1_MINUTE'],
+    maxSize: 1000,
+  });
+
+  sessionCache = new CacheService({
+    backend: 'valkey',
+    defaultTtl: sessionTtl,
+  });
+  sessionCache.setBackend(createValkeyBackend(sharedClient, 'session'));
+
+  configCache = new CacheService({
+    backend: 'valkey',
+    defaultTtl: configTtl,
+  });
+  configCache.setBackend(createValkeyBackend(sharedClient, 'config'));
+
+  oauthStore = new CacheService({ backend: 'valkey' });
+  oauthStore.setBackend(createValkeyBackend(sharedClient, 'oauth'));
+
+  mcpServersCache = new CacheService({ backend: 'valkey' });
+  mcpServersCache.setBackend(createValkeyBackend(sharedClient, 'mcp'));
 }
 
 export function createCacheBackendsCF(env: any): void {

--- a/src/shared/services/cache/index.ts
+++ b/src/shared/services/cache/index.ts
@@ -428,7 +428,10 @@ export async function createCacheBackendsLocal(): Promise<void> {
 }
 
 export function createCacheBackendsRedis(redisUrl: string): void {
-  logger.info('Creating cache backends with Redis', redisUrl);
+  logger.info(
+    'Creating cache backends with Redis',
+    redactConnectionString(redisUrl)
+  );
   let commonOptions: CacheConfig = {
     backend: 'redis',
     redisUrl: redisUrl,

--- a/src/shared/services/cache/index.ts
+++ b/src/shared/services/cache/index.ts
@@ -91,28 +91,33 @@ export class CacheService {
 
       case 'valkey':
         // Backend is injected post-construction by createCacheBackendsValkey()
-        // after the async GLIDE client is created. Operations throw until then.
+        // after the async GLIDE client is created. Returns safe no-ops until then,
+        // allowing callers without try/catch (config, session, OAuth) to degrade
+        // gracefully rather than throwing unhandled 500s during startup.
         return {
           async get() {
-            throw new Error('Valkey cache not initialized yet');
+            return null;
           },
-          async set() {
-            throw new Error('Valkey cache not initialized yet');
-          },
+          async set() {},
           async delete() {
-            throw new Error('Valkey cache not initialized yet');
+            return false;
           },
-          async clear() {
-            throw new Error('Valkey cache not initialized yet');
-          },
+          async clear() {},
           async has() {
-            throw new Error('Valkey cache not initialized yet');
+            return false;
           },
           async keys() {
-            throw new Error('Valkey cache not initialized yet');
+            return [];
           },
           async getStats() {
-            throw new Error('Valkey cache not initialized yet');
+            return {
+              hits: 0,
+              misses: 0,
+              sets: 0,
+              deletes: 0,
+              size: 0,
+              expired: 0,
+            };
           },
           async cleanup() {},
           async close() {},

--- a/src/shared/services/cache/types.ts
+++ b/src/shared/services/cache/types.ts
@@ -38,7 +38,7 @@ export interface CacheBackend {
 }
 
 export interface CacheConfig {
-  backend: 'memory' | 'file' | 'redis' | 'cloudflareKV';
+  backend: 'memory' | 'file' | 'redis' | 'cloudflareKV' | 'valkey';
   defaultTtl?: number; // Default TTL in milliseconds
   cleanupInterval?: number; // Cleanup interval in milliseconds
   // File backend options

--- a/src/shared/services/cache/utils/valkeyRateLimiter.ts
+++ b/src/shared/services/cache/utils/valkeyRateLimiter.ts
@@ -1,0 +1,162 @@
+/**
+ * @file src/shared/services/cache/utils/valkeyRateLimiter.ts
+ * Token-bucket rate limiter for the Valkey GLIDE client.
+ *
+ * Uses the same Lua script logic as the ioredis RedisRateLimiter but adapted
+ * for GLIDE's Script/invokeScript API. GLIDE manages script caching internally,
+ * so there is no need to LOAD the script manually or handle NOSCRIPT errors.
+ */
+import { GlideClient, Script } from '@valkey/valkey-glide';
+import { RateLimiterKeyTypes } from '../../../../globals';
+
+const RATE_LIMIT_LUA = `
+local tokensKey = KEYS[1]
+local refillKey = KEYS[2]
+
+local capacity = tonumber(ARGV[1])
+local windowSize = tonumber(ARGV[2])
+local units = tonumber(ARGV[3])
+local now = tonumber(ARGV[4])
+local ttl = tonumber(ARGV[5])
+local consume = tonumber(ARGV[6]) -- 1 = consume, 0 = check only
+
+-- Reject invalid input
+if units <= 0 or capacity <= 0 or windowSize <= 0 then
+  return {0, -1, -1}
+end
+
+local lastRefill = tonumber(redis.call("GET", refillKey) or "0")
+local tokens = tonumber(redis.call("GET", tokensKey) or "-1")
+
+local tokensModified = false
+local refillModified = false
+
+-- Initialization
+if tokens == -1 then
+  tokens = capacity
+  tokensModified = true
+end
+
+if lastRefill == 0 then
+  lastRefill = now
+  refillModified = true
+end
+
+-- Refill logic
+local elapsed = now - lastRefill
+if elapsed > 0 then
+  local rate = capacity / windowSize
+  local tokensToAdd = math.floor(elapsed * rate)
+  if tokensToAdd > 0 then
+    tokens = math.min(tokens + tokensToAdd, capacity)
+    lastRefill = now
+    tokensModified = true
+    refillModified = true
+  end
+end
+
+-- Consume logic
+local allowed = 0
+local waitTime = 0
+local currentTokens = tokens
+
+if tokens >= units then
+  allowed = 1
+  if consume == 1 then
+    tokens = tokens - units
+    tokensModified = true
+  end
+else
+  if tokens > 0 then
+    tokensModified = true
+  end
+  tokens = 0
+  local needed = units - currentTokens
+  local rate = capacity / windowSize
+  waitTime = (rate > 0) and math.floor(needed / rate) or -1
+end
+
+-- Save changes
+if tokensModified then
+  redis.call("SET", tokensKey, tokens, "PX", ttl)
+end
+
+if refillModified then
+  redis.call("SET", refillKey, lastRefill, "PX", ttl)
+end
+
+return {allowed, waitTime, currentTokens}
+`;
+
+class ValkeyRateLimiter {
+  private script: Script;
+  private tokensKey: string;
+  private lastRefillKey: string;
+  private keyTTL: number;
+  private keyType: RateLimiterKeyTypes;
+  private key: string;
+
+  constructor(
+    private client: GlideClient,
+    key: string,
+    private capacity: number,
+    private windowSize: number,
+    keyType: RateLimiterKeyTypes,
+    ttlFactor: number = 3
+  ) {
+    this.key = key;
+    this.keyType = keyType;
+    this.keyTTL = windowSize * ttlFactor;
+
+    // GLIDE manages script caching internally via Script object
+    this.script = new Script(RATE_LIMIT_LUA);
+
+    const tag = `{rate:${key}}`;
+    this.tokensKey = `default:default:${tag}:tokens`;
+    this.lastRefillKey = `default:default:${tag}:lastRefill`;
+  }
+
+  async checkRateLimit(
+    units: number,
+    consume: boolean = true
+  ): Promise<{
+    keyType: RateLimiterKeyTypes;
+    key: string;
+    allowed: boolean;
+    waitTime: number;
+    currentTokens: number;
+  }> {
+    const now = Date.now();
+
+    const result = await this.client.invokeScript(this.script, {
+      keys: [this.tokensKey, this.lastRefillKey],
+      args: [
+        this.capacity.toString(),
+        this.windowSize.toString(),
+        units.toString(),
+        now.toString(),
+        this.keyTTL.toString(),
+        consume ? '1' : '0',
+      ],
+    });
+
+    const [allowed, waitTime, currentTokens] = result as number[];
+
+    return {
+      keyType: this.keyType,
+      key: this.key,
+      allowed: allowed === 1,
+      waitTime: Number(waitTime),
+      currentTokens: Number(currentTokens),
+    };
+  }
+
+  async decrementToken(
+    units: number
+  ): Promise<{ allowed: boolean; waitTime: number }> {
+    const { allowed, waitTime } = await this.checkRateLimit(units, true);
+    return { allowed, waitTime };
+  }
+}
+
+export default ValkeyRateLimiter;

--- a/src/shared/services/cache/utils/valkeyRateLimiter.ts
+++ b/src/shared/services/cache/utils/valkeyRateLimiter.ts
@@ -6,7 +6,7 @@
  * for GLIDE's Script/invokeScript API. GLIDE manages script caching internally,
  * so there is no need to LOAD the script manually or handle NOSCRIPT errors.
  */
-import { GlideClient, Script } from '@valkey/valkey-glide';
+import { GlideClient, GlideClusterClient, Script } from '@valkey/valkey-glide';
 import { RateLimiterKeyTypes } from '../../../../globals';
 
 const RATE_LIMIT_LUA = `
@@ -97,7 +97,7 @@ class ValkeyRateLimiter {
   private key: string;
 
   constructor(
-    private client: GlideClient,
+    private client: GlideClient | GlideClusterClient,
     key: string,
     private capacity: number,
     private windowSize: number,

--- a/src/shared/services/valkey/client.ts
+++ b/src/shared/services/valkey/client.ts
@@ -24,6 +24,7 @@ export async function createStandaloneClient(
     addresses: [{ host, port }],
     useTLS: options?.useTLS ?? false,
     requestTimeout: options?.requestTimeout ?? 5000,
+    advancedConfiguration: { connectionTimeout: 5000 },
   };
 
   if (options?.password) {
@@ -41,6 +42,7 @@ export async function createClusterClient(
     addresses,
     useTLS: options?.useTLS ?? false,
     requestTimeout: options?.requestTimeout ?? 5000,
+    advancedConfiguration: { connectionTimeout: 5000 },
   };
   if (options?.password) {
     config.credentials = { password: options.password };

--- a/src/shared/services/valkey/client.ts
+++ b/src/shared/services/valkey/client.ts
@@ -71,10 +71,12 @@ export function parseValkeyConnectionString(connectionString: string): {
   addresses: Array<{ host: string; port: number }>;
   options: ValkeyClientOptions;
 } {
+  const redact = (s: string) => s.replace(/\/\/[^@]*@/, '//***@');
+
   const schemeMatch = connectionString.match(/^([a-zA-Z]+):\/\//);
   if (!schemeMatch) {
     throw new Error(
-      `Invalid Valkey connection string: "${connectionString}". ` +
+      `Invalid Valkey connection string: "${redact(connectionString)}". ` +
         'Expected format: valkey://[password@]host:port[,host2:port2][?cluster=true]'
     );
   }
@@ -110,7 +112,7 @@ export function parseValkeyConnectionString(connectionString: string): {
 
   if (!hostsPart) {
     throw new Error(
-      `Missing host in Valkey connection string: "${connectionString}"`
+      `Missing host in Valkey connection string: "${redact(connectionString)}"`
     );
   }
 
@@ -125,7 +127,7 @@ export function parseValkeyConnectionString(connectionString: string): {
     const port = parseInt(portStr, 10);
     if (isNaN(port) || port < 1 || port > 65535) {
       throw new Error(
-        `Invalid port "${portStr}" in Valkey connection string: "${connectionString}"`
+        `Invalid port "${portStr}" in Valkey connection string: "${redact(connectionString)}"`
       );
     }
     return { host, port };
@@ -133,7 +135,7 @@ export function parseValkeyConnectionString(connectionString: string): {
 
   if (!addresses[0].host) {
     throw new Error(
-      `Missing host in Valkey connection string: "${connectionString}"`
+      `Missing host in Valkey connection string: "${redact(connectionString)}"`
     );
   }
 

--- a/src/shared/services/valkey/client.ts
+++ b/src/shared/services/valkey/client.ts
@@ -1,0 +1,152 @@
+/**
+ * @file src/shared/services/valkey/client.ts
+ * Shared Valkey GLIDE client factory and connection string parser.
+ */
+import { GlideClient, GlideClusterClient } from '@valkey/valkey-glide';
+
+export interface ValkeyClientOptions {
+  useTLS?: boolean;
+  password?: string;
+  requestTimeout?: number;
+  cluster?: boolean;
+}
+
+/**
+ * Create a standalone (non-cluster) GlideClient connected to a single Valkey node.
+ * GLIDE requires async initialization - there is no sync/lazy alternative.
+ */
+export async function createStandaloneClient(
+  host: string,
+  port: number,
+  options?: ValkeyClientOptions
+): Promise<GlideClient> {
+  const config: any = {
+    addresses: [{ host, port }],
+    useTLS: options?.useTLS ?? false,
+    requestTimeout: options?.requestTimeout ?? 5000,
+  };
+
+  if (options?.password) {
+    config.credentials = { password: options.password };
+  }
+
+  return await GlideClient.createClient(config);
+}
+
+export async function createClusterClient(
+  addresses: Array<{ host: string; port: number }>,
+  options?: ValkeyClientOptions
+): Promise<GlideClusterClient> {
+  const config: any = {
+    addresses,
+    useTLS: options?.useTLS ?? false,
+    requestTimeout: options?.requestTimeout ?? 5000,
+  };
+  if (options?.password) {
+    config.credentials = { password: options.password };
+  }
+  return await GlideClusterClient.createClient(config);
+}
+
+export async function createValkeyClient(
+  addresses: Array<{ host: string; port: number }>,
+  options?: ValkeyClientOptions
+): Promise<GlideClient | GlideClusterClient> {
+  if (options?.cluster) {
+    return createClusterClient(addresses, options);
+  }
+  return createStandaloneClient(addresses[0].host, addresses[0].port, options);
+}
+
+/**
+ * Parse a Valkey/Redis connection string into addresses and options.
+ * Supported schemes: valkey://, valkeys://, redis://, rediss://
+ * TLS is enabled for valkeys:// and rediss:// schemes.
+ *
+ * Multi-seed cluster format: valkey://host1:6379,host2:6380?cluster=true
+ * GLIDE will discover all nodes via CLUSTER SLOTS; additional seeds improve
+ * bootstrap resilience.
+ */
+export function parseValkeyConnectionString(connectionString: string): {
+  addresses: Array<{ host: string; port: number }>;
+  options: ValkeyClientOptions;
+} {
+  const schemeMatch = connectionString.match(/^([a-zA-Z]+):\/\//);
+  if (!schemeMatch) {
+    throw new Error(
+      `Invalid Valkey connection string: "${connectionString}". ` +
+        'Expected format: valkey://[password@]host:port[,host2:port2][?cluster=true]'
+    );
+  }
+
+  const scheme = schemeMatch[1].toLowerCase();
+  const supportedSchemes = ['valkey', 'valkeys', 'redis', 'rediss'];
+  if (!supportedSchemes.includes(scheme)) {
+    throw new Error(
+      `Unsupported scheme "${scheme}" in Valkey connection string. ` +
+        `Supported schemes: ${supportedSchemes.join(', ')}`
+    );
+  }
+
+  const afterScheme = connectionString.slice(schemeMatch[0].length);
+  const queryStart = afterScheme.search(/[?#]/);
+  const authorityPart =
+    queryStart >= 0 ? afterScheme.slice(0, queryStart) : afterScheme;
+  const queryPart = queryStart >= 0 ? afterScheme.slice(queryStart + 1) : '';
+
+  // Extract optional password (user:pass@hosts or :pass@hosts)
+  let password: string | undefined;
+  let hostsPart = authorityPart;
+  const atIndex = authorityPart.lastIndexOf('@');
+  if (atIndex >= 0) {
+    const credentials = authorityPart.slice(0, atIndex);
+    const colonIndex = credentials.indexOf(':');
+    if (colonIndex >= 0) {
+      const raw = credentials.slice(colonIndex + 1);
+      password = raw ? decodeURIComponent(raw) : undefined;
+    }
+    hostsPart = authorityPart.slice(atIndex + 1);
+  }
+
+  if (!hostsPart) {
+    throw new Error(
+      `Missing host in Valkey connection string: "${connectionString}"`
+    );
+  }
+
+  const addresses = hostsPart.split(',').map((hostStr) => {
+    const trimmed = hostStr.trim();
+    const colonIdx = trimmed.lastIndexOf(':');
+    if (colonIdx <= 0) {
+      return { host: trimmed, port: 6379 };
+    }
+    const host = trimmed.slice(0, colonIdx);
+    const portStr = trimmed.slice(colonIdx + 1);
+    const port = parseInt(portStr, 10);
+    if (isNaN(port) || port < 1 || port > 65535) {
+      throw new Error(
+        `Invalid port "${portStr}" in Valkey connection string: "${connectionString}"`
+      );
+    }
+    return { host, port };
+  });
+
+  if (!addresses[0].host) {
+    throw new Error(
+      `Missing host in Valkey connection string: "${connectionString}"`
+    );
+  }
+
+  const params = queryPart ? new URLSearchParams(queryPart) : null;
+  const cluster = params?.get('cluster') === 'true' ? true : undefined;
+  const useTLS = scheme === 'valkeys' || scheme === 'rediss';
+
+  return {
+    addresses,
+    options: {
+      useTLS,
+      ...(password ? { password } : {}),
+      ...(cluster ? { cluster } : {}),
+    },
+  };
+}

--- a/tests/unit/src/providers/valkey-search/handlers.test.ts
+++ b/tests/unit/src/providers/valkey-search/handlers.test.ts
@@ -1,0 +1,328 @@
+import { Context } from 'hono';
+
+// Mock @valkey/valkey-glide before importing handlers
+const mockGlideClient = {
+  hset: jest.fn().mockResolvedValue(1),
+  del: jest.fn().mockResolvedValue(1),
+  close: jest.fn().mockResolvedValue(undefined),
+};
+
+const mockGlideFt = {
+  create: jest.fn().mockResolvedValue('OK'),
+  dropindex: jest.fn().mockResolvedValue('OK'),
+  info: jest.fn(),
+  search: jest.fn().mockResolvedValue([1, []]),
+};
+
+jest.mock('@valkey/valkey-glide', () => ({
+  GlideClient: {
+    createClient: jest.fn().mockResolvedValue(mockGlideClient),
+  },
+  GlideFt: mockGlideFt,
+  Decoder: { Bytes: 'Bytes' },
+  Field: {},
+}));
+
+jest.mock('../../../../../src/shared/services/valkey/client', () => ({
+  createValkeyClient: jest.fn().mockResolvedValue(mockGlideClient),
+  parseValkeyConnectionString: jest.fn().mockReturnValue({
+    addresses: [{ host: '127.0.0.1', port: 6379 }],
+    options: {},
+  }),
+}));
+
+import {
+  createIndexHandler,
+  dropIndexHandler,
+  getIndexHandler,
+  upsertDocsHandler,
+  searchIndexHandler,
+  deleteDocsHandler,
+} from '../../../../../src/providers/valkey-search/handlers';
+
+function makeCtx(overrides: any = {}) {
+  return {
+    c: { req: { method: 'POST' } } as unknown as Context,
+    providerOptions: { customHost: 'valkey://127.0.0.1:6379' },
+    requestURL: overrides.requestURL || 'http://localhost:8787/v1/indexes',
+    requestHeaders: {},
+    requestBody: overrides.requestBody || {},
+    ...overrides,
+  };
+}
+
+async function parseRes(res: Response) {
+  return { status: res.status, body: JSON.parse(await res.text()) };
+}
+
+describe('valkey-search handlers', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default: index not found (for create to succeed)
+    mockGlideFt.info.mockRejectedValue(new Error('Unknown index name'));
+  });
+
+  describe('createIndexHandler', () => {
+    it('should create an index and return 201', async () => {
+      const res = await createIndexHandler(
+        makeCtx({
+          requestBody: {
+            name: 'test_idx',
+            schema: {
+              vector: {
+                type: 'VECTOR',
+                algorithm: 'HNSW',
+                dims: 3,
+                distance: 'COSINE',
+              },
+              content: { type: 'TEXT' },
+            },
+          },
+        })
+      );
+      const { status, body } = await parseRes(res);
+      expect(status).toBe(201);
+      expect(body.status).toBe('created');
+      expect(mockGlideFt.create).toHaveBeenCalled();
+    });
+
+    it('should return 409 if index already exists', async () => {
+      mockGlideFt.info.mockResolvedValue({ index_name: 'test_idx' });
+      const res = await createIndexHandler(
+        makeCtx({
+          requestBody: {
+            name: 'test_idx',
+            schema: { v: { type: 'TEXT' } },
+          },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(409);
+    });
+
+    it('should return 400 for invalid index name', async () => {
+      const res = await createIndexHandler(
+        makeCtx({
+          requestBody: { name: 'bad name!', schema: { v: { type: 'TEXT' } } },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(400);
+    });
+
+    it('should return 400 if name is missing', async () => {
+      const res = await createIndexHandler(
+        makeCtx({
+          requestBody: { schema: { v: { type: 'TEXT' } } },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(400);
+    });
+
+    it('should return 400 if customHost is missing', async () => {
+      const res = await createIndexHandler(
+        makeCtx({
+          providerOptions: {},
+          requestBody: { name: 'idx', schema: { v: { type: 'TEXT' } } },
+        })
+      );
+      const { status, body } = await parseRes(res);
+      expect(status).toBe(400);
+      expect(body.error.message).toContain('customHost');
+    });
+  });
+
+  describe('searchIndexHandler', () => {
+    beforeEach(() => {
+      mockGlideFt.info.mockResolvedValue({ index_name: 'test_idx' });
+    });
+
+    it('should execute KNN search', async () => {
+      const res = await searchIndexHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/search',
+          requestBody: { vector: [1.0, 0.0, 0.0], top_k: 3 },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(200);
+      expect(mockGlideFt.search).toHaveBeenCalled();
+    });
+
+    it('should reject filter containing => (injection guard)', async () => {
+      const res = await searchIndexHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/search',
+          requestBody: {
+            vector: [1.0],
+            top_k: 3,
+            filter: '@tag:{x}=>[KNN 100 @v $B]',
+          },
+        })
+      );
+      const { status, body } = await parseRes(res);
+      expect(status).toBe(400);
+      expect(body.error.message).toContain('=>');
+    });
+
+    it('should return 400 for empty vector', async () => {
+      const res = await searchIndexHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/search',
+          requestBody: { vector: [], top_k: 3 },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(400);
+    });
+
+    it('should return 404 if index does not exist', async () => {
+      mockGlideFt.info.mockRejectedValue(new Error('Unknown index name'));
+      const res = await searchIndexHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/missing/search',
+          requestBody: { vector: [1.0], top_k: 3 },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(404);
+    });
+  });
+
+  describe('upsertDocsHandler', () => {
+    it('should upsert documents', async () => {
+      const res = await upsertDocsHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/upsert',
+          requestBody: {
+            documents: [
+              {
+                id: 'doc1',
+                fields: { content: 'hello' },
+                vector: [1.0, 0.0, 0.0],
+              },
+            ],
+          },
+        })
+      );
+      const { status, body } = await parseRes(res);
+      expect(status).toBe(200);
+      expect(body.data[0].status).toBe('upserted');
+      expect(mockGlideClient.hset).toHaveBeenCalled();
+    });
+
+    it('should reject invalid document IDs', async () => {
+      const res = await upsertDocsHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/upsert',
+          requestBody: {
+            documents: [{ id: 'bad id!@#', fields: {} }],
+          },
+        })
+      );
+      const { body } = await parseRes(res);
+      expect(body.data[0].status).toBe('error');
+    });
+
+    it('should return 400 for empty documents array', async () => {
+      const res = await upsertDocsHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/upsert',
+          requestBody: { documents: [] },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(400);
+    });
+  });
+
+  describe('dropIndexHandler', () => {
+    it('should drop an existing index', async () => {
+      mockGlideFt.info.mockResolvedValue({ index_name: 'test_idx' });
+      const res = await dropIndexHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx',
+        })
+      );
+      const { status, body } = await parseRes(res);
+      expect(status).toBe(200);
+      expect(body.deleted).toBe(true);
+    });
+
+    it('should return 404 if index does not exist', async () => {
+      mockGlideFt.info.mockRejectedValue(new Error('Unknown index name'));
+      const res = await dropIndexHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/missing',
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(404);
+    });
+  });
+
+  describe('getIndexHandler', () => {
+    it('should return index info', async () => {
+      mockGlideFt.info.mockResolvedValue({
+        index_name: 'test_idx',
+        num_docs: 5,
+      });
+      const res = await getIndexHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx',
+        })
+      );
+      const { status, body } = await parseRes(res);
+      expect(status).toBe(200);
+      expect(body.name).toBe('test_idx');
+    });
+
+    it('should return 404 for missing index', async () => {
+      mockGlideFt.info.mockRejectedValue(new Error('Unknown index name'));
+      const res = await getIndexHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/nope',
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(404);
+    });
+  });
+
+  describe('deleteDocsHandler', () => {
+    it('should delete documents by ID', async () => {
+      const res = await deleteDocsHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/documents',
+          requestBody: { ids: ['doc1', 'doc2'] },
+        })
+      );
+      const { status, body } = await parseRes(res);
+      expect(status).toBe(200);
+      expect(body.deleted).toBe(1);
+    });
+
+    it('should return 400 for empty ids array', async () => {
+      const res = await deleteDocsHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/documents',
+          requestBody: { ids: [] },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(400);
+    });
+
+    it('should return 400 for invalid document ID', async () => {
+      const res = await deleteDocsHandler(
+        makeCtx({
+          requestURL: 'http://localhost:8787/v1/indexes/test_idx/documents',
+          requestBody: { ids: ['valid', 'bad id!'] },
+        })
+      );
+      const { status } = await parseRes(res);
+      expect(status).toBe(400);
+    });
+  });
+});

--- a/tests/unit/src/shared/services/cache/backends/valkey.test.ts
+++ b/tests/unit/src/shared/services/cache/backends/valkey.test.ts
@@ -1,0 +1,146 @@
+import { TimeUnit } from '@valkey/valkey-glide';
+import { ValkeyCacheBackend } from '../../../../../../../src/shared/services/cache/backends/valkey';
+import { CacheEntry } from '../../../../../../../src/shared/services/cache/types';
+
+// Mock GlideClient methods
+const mockClient = {
+  get: jest.fn(),
+  set: jest.fn(),
+  del: jest.fn(),
+  exists: jest.fn(),
+  scan: jest.fn(),
+  close: jest.fn(),
+};
+
+// Make instanceof GlideClusterClient return false (standalone path)
+jest.mock('@valkey/valkey-glide', () => {
+  const actual = jest.requireActual('@valkey/valkey-glide');
+  return {
+    ...actual,
+    GlideClusterClient: class GlideClusterClient {},
+  };
+});
+
+describe('ValkeyCacheBackend', () => {
+  let backend: ValkeyCacheBackend;
+  const DB = 'testdb';
+
+  beforeEach(() => {
+    jest.resetAllMocks();
+    mockClient.scan.mockResolvedValue(['0', []]);
+    backend = new ValkeyCacheBackend(mockClient as any, DB);
+  });
+
+  describe('getFullKey', () => {
+    it('prefixes with dbName:namespace: when namespace given', () => {
+      expect(backend.getFullKey('k', 'ns')).toBe('testdb:ns:k');
+    });
+
+    it('prefixes with dbName:default: when no namespace', () => {
+      expect(backend.getFullKey('k')).toBe('testdb:default:k');
+    });
+  });
+
+  describe('get', () => {
+    it('returns null on cache miss', async () => {
+      mockClient.get.mockResolvedValue(null);
+      expect(await backend.get('k')).toBeNull();
+    });
+
+    it('returns entry on cache hit', async () => {
+      const entry: CacheEntry<string> = { value: 'v', createdAt: Date.now() };
+      mockClient.get.mockResolvedValue(JSON.stringify(entry));
+      const result = await backend.get<string>('k');
+      expect(result?.value).toBe('v');
+    });
+
+    it('deletes and returns null for expired entry', async () => {
+      const entry: CacheEntry<string> = {
+        value: 'v',
+        createdAt: Date.now() - 2000,
+        expiresAt: Date.now() - 1000,
+      };
+      mockClient.get.mockResolvedValue(JSON.stringify(entry));
+      mockClient.del.mockResolvedValue(1);
+      expect(await backend.get('k')).toBeNull();
+      expect(mockClient.del).toHaveBeenCalledWith(['testdb:default:k']);
+    });
+
+    it('returns null on client error without throwing', async () => {
+      mockClient.get.mockRejectedValue(new Error('connection lost'));
+      expect(await backend.get('k')).toBeNull();
+    });
+  });
+
+  describe('set', () => {
+    it('calls client.set without expiry when no TTL', async () => {
+      mockClient.set.mockResolvedValue('OK');
+      await backend.set('k', 'v');
+      expect(mockClient.set).toHaveBeenCalledTimes(1);
+      const [, , opts] = mockClient.set.mock.calls[0];
+      expect(opts).toBeUndefined();
+    });
+
+    it('calls client.set with expiry struct when TTL given', async () => {
+      mockClient.set.mockResolvedValue('OK');
+      await backend.set('k', 'v', { ttl: 5000 });
+      const [, , opts] = mockClient.set.mock.calls[0];
+      expect(opts).toEqual({ expiry: { type: TimeUnit.Seconds, count: 5 } });
+    });
+
+    it('rethrows on client error', async () => {
+      mockClient.set.mockRejectedValue(new Error('write fail'));
+      await expect(backend.set('k', 'v')).rejects.toThrow('write fail');
+    });
+  });
+
+  describe('delete', () => {
+    it('returns true when key was deleted', async () => {
+      mockClient.del.mockResolvedValue(1);
+      expect(await backend.delete('k')).toBe(true);
+      expect(mockClient.del).toHaveBeenCalledWith(['testdb:default:k']);
+    });
+
+    it('returns false when key was absent', async () => {
+      mockClient.del.mockResolvedValue(0);
+      expect(await backend.delete('k')).toBe(false);
+    });
+  });
+
+  describe('has', () => {
+    it('returns true when key exists', async () => {
+      mockClient.exists.mockResolvedValue(1);
+      expect(await backend.has('k')).toBe(true);
+      expect(mockClient.exists).toHaveBeenCalledWith(['testdb:default:k']);
+    });
+
+    it('returns false when key absent', async () => {
+      mockClient.exists.mockResolvedValue(0);
+      expect(await backend.has('k')).toBe(false);
+    });
+  });
+
+  describe('clear', () => {
+    it('scans then deletes matched keys', async () => {
+      mockClient.scan
+        .mockResolvedValueOnce(['0', ['testdb:ns:a', 'testdb:ns:b']])
+        .mockResolvedValueOnce(['0', []]);
+      mockClient.del.mockResolvedValue(2);
+      await backend.clear('ns');
+      expect(mockClient.del).toHaveBeenCalledWith([
+        'testdb:ns:a',
+        'testdb:ns:b',
+      ]);
+    });
+  });
+
+  describe('keys', () => {
+    it('returns keys stripped of dbName:namespace: prefix', async () => {
+      mockClient.scan
+        .mockResolvedValueOnce(['0', ['testdb:ns:foo', 'testdb:ns:bar']])
+        .mockResolvedValueOnce(['0', []]);
+      const result = await backend.keys('ns');
+      expect(result).toEqual(['foo', 'bar']);
+    });
+  });
+});

--- a/tests/unit/src/shared/services/valkey/client.test.ts
+++ b/tests/unit/src/shared/services/valkey/client.test.ts
@@ -1,0 +1,260 @@
+import {
+  parseValkeyConnectionString,
+  createValkeyClient,
+} from '../../../../../../src/shared/services/valkey/client';
+import { createCacheBackendsValkey } from '../../../../../../src/shared/services/cache/index';
+
+jest.mock('@valkey/valkey-glide', () => ({
+  GlideClient: {
+    createClient: jest.fn().mockResolvedValue({ type: 'standalone' }),
+  },
+  GlideClusterClient: {
+    createClient: jest.fn().mockResolvedValue({ type: 'cluster' }),
+  },
+}));
+
+jest.mock(
+  '../../../../../../src/shared/services/cache/backends/valkey',
+  () => ({
+    createValkeyBackend: jest.fn().mockReturnValue({ type: 'mockBackend' }),
+  })
+);
+
+describe('parseValkeyConnectionString', () => {
+  describe('valid connection strings', () => {
+    it('should parse valkey:// scheme', () => {
+      const result = parseValkeyConnectionString('valkey://myhost:6380');
+      expect(result.addresses).toEqual([{ host: 'myhost', port: 6380 }]);
+      expect(result.options.useTLS).toBe(false);
+    });
+
+    it('should parse valkeys:// scheme with TLS', () => {
+      const result = parseValkeyConnectionString('valkeys://secure:7777');
+      expect(result.addresses).toEqual([{ host: 'secure', port: 7777 }]);
+      expect(result.options.useTLS).toBe(true);
+    });
+
+    it('should parse redis:// compat scheme', () => {
+      const result = parseValkeyConnectionString('redis://compat:6379');
+      expect(result.addresses[0].host).toBe('compat');
+      expect(result.options.useTLS).toBe(false);
+    });
+
+    it('should parse rediss:// scheme with TLS', () => {
+      const result = parseValkeyConnectionString('rediss://tlshost:6380');
+      expect(result.options.useTLS).toBe(true);
+    });
+
+    it('should extract password from URL', () => {
+      const result = parseValkeyConnectionString(
+        'valkey://:secret123@myhost:6379'
+      );
+      expect(result.options.password).toBe('secret123');
+    });
+
+    it('should decode URL-encoded password', () => {
+      const result = parseValkeyConnectionString(
+        'valkey://:p%40ss%3Dword@host:6379'
+      );
+      expect(result.options.password).toBe('p@ss=word');
+    });
+
+    it('should default port to 6379 when omitted', () => {
+      const result = parseValkeyConnectionString('valkey://noport');
+      expect(result.addresses[0].port).toBe(6379);
+    });
+
+    it('should not set password when none provided', () => {
+      const result = parseValkeyConnectionString('valkey://host:6379');
+      expect(result.options.password).toBeUndefined();
+    });
+
+    it('should parse multi-seed cluster URL', () => {
+      const result = parseValkeyConnectionString(
+        'valkey://host1:6379,host2:6380,host3:6381?cluster=true'
+      );
+      expect(result.addresses).toEqual([
+        { host: 'host1', port: 6379 },
+        { host: 'host2', port: 6380 },
+        { host: 'host3', port: 6381 },
+      ]);
+      expect(result.options.cluster).toBe(true);
+    });
+
+    it('should parse multi-seed with password', () => {
+      const result = parseValkeyConnectionString(
+        'valkeys://:secret@host1:6379,host2:6380?cluster=true'
+      );
+      expect(result.addresses).toEqual([
+        { host: 'host1', port: 6379 },
+        { host: 'host2', port: 6380 },
+      ]);
+      expect(result.options.password).toBe('secret');
+      expect(result.options.useTLS).toBe(true);
+    });
+  });
+
+  describe('invalid connection strings', () => {
+    it('should reject unsupported schemes', () => {
+      expect(() => parseValkeyConnectionString('http://bad:1234')).toThrow(
+        /Unsupported scheme/
+      );
+    });
+
+    it('should reject malformed URLs', () => {
+      expect(() => parseValkeyConnectionString('not a url')).toThrow(
+        /Invalid Valkey connection string/
+      );
+    });
+
+    it('should reject empty string', () => {
+      expect(() => parseValkeyConnectionString('')).toThrow();
+    });
+  });
+});
+
+// --- cluster query param tests (appended to parseValkeyConnectionString suite) ---
+describe('parseValkeyConnectionString cluster param', () => {
+  it('cluster=true sets options.cluster = true', () => {
+    const result = parseValkeyConnectionString(
+      'valkey://host:6379?cluster=true'
+    );
+    expect(result.options.cluster).toBe(true);
+  });
+
+  it('cluster=false does not set options.cluster', () => {
+    const result = parseValkeyConnectionString(
+      'valkey://host:6379?cluster=false'
+    );
+    expect(result.options.cluster).toBeUndefined();
+  });
+
+  it('no cluster param leaves options.cluster undefined', () => {
+    const result = parseValkeyConnectionString('valkey://host:6379');
+    expect(result.options.cluster).toBeUndefined();
+  });
+
+  it('multi-seed single-address still returns one-element addresses array', () => {
+    const result = parseValkeyConnectionString(
+      'valkey://host:6379?cluster=true'
+    );
+    expect(result.addresses).toHaveLength(1);
+    expect(result.addresses[0]).toEqual({ host: 'host', port: 6379 });
+  });
+});
+
+describe('createValkeyClient', () => {
+  const { GlideClient, GlideClusterClient } = jest.requireMock(
+    '@valkey/valkey-glide'
+  );
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('calls GlideClient.createClient when cluster is undefined', async () => {
+    await createValkeyClient([{ host: 'localhost', port: 6379 }]);
+    expect(GlideClient.createClient).toHaveBeenCalledTimes(1);
+    expect(GlideClusterClient.createClient).not.toHaveBeenCalled();
+  });
+
+  it('calls GlideClient.createClient when cluster is false', async () => {
+    await createValkeyClient([{ host: 'localhost', port: 6379 }], {
+      cluster: false,
+    });
+    expect(GlideClient.createClient).toHaveBeenCalledTimes(1);
+    expect(GlideClusterClient.createClient).not.toHaveBeenCalled();
+  });
+
+  it('calls GlideClusterClient.createClient when cluster is true', async () => {
+    await createValkeyClient([{ host: 'localhost', port: 6379 }], {
+      cluster: true,
+    });
+    expect(GlideClusterClient.createClient).toHaveBeenCalledTimes(1);
+    expect(GlideClient.createClient).not.toHaveBeenCalled();
+  });
+
+  it('passes all seed addresses to GlideClusterClient', async () => {
+    const addresses = [
+      { host: 'node1', port: 6379 },
+      { host: 'node2', port: 6380 },
+    ];
+    await createValkeyClient(addresses, { cluster: true });
+    expect(GlideClusterClient.createClient).toHaveBeenCalledWith(
+      expect.objectContaining({ addresses })
+    );
+  });
+});
+
+describe('createCacheBackendsValkey TTL env vars', () => {
+  const VALKEY_URL = 'valkey://localhost:6379';
+
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    process.env = { ...originalEnv };
+    delete process.env.VALKEY_DEFAULT_TTL_MS;
+    delete process.env.VALKEY_SESSION_TTL_MS;
+    delete process.env.VALKEY_CONFIG_TTL_MS;
+    jest.clearAllMocks();
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+  });
+
+  it('uses default TTLs when no env vars set', async () => {
+    await createCacheBackendsValkey(VALKEY_URL);
+    const { getDefaultCache, getSessionCache, getConfigCache } = await import(
+      '../../../../../../src/shared/services/cache/index'
+    );
+    expect((getDefaultCache() as any).defaultTtl).toBe(300000); // 5 min
+    expect((getSessionCache() as any).defaultTtl).toBe(1800000); // 30 min
+    expect((getConfigCache() as any).defaultTtl).toBe(2592000000); // 30 days
+  });
+
+  it('VALKEY_DEFAULT_TTL_MS overrides defaultCache TTL', async () => {
+    process.env.VALKEY_DEFAULT_TTL_MS = '60000';
+    await createCacheBackendsValkey(VALKEY_URL);
+    const { getDefaultCache } = await import(
+      '../../../../../../src/shared/services/cache/index'
+    );
+    expect((getDefaultCache() as any).defaultTtl).toBe(60000);
+  });
+
+  it('VALKEY_SESSION_TTL_MS overrides sessionCache TTL', async () => {
+    process.env.VALKEY_SESSION_TTL_MS = '120000';
+    await createCacheBackendsValkey(VALKEY_URL);
+    const { getSessionCache } = await import(
+      '../../../../../../src/shared/services/cache/index'
+    );
+    expect((getSessionCache() as any).defaultTtl).toBe(120000);
+  });
+
+  it('VALKEY_CONFIG_TTL_MS overrides configCache TTL', async () => {
+    process.env.VALKEY_CONFIG_TTL_MS = '3600000';
+    await createCacheBackendsValkey(VALKEY_URL);
+    const { getConfigCache } = await import(
+      '../../../../../../src/shared/services/cache/index'
+    );
+    expect((getConfigCache() as any).defaultTtl).toBe(3600000);
+  });
+
+  it('VALKEY_DEFAULT_TTL_MS=0 falls back to default 5 minutes', async () => {
+    process.env.VALKEY_DEFAULT_TTL_MS = '0';
+    await createCacheBackendsValkey(VALKEY_URL);
+    const { getDefaultCache } = await import(
+      '../../../../../../src/shared/services/cache/index'
+    );
+    expect((getDefaultCache() as any).defaultTtl).toBe(300000);
+  });
+
+  it('VALKEY_DEFAULT_TTL_MS=abc (NaN) falls back to default 5 minutes', async () => {
+    process.env.VALKEY_DEFAULT_TTL_MS = 'abc';
+    await createCacheBackendsValkey(VALKEY_URL);
+    const { getDefaultCache } = await import(
+      '../../../../../../src/shared/services/cache/index'
+    );
+    expect((getDefaultCache() as any).defaultTtl).toBe(300000);
+  });
+});


### PR DESCRIPTION
Closes: https://github.com/Portkey-AI/gateway/issues/1700

**Description:**
- Add a `valkey-search` vector database provider that routes FT.* commands natively over RESP via `@valkey/valkey-glide`, making the gateway the first LLM router with native Valkey Search support. Supports create index, drop index, get info, upsert documents, KNN vector search, and delete documents.
- Add a `valkey-glide` cache backend as an alternative to the existing ioredis/Redis backend. Triggered by `VALKEY_CONNECTION_STRING` env var (takes priority over `REDIS_CONNECTION_STRING`). Initializes all five cache stores (default, session, config, OAuth, MCP) backed by a single shared GLIDE connection.
- Add a shared GLIDE client module (`src/shared/services/valkey/client.ts`) with connection string parsing supporting `valkey://`, `valkeys://` (TLS), `redis://`, `rediss://`, multi-seed cluster URLs, and password extraction.
- Add `ValkeyRateLimiter` using GLIDE's `Script` + `invokeScript()` pattern (same Lua logic as the ioredis rate limiter, adapted for GLIDE's API).
- Extend `isValidCustomHost` to accept `valkey://` and `redis://` protocol schemes for the valkey-search provider.
- Add `CacheService.setBackend()` method to properly close placeholder backends before replacing them (prevents timer leaks on startup).
- Add SIGTERM/SIGINT shutdown hooks for the valkey-search client cache to close GLIDE connections gracefully.
- Existing ioredis cache backend is completely unchanged for backward compatibility.

**Tests Run/Test cases added:**
- [x] `tests/unit/src/shared/services/valkey/client.test.ts` — Connection string parsing (all schemes, multi-seed, passwords, edge cases), `createValkeyClient` standalone vs cluster dispatch, `createCacheBackendsValkey` TTL env var overrides
- [x] `tests/unit/src/providers/valkey-search/handlers.test.ts` — All six handlers (create/drop/get index, upsert, search, delete docs), input validation (bad index names, empty vectors, injection guard), error paths (missing index 404, connection failure 503)
- [x] `tests/unit/src/shared/services/cache/backends/valkey.test.ts` — CacheBackend interface compliance (get/set/delete/has/clear/keys), TTL handling with GLIDE's expiry struct, expired entry cleanup, error resilience
- [x] Manual end-to-end: gateway with `VALKEY_CONNECTION_STRING` -> Ollama chat completion -> verified cache key written to Valkey with correct format (`default:llm-responses:<hash>`), confirmed cache HIT on repeat request

**Type of Change:**
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [ ] Refactoring (no functional changes)

No changes needed on the SDK side of things.
