### PR TITLE
[New Plugin] Cryptowerk guardrail plugin to create verifiable proofs

### DIFF
--- a/conf.example.json
+++ b/conf.example.json
@@ -10,7 +10,8 @@
     "pangea",
     "promptsecurity",
     "panw-prisma-airs",
-    "walledai"
+    "walledai",
+    "cryptowerk"
   ],
   "credentials": {
     "portkey": {

--- a/conf.json
+++ b/conf.json
@@ -1,4 +1,5 @@
 {
+  "admin_token": "fqohggb07saegyba47tyboze34yfb7FgfgHU",
   "plugins_enabled": [
     "default",
     "portkey",
@@ -10,7 +11,8 @@
     "pangea",
     "promptsecurity",
     "panw-prisma-airs",
-    "walledai"
+    "walledai",
+    "cryptowerk"
   ],
   "credentials": {
     "portkey": {

--- a/plugins/cryptowerk/impl.ts
+++ b/plugins/cryptowerk/impl.ts
@@ -1,8 +1,5 @@
 import crypto from 'crypto';
 
-//const http=require("http");
-import * as https from 'node:https';
-
 interface APIResponse {
   minSupportedAPIVersion: number;
   maxSupportedAPIVersion: number;
@@ -42,48 +39,47 @@ export class APIAccess {
     callName: string,
     reqParams: object
   ): Promise<APIResponse> {
-    const apiServer = 'developers.cryptowerk.com'; // 'localhost'
-    const apiPort = 443; // 8443
     const postData: string = JSON.stringify(reqParams);
-    const options = {
-      hostname: apiServer,
-      port: apiPort,
-      path: '/platform/API/v8/' + callName,
-      method: 'POST',
-      headers: {
-        'X-ApiKey': this.apiKey + ' ' + this.apiCredential,
-        'Content-Type': 'application/json', //"application/x-www-form-urlencoded"
-        'Content-Length': Buffer.byteLength(postData),
-      },
-    };
     return new Promise((resolve, reject) => {
-      const req = https.request(options, (resp) => {
-        let responseData = '';
-        resp.on('data', (chunk) => {
-          responseData += chunk;
+      const apiUrl =
+        'https://developers.cryptowerk.com/platform/API/v8/' + callName;
+      fetch(apiUrl, {
+        method: 'POST',
+        headers: {
+          'X-ApiKey': this.apiKey + ' ' + this.apiCredential,
+          'Content-Type': 'application/json', //"application/x-www-form-urlencoded"
+          'Content-Length': Buffer.byteLength(postData),
+        },
+        body: postData,
+      })
+        .then((response: Response) => {
+          if (response.ok && response.status == 200) {
+            response
+              .json()
+              .then((json) => {
+                resolve(json);
+              })
+              .catch((e) => {
+                reject('Cannot parse JSON response: ' + e.toString());
+              });
+          } else {
+            let msg = 'Error: status=' + response.status;
+            if (response.statusText) msg += ' ' + response.statusText;
+            response
+              .json()
+              .then((json) => {
+                if (json.error) msg += ", server says '" + json.error + "'";
+                reject(msg);
+              })
+              .catch((e) => {
+                msg += ' ' + e.toString();
+                reject(msg);
+              });
+          }
+        })
+        .catch((e) => {
+          reject(e.toString());
         });
-        resp.on('end', () => {
-          let result = JSON.parse(responseData);
-          //console.log(result);
-          if (result.error)
-            reject(
-              'API request rejected by server ' +
-                apiServer +
-                ' : ' +
-                result.error
-            );
-          else resolve(result);
-        });
-      });
-
-      req.on('error', (err) => {
-        let errMsg = 'Error: ' + err.message + ' stack: ' + err.stack;
-        //console.log(errMsg);
-        reject(errMsg);
-      });
-
-      req.write(postData);
-      req.end();
     });
   }
 

--- a/plugins/cryptowerk/impl.ts
+++ b/plugins/cryptowerk/impl.ts
@@ -32,12 +32,9 @@ interface GetSealResponseDocument {
   hasBeenInsertedIntoAtLeastOneBlockchain: boolean;
   blockchainRegistrations: BlockchainRegistration[];
   hasBeenInsertedIntoAllRequestedBlockchains: boolean;
-
 }
-interface Seal {
-}
-interface BlockchainRegistration {
-}
+interface Seal {}
+interface BlockchainRegistration {}
 
 export class APIAccess {
   apiKey: string;
@@ -104,9 +101,9 @@ export class APIAccess {
     );
   }
 
-  async getSeal(retrievalId:string):Promise<GetSealResponse> {
-    return this.apiRequest("getseal",{
-      "retrievalId": retrievalId
+  async getSeal(retrievalId: string): Promise<GetSealResponse> {
+    return this.apiRequest('getseal', {
+      retrievalId: retrievalId,
     }) as Promise<GetSealResponse>;
   }
 }

--- a/plugins/cryptowerk/impl.ts
+++ b/plugins/cryptowerk/impl.ts
@@ -3,13 +3,6 @@ import crypto from 'crypto';
 //const http=require("http");
 import * as https from 'node:https';
 
-/*
-export type JSON_t =
-    | string | number | boolean | null
-    | JSON_t[]
-    | { [k: string]: JSON_t };
-*/
-
 interface APIResponse {
   minSupportedAPIVersion: number;
   maxSupportedAPIVersion: number;
@@ -115,11 +108,3 @@ export class APIAccess {
     }) as Promise<GetSealResponse>;
   }
 }
-
-/*
-function test() {
-  const doc:Buffer=Buffer.from("Hello, world.");
-  register(doc);
-}
-//test();
-*/

--- a/plugins/cryptowerk/impl.ts
+++ b/plugins/cryptowerk/impl.ts
@@ -1,0 +1,120 @@
+import crypto from 'crypto';
+
+//const http=require("http");
+import * as https from 'node:https';
+
+/*
+export type JSON_t =
+    | string | number | boolean | null
+    | JSON_t[]
+    | { [k: string]: JSON_t };
+*/
+
+interface APIResponse {
+  minSupportedAPIVersion: number;
+  maxSupportedAPIVersion: number;
+}
+
+interface RegisterResponse extends APIResponse {
+  documents: RegisterResponseDocument[];
+}
+interface RegisterResponseDocument {
+  retrievalId: string;
+}
+
+interface GetSealResponse extends APIResponse {
+  documents: GetSealResponseDocument[];
+}
+interface GetSealResponseDocument {
+  retrievalId: string;
+  seal: Seal;
+  submittedAt: number;
+  hasBeenInsertedIntoAtLeastOneBlockchain: boolean;
+  blockchainRegistrations: BlockchainRegistration[];
+  hasBeenInsertedIntoAllRequestedBlockchains: boolean;
+
+}
+interface Seal {
+}
+interface BlockchainRegistration {
+}
+
+export class APIAccess {
+  apiKey: string;
+  apiCredential: string;
+
+  constructor(apiKey: string, apiCredential: string) {
+    this.apiKey = apiKey;
+    this.apiCredential = apiCredential;
+  }
+
+  private async apiRequest(
+    callName: string,
+    reqParams: object
+  ): Promise<APIResponse> {
+    const apiServer = 'developers.cryptowerk.com'; // 'localhost'
+    const apiPort = 443; // 8443
+    const postData: string = JSON.stringify(reqParams);
+    const options = {
+      hostname: apiServer,
+      port: apiPort,
+      path: '/platform/API/v8/' + callName,
+      method: 'POST',
+      headers: {
+        'X-ApiKey': this.apiKey + ' ' + this.apiCredential,
+        'Content-Type': 'application/json', //"application/x-www-form-urlencoded"
+        'Content-Length': Buffer.byteLength(postData),
+      },
+    };
+    return new Promise((resolve, reject) => {
+      const req = https.request(options, (resp) => {
+        let responseData = '';
+        resp.on('data', (chunk) => {
+          responseData += chunk;
+        });
+        resp.on('end', () => {
+          let result = JSON.parse(responseData);
+          //console.log(result);
+          resolve(result);
+        });
+      });
+
+      req.on('error', (err) => {
+        let errMsg = 'Error: ' + err.message + ' stack: ' + err.stack;
+        console.log(errMsg);
+        reject(errMsg);
+      });
+
+      req.write(postData);
+      req.end();
+    });
+  }
+
+  async register(
+    doc: Buffer
+  ): Promise<{ docHash: string; apiResult: RegisterResponse }> {
+    const docHash: string = crypto
+      .createHash('sha256')
+      .update(doc)
+      .digest('hex');
+    return this.apiRequest('register', { hashes: docHash }).then(
+      (apiResult: APIResponse) => {
+        return { docHash: docHash, apiResult: apiResult as RegisterResponse };
+      }
+    );
+  }
+
+  async getSeal(retrievalId:string):Promise<GetSealResponse> {
+    return this.apiRequest("getseal",{
+      "retrievalId": retrievalId
+    }) as Promise<GetSealResponse>;
+  }
+}
+
+/*
+function test() {
+  const doc:Buffer=Buffer.from("Hello, world.");
+  register(doc);
+}
+//test();
+*/

--- a/plugins/cryptowerk/impl.ts
+++ b/plugins/cryptowerk/impl.ts
@@ -3,6 +3,7 @@ import crypto from 'crypto';
 interface APIResponse {
   minSupportedAPIVersion: number;
   maxSupportedAPIVersion: number;
+  error?: string;
 }
 
 interface RegisterResponse extends APIResponse {
@@ -48,34 +49,28 @@ export class APIAccess {
         headers: {
           'X-ApiKey': this.apiKey + ' ' + this.apiCredential,
           'Content-Type': 'application/json', //"application/x-www-form-urlencoded"
-          'Content-Length': Buffer.byteLength(postData),
+          'Content-Length': String(Buffer.byteLength(postData)),
         },
         body: postData,
       })
         .then((response: Response) => {
-          if (response.ok && response.status == 200) {
-            response
-              .json()
-              .then((json) => {
+          let success: boolean = response.ok && response.status == 200;
+          response
+            .text() // .json()
+            .then((jsonText) => {
+              let json: APIResponse = JSON.parse(jsonText);
+              if (success) {
                 resolve(json);
-              })
-              .catch((e) => {
-                reject('Cannot parse JSON response: ' + e.toString());
-              });
-          } else {
-            let msg = 'Error: status=' + response.status;
-            if (response.statusText) msg += ' ' + response.statusText;
-            response
-              .json()
-              .then((json) => {
+              } else {
+                let msg = 'status=' + response.status;
+                if (response.statusText) msg += ' ' + response.statusText;
                 if (json.error) msg += ", server says '" + json.error + "'";
                 reject(msg);
-              })
-              .catch((e) => {
-                msg += ' ' + e.toString();
-                reject(msg);
-              });
-          }
+              }
+            })
+            .catch((e) => {
+              reject('Cannot retrieve JSON response: ' + e.toString());
+            });
         })
         .catch((e) => {
           reject(e.toString());

--- a/plugins/cryptowerk/impl.ts
+++ b/plugins/cryptowerk/impl.ts
@@ -1,4 +1,5 @@
 import crypto from 'crypto';
+import { post } from '../utils';
 
 interface APIResponse {
   minSupportedAPIVersion: number;
@@ -40,40 +41,35 @@ export class APIAccess {
     callName: string,
     reqParams: object
   ): Promise<APIResponse> {
-    const postData: string = JSON.stringify(reqParams);
+    //const server="http://localhost:8080"; // for local debugging
+    const server = 'https://developers.cryptowerk.com';
     return new Promise((resolve, reject) => {
-      const apiUrl =
-        'https://developers.cryptowerk.com/platform/API/v8/' + callName;
-      fetch(apiUrl, {
-        method: 'POST',
-        headers: {
-          'X-ApiKey': this.apiKey + ' ' + this.apiCredential,
-          'Content-Type': 'application/json', //"application/x-www-form-urlencoded"
-          'Content-Length': String(Buffer.byteLength(postData)),
+      const apiUrl = server + '/platform/API/v8/' + callName;
+      post(
+        apiUrl,
+        reqParams, // JSON.stringify() is done by post()
+        {
+          headers: {
+            'X-ApiKey': this.apiKey + ' ' + this.apiCredential,
+            // already set by post(): 'Content-Type': 'application/json', //"application/x-www-form-urlencoded"
+            // no suitable for post(): 'Content-Length': String(Buffer.byteLength(postData)),
+          },
         },
-        body: postData,
-      })
-        .then((response: Response) => {
-          let success: boolean = response.ok && response.status == 200;
-          response
-            .text() // .json()
-            .then((jsonText) => {
-              let json: APIResponse = JSON.parse(jsonText);
-              if (success) {
-                resolve(json);
-              } else {
-                let msg = 'status=' + response.status;
-                if (response.statusText) msg += ' ' + response.statusText;
-                if (json.error) msg += ", server says '" + json.error + "'";
-                reject(msg);
-              }
-            })
-            .catch((e) => {
-              reject('Cannot retrieve JSON response: ' + e.toString());
-            });
+        30000 // timeout
+      )
+        .then((json: APIResponse) => {
+          if (json.error) reject('Server responded with error: ' + json.error);
+          else resolve(json);
         })
         .catch((e) => {
-          reject(e.toString());
+          let msg = e.toString();
+          if (e.response) {
+            const response = e.response;
+            if (response.status) msg += ', status=' + response.status;
+            if (response.statusText) msg += ', ' + response.statusText;
+            if (response.body) msg += ", server says '" + response.body + "'";
+          }
+          reject(msg);
         });
     });
   }

--- a/plugins/cryptowerk/impl.ts
+++ b/plugins/cryptowerk/impl.ts
@@ -72,13 +72,20 @@ export class APIAccess {
         resp.on('end', () => {
           let result = JSON.parse(responseData);
           //console.log(result);
-          resolve(result);
+          if (result.error)
+            reject(
+              'API request rejected by server ' +
+                apiServer +
+                ' : ' +
+                result.error
+            );
+          else resolve(result);
         });
       });
 
       req.on('error', (err) => {
         let errMsg = 'Error: ' + err.message + ' stack: ' + err.stack;
-        console.log(errMsg);
+        //console.log(errMsg);
         reject(errMsg);
       });
 
@@ -94,11 +101,12 @@ export class APIAccess {
       .createHash('sha256')
       .update(doc)
       .digest('hex');
-    return this.apiRequest('register', { hashes: docHash }).then(
-      (apiResult: APIResponse) => {
-        return { docHash: docHash, apiResult: apiResult as RegisterResponse };
-      }
-    );
+    return this.apiRequest('register', {
+      hashes: docHash,
+      publiclyRetrievable: true,
+    }).then((apiResult: APIResponse) => {
+      return { docHash: docHash, apiResult: apiResult as RegisterResponse };
+    });
   }
 
   async getSeal(retrievalId: string): Promise<GetSealResponse> {

--- a/plugins/cryptowerk/manifest.json
+++ b/plugins/cryptowerk/manifest.json
@@ -8,14 +8,12 @@
         "type": "string",
         "label": "API Key",
         "description": "Your Cryptowerk API key",
-        "required": true,
         "encrypted": true
       },
       "apiCredential": {
         "type": "string",
         "label": "API Credential",
         "description": "Your Cryptowerk API credential",
-        "required": true,
         "encrypted": true
       }
     },

--- a/plugins/cryptowerk/manifest.json
+++ b/plugins/cryptowerk/manifest.json
@@ -1,0 +1,39 @@
+{
+  "id": "cryptowerk",
+  "description": "A guardrail plugin creating verifiable proofs of a requests's input and output.",
+  "credentials": {
+    "type": "object",
+    "properties": {
+      "apiKey": {
+        "type": "string",
+        "label": "API Key",
+        "description": "Your Cryptowerk API key",
+        "required": true,
+        "encrypted": true
+      },
+      "apiCredential": {
+        "type": "string",
+        "label": "API Credential",
+        "description": "Your Cryptowerk API credential",
+        "required": true,
+        "encrypted": true
+      }
+    },
+    "required": ["apiKey", "apiCredential"]
+  },
+  "functions": [
+    {
+      "name": "Guardrail Sealing Function",
+      "id": "seal",
+      "supportedHooks": ["beforeRequestHook", "afterRequestHook"],
+      "type": "guardrail",
+      "description": [
+        {
+          "type": "subHeading",
+          "text": "This guardrail function takes the request's input and output and creates a verifiable proof for both."
+        }
+      ],
+      "parameters": {}
+    }
+  ]
+}

--- a/plugins/cryptowerk/seal.test.ts
+++ b/plugins/cryptowerk/seal.test.ts
@@ -3,9 +3,9 @@ import { HookEventType, PluginContext, PluginParameters } from '../types';
 import { APIAccess } from './impl';
 
 describe('Cryptowerk Plugin', () => {
-  const apiKey='K3MiuGZCcDsmYp6io/tBuX6VabGK3O3SVMe8mZlQF68='; // test credentials;
-  const apiCredential='idp3RCub/9zQVggIAMxeMxDtLZ09SogdTFHXrGAx084=';
-  
+  const apiKey = 'K3MiuGZCcDsmYp6io/tBuX6VabGK3O3SVMe8mZlQF68='; // test credentials;
+  const apiCredential = 'idp3RCub/9zQVggIAMxeMxDtLZ09SogdTFHXrGAx084=';
+
   it('should create a proof', async () => {
     const context: PluginContext = {
       request: {
@@ -43,17 +43,18 @@ describe('Cryptowerk Plugin', () => {
     );
     expect(result.data.docHash).toHaveLength((256 / 8) * 2);
     expect(result.data.retrievalId.startsWith('ri3')).toBe(true);
-    
+
     //console.log("retrievalId="+result.data.retrievalId);
   });
-  
+
   it('should retrieve a proof', async () => {
-    let api = new APIAccess(apiKey,apiCredential);
-    let retrievalId='ri31907897c52999213379ced8e63f8e1bc94da484b45a5d175adfde2da2466fcc1';
+    let api = new APIAccess(apiKey, apiCredential);
+    let retrievalId =
+      'ri31907897c52999213379ced8e63f8e1bc94da484b45a5d175adfde2da2466fcc1';
     let response = await api.getSeal(retrievalId);
     //console.log(response);
     expect(response.documents).toHaveLength(1);
-    let doc=response.documents[0];
+    let doc = response.documents[0];
     expect(doc.retrievalId).toEqual(retrievalId);
     expect(doc.submittedAt).toEqual(1782985598783);
   });

--- a/plugins/cryptowerk/seal.test.ts
+++ b/plugins/cryptowerk/seal.test.ts
@@ -3,7 +3,7 @@ import { HookEventType, PluginContext, PluginParameters } from '../types';
 import { APIAccess } from './impl';
 
 describe('Cryptowerk Plugin', () => {
-  const apiKey = 'K3MiuGZCcDsmYp6io/tBuX6VabGK3O3SVMe8mZlQF68='; // test credentials;
+  const apiKey = 'K3MiuGZCcDsmYp6io/tBuX6VabGK3O3SVMe8mZlQF68='; // test credentials, committing them to git is intentional
   const apiCredential = 'idp3RCub/9zQVggIAMxeMxDtLZ09SogdTFHXrGAx084=';
 
   it('should create a proof', async () => {

--- a/plugins/cryptowerk/seal.test.ts
+++ b/plugins/cryptowerk/seal.test.ts
@@ -1,34 +1,39 @@
 import { handler } from './seal';
-import { HookEventType, PluginContext, PluginParameters } from '../types';
+import {
+  HookEventType,
+  PluginContext,
+  PluginParameters,
+  PluginHandler,
+  PluginHandlerResponse,
+} from '../types';
 import { APIAccess } from './impl';
 
 describe('Cryptowerk Plugin', () => {
   const apiKey = 'K3MiuGZCcDsmYp6io/tBuX6VabGK3O3SVMe8mZlQF68='; // test credentials, committing them to git is intentional
   const apiCredential = 'idp3RCub/9zQVggIAMxeMxDtLZ09SogdTFHXrGAx084=';
 
+  const context: PluginContext = {
+    request: {
+      //text: "This is an example request for which a verifiable proof will be created.",
+      json: {
+        messages: [
+          {
+            role: 'user',
+            content:
+              'This is an example request for which a verifiable proof will be created.',
+          },
+        ],
+      },
+    },
+    credentials: {
+      apiKey: apiKey,
+      apiCredential: apiCredential,
+    },
+  };
+  const parameters: PluginParameters = {};
+  const eventType: HookEventType = 'afterRequestHook';
+
   it('should create a proof', async () => {
-    const context: PluginContext = {
-      request: {
-        //text: "This is an example request for which a verifiable proof will be created.",
-        json: {
-          messages: [
-            {
-              role: 'user',
-              content:
-                'This is an example request for which a verifiable proof will be created.',
-            },
-          ],
-        },
-      },
-      credentials: {
-        apiKey: apiKey,
-        apiCredential: apiCredential,
-      },
-    };
-
-    const parameters: PluginParameters = {};
-    const eventType: HookEventType = 'afterRequestHook';
-
     const result = await handler(context, parameters, eventType);
 
     expect(result.error).toBeNull();
@@ -57,5 +62,41 @@ describe('Cryptowerk Plugin', () => {
     let doc = response.documents[0];
     expect(doc.retrievalId).toEqual(retrievalId);
     expect(doc.submittedAt).toEqual(1782985598783);
+  });
+
+  it('should tell about wrong credentials', async () => {
+    function wrongCred(
+      manipulator: (context: PluginContext) => void
+    ): Promise<PluginHandlerResponse> {
+      let contextCopy = JSON.parse(JSON.stringify(context));
+      manipulator(contextCopy);
+      const response = handler(contextCopy, parameters, eventType);
+      response.then((result) => {
+        //console.log(result);
+        //console.log(typeof result.error);
+        expect(result.error).toBeInstanceOf(Error);
+      });
+      return response;
+    }
+    {
+      const result = await wrongCred((context) => {
+        context.credentials.apiCredential += 'wrong';
+      });
+      expect(result.error.message).toContain(
+        'Input byte array has incorrect ending byte'
+      );
+    }
+    {
+      const result = await wrongCred((context) => {
+        context.credentials.apiCredential = 'abc';
+      });
+      expect(result.error.message).toContain('Credentials are invalid');
+    }
+    {
+      const result = await wrongCred((context) => {
+        context.credentials.apiKey = 'abc';
+      });
+      expect(result.error.message).toContain('Account does not exist');
+    }
   });
 });

--- a/plugins/cryptowerk/seal.test.ts
+++ b/plugins/cryptowerk/seal.test.ts
@@ -72,12 +72,11 @@ describe('Cryptowerk Plugin', () => {
       manipulator(contextCopy);
       const response = handler(contextCopy, parameters, eventType);
       response.then((result) => {
-        //console.log(result);
-        //console.log(typeof result.error);
         expect(result.error).toBeInstanceOf(Error);
       });
       return response;
     }
+
     {
       const result = await wrongCred((context) => {
         context.credentials.apiCredential += 'wrong';

--- a/plugins/cryptowerk/seal.test.ts
+++ b/plugins/cryptowerk/seal.test.ts
@@ -1,0 +1,60 @@
+import { handler } from './seal';
+import { HookEventType, PluginContext, PluginParameters } from '../types';
+import { APIAccess } from './impl';
+
+describe('Cryptowerk Plugin', () => {
+  const apiKey='K3MiuGZCcDsmYp6io/tBuX6VabGK3O3SVMe8mZlQF68='; // test credentials;
+  const apiCredential='idp3RCub/9zQVggIAMxeMxDtLZ09SogdTFHXrGAx084=';
+  
+  it('should create a proof', async () => {
+    const context: PluginContext = {
+      request: {
+        //text: "This is an example request for which a verifiable proof will be created.",
+        json: {
+          messages: [
+            {
+              role: 'user',
+              content:
+                'This is an example request for which a verifiable proof will be created.',
+            },
+          ],
+        },
+      },
+      credentials: {
+        apiKey: apiKey,
+        apiCredential: apiCredential,
+      },
+    };
+
+    const parameters: PluginParameters = {};
+    const eventType: HookEventType = 'afterRequestHook';
+
+    const result = await handler(context, parameters, eventType);
+
+    expect(result.error).toBeNull();
+    expect(result.verdict).toBe(true);
+    expect(
+      result.data.sealedData.indexOf(
+        context.request.json.messages[0].content
+      ) >= 0
+    ).toBe(true);
+    expect(result.data.sealedDataBase64.length).toBeGreaterThan(
+      result.data.sealedData.length
+    );
+    expect(result.data.docHash).toHaveLength((256 / 8) * 2);
+    expect(result.data.retrievalId.startsWith('ri3')).toBe(true);
+    
+    //console.log("retrievalId="+result.data.retrievalId);
+  });
+  
+  it('should retrieve a proof', async () => {
+    let api = new APIAccess(apiKey,apiCredential);
+    let retrievalId='ri31907897c52999213379ced8e63f8e1bc94da484b45a5d175adfde2da2466fcc1';
+    let response = await api.getSeal(retrievalId);
+    //console.log(response);
+    expect(response.documents).toHaveLength(1);
+    let doc=response.documents[0];
+    expect(doc.retrievalId).toEqual(retrievalId);
+    expect(doc.submittedAt).toEqual(1782985598783);
+  });
+});

--- a/plugins/cryptowerk/seal.ts
+++ b/plugins/cryptowerk/seal.ts
@@ -7,20 +7,11 @@ import {
 } from '../types';
 import { APIAccess } from './impl';
 
-//console.log('CW PluginHandler initialized.');
-
 export const handler: PluginHandler = async (
   context: PluginContext,
   parameters: PluginParameters,
   eventType: HookEventType
-  // options: HandlerOptions // e.g. options.env for environment variables
 ) => {
-  // - context.request for request data
-  // - context.response for response data (in afterRequestHook)
-  // - parameters for plugin-specific parameters
-  // - eventType to determine which hook is being executed
-
-  //console.log('CW PluginHandler called.');
   let errors = [];
   let logMsg = [];
   let data = null;
@@ -47,55 +38,52 @@ export const handler: PluginHandler = async (
         parameters.credentials.apiCredential
       );
     } else {
-      api = new APIAccess(
-        // Those are fallback credentials for ease-of-use meant to get started quickly. They might be revoked if being abused.
-        // This is committed to git intentionally.
-        'SlR2+djTs+ydFNGiSs9oPAfV8RYJzkOqLgCD3HtZCsU=',
-        '+9uJ4f2hzpDsXCT1/19KToX8vBGmFvOZRyySd0fxbZs='
-      );
-      logMsg.push(
-        'Warning: Please provide your own API key and/or credential (e.g. from before/afterRequestHooks/checks/parameters). For now using fallback credentials that may expire any time.'
+      api = null;
+      errors.push(
+        'Please provide your Cryptowerk API key and credential (e.g. in before/afterRequestHooks/checks/parameters).'
       );
       //throw new Error(...)
     }
 
-    let docToSealJson = {
-      eventType: eventType,
-      request: context.request.json,
-      response:
-        context.response && context.response.json
-          ? context.response.json
-          : null,
-    };
-    let docToSealText = JSON.stringify(docToSealJson);
-    let docToSealBin = Buffer.from(docToSealText);
-    let docToSeal64 = docToSealBin.toString('base64');
-    let response = await api.register(docToSealBin);
-    if (!('apiResult' in response))
-      errors.push(
-        'Missing API result. Possibly the connection to the API server failed.'
-      );
-    else if (!('documents' in response.apiResult))
-      errors.push('Missing documents in API result.');
-    else {
-      let retrievalId = response.apiResult.documents[0].retrievalId;
-      let docHash = response.docHash;
-      logMsg.push(
-        //'Sealed text=' + docToSealText /*+" base64="+docToSeal64*/ +
-        'Proof created: docHash=' +
-          docHash +
-          ' retrievalId=' +
-          retrievalId +
-          ' verifiable at https://developers.cryptowerk.com/platform/permalink/sealapiverify?retrievalId=' +
-          retrievalId
-      );
-      data = {
-        // any additional data you want to return
-        sealedData: docToSealText,
-        sealedDataBase64: docToSeal64,
-        docHash: docHash,
-        retrievalId: retrievalId,
+    if (api != null) {
+      let docToSealJson = {
+        eventType: eventType,
+        request: context.request.json,
+        response:
+          context.response && context.response.json
+            ? context.response.json
+            : null,
       };
+      let docToSealText = JSON.stringify(docToSealJson);
+      let docToSealBin = Buffer.from(docToSealText);
+      let docToSeal64 = docToSealBin.toString('base64');
+      let response = await api.register(docToSealBin);
+      if (!('apiResult' in response))
+        errors.push(
+          'Missing API result. Possibly the connection to the API server failed.'
+        );
+      else if (!('documents' in response.apiResult))
+        errors.push('Missing documents in API result.');
+      else {
+        let retrievalId = response.apiResult.documents[0].retrievalId;
+        let docHash = response.docHash;
+        logMsg.push(
+          //'Sealed text=' + docToSealText /*+" base64="+docToSeal64*/ +
+          'Proof created: docHash=' +
+            docHash +
+            ' retrievalId=' +
+            retrievalId +
+            ' verifiable at https://developers.cryptowerk.com/platform/permalink/sealapiverify?retrievalId=' +
+            retrievalId
+        );
+        data = {
+          // any additional data you want to return
+          sealedData: docToSealText,
+          sealedDataBase64: docToSeal64,
+          docHash: docHash,
+          retrievalId: retrievalId,
+        };
+      }
     }
   } catch (e: any) {
     let msg;
@@ -105,7 +93,7 @@ export const handler: PluginHandler = async (
   }
   const error = errors.length > 0 ? new Error(errors.join(' ')) : null;
   return {
-    error: error, // or error object if an error occurred
+    error: error, // error object if an error occurred
     verdict: errors.length == 0, // indicate if the guardrail passed or failed
     data: data,
     log: logMsg.join(' '),

--- a/plugins/cryptowerk/seal.ts
+++ b/plugins/cryptowerk/seal.ts
@@ -1,0 +1,92 @@
+import {
+  HookEventType,
+  PluginContext,
+  PluginHandler,
+  PluginParameters,
+  //HandlerOptions
+} from '../types';
+import { APIAccess } from './impl';
+
+//console.log('CW PluginHandler initialized.');
+
+export const handler: PluginHandler = async (
+  context: PluginContext,
+  parameters: PluginParameters,
+  eventType: HookEventType
+  // options: HandlerOptions // e.g. options.env for environment variables
+) => {
+  // - context.request for request data
+  // - context.response for response data (in afterRequestHook)
+  // - parameters for plugin-specific parameters
+  // - eventType to determine which hook is being executed
+
+  //console.log('CW PluginHandler called.');
+  let error = null;
+  let logMsg = '';
+  let data = null;
+
+  let api;
+  if (
+    context.credentials &&
+    context.credentials.apiKey &&
+    context.credentials.apiCredential
+  )
+    api = new APIAccess(
+      context.credentials.apiKey,
+      context.credentials.apiCredential
+    );
+  else if (
+    parameters &&
+    parameters.credentials &&
+    parameters.credentials.apiKey &&
+    parameters.credentials.apiCredential
+  )
+    api = new APIAccess(
+      parameters.credentials.apiKey,
+      parameters.credentials.apiCredential
+    );
+  else
+    throw new Error(
+      'Missing API key and/or credential (e.g. from before/afterRequestHooks/checks/parameters).'
+    );
+
+  let docToSealJson = {
+    eventType: eventType,
+    request: context.request.json,
+    response:
+      context.response && context.response.json ? context.response.json : null,
+  };
+  let docToSealText = JSON.stringify(docToSealJson);
+  let docToSealBin = Buffer.from(docToSealText);
+  let docToSeal64 = docToSealBin.toString('base64');
+  let response = await api.register(docToSealBin);
+  if (!('apiResult' in response))
+    error =
+      'Missing API result. Possibly the connection to the API server failed.';
+  else if (!('documents' in response.apiResult))
+    error = 'Missing documents in API result.';
+  else {
+    let retrievalId = response.apiResult.documents[0].retrievalId;
+    let docHash = response.docHash;
+    logMsg +=
+      'Sealed text=' +
+      docToSealText /*+" base64="+docToSeal64*/ +
+      ' docHash=' +
+      docHash +
+      ' retrievalId=' +
+      retrievalId;
+    data = {
+      // any additional data you want to return
+      sealedData: docToSealText,
+      sealedDataBase64: docToSeal64,
+      docHash: docHash,
+      retrievalId: retrievalId,
+    };
+  }
+  return {
+    error: error, // or error object if an error occurred
+    verdict: true, // or false to indicate if the guardrail passed or failed
+    data: data,
+    log: logMsg,
+  };
+};

--- a/plugins/cryptowerk/seal.ts
+++ b/plugins/cryptowerk/seal.ts
@@ -48,12 +48,13 @@ export const handler: PluginHandler = async (
       );
     } else {
       api = new APIAccess(
-        // fallback credentials for ease-of-use, don't rely on them, they might expire any time
+        // Those are fallback credentials for ease-of-use meant to get started quickly. They might be revoked if being abused.
+        // This is committed to git intentionally.
         'SlR2+djTs+ydFNGiSs9oPAfV8RYJzkOqLgCD3HtZCsU=',
         '+9uJ4f2hzpDsXCT1/19KToX8vBGmFvOZRyySd0fxbZs='
       );
       logMsg.push(
-        'Warning: Missing API key and/or credential (e.g. from before/afterRequestHooks/checks/parameters). Using fallback credentials that may expire any time.'
+        'Warning: Please provide your own API key and/or credential (e.g. from before/afterRequestHooks/checks/parameters). For now using fallback credentials that may expire any time.'
       );
       //throw new Error(...)
     }

--- a/plugins/cryptowerk/seal.ts
+++ b/plugins/cryptowerk/seal.ts
@@ -96,7 +96,7 @@ export const handler: PluginHandler = async (
         retrievalId: retrievalId,
       };
     }
-  } catch (e) {
+  } catch (e: any) {
     let msg;
     if (e instanceof Error) msg = e.message;
     else msg = e.toString();

--- a/plugins/cryptowerk/seal.ts
+++ b/plugins/cryptowerk/seal.ts
@@ -21,72 +21,92 @@ export const handler: PluginHandler = async (
   // - eventType to determine which hook is being executed
 
   //console.log('CW PluginHandler called.');
-  let error = null;
-  let logMsg = '';
+  let errors = [];
+  let logMsg = [];
   let data = null;
 
-  let api;
-  if (
-    context.credentials &&
-    context.credentials.apiKey &&
-    context.credentials.apiCredential
-  )
-    api = new APIAccess(
-      context.credentials.apiKey,
+  try {
+    let api;
+    if (
+      context.credentials &&
+      context.credentials.apiKey &&
       context.credentials.apiCredential
-    );
-  else if (
-    parameters &&
-    parameters.credentials &&
-    parameters.credentials.apiKey &&
-    parameters.credentials.apiCredential
-  )
-    api = new APIAccess(
-      parameters.credentials.apiKey,
+    ) {
+      api = new APIAccess(
+        context.credentials.apiKey,
+        context.credentials.apiCredential
+      );
+    } else if (
+      parameters &&
+      parameters.credentials &&
+      parameters.credentials.apiKey &&
       parameters.credentials.apiCredential
-    );
-  else
-    throw new Error(
-      'Missing API key and/or credential (e.g. from before/afterRequestHooks/checks/parameters).'
-    );
+    ) {
+      api = new APIAccess(
+        parameters.credentials.apiKey,
+        parameters.credentials.apiCredential
+      );
+    } else {
+      api = new APIAccess(
+        // fallback credentials for ease-of-use, don't rely on them, they might expire any time
+        'SlR2+djTs+ydFNGiSs9oPAfV8RYJzkOqLgCD3HtZCsU=',
+        '+9uJ4f2hzpDsXCT1/19KToX8vBGmFvOZRyySd0fxbZs='
+      );
+      logMsg.push(
+        'Warning: Missing API key and/or credential (e.g. from before/afterRequestHooks/checks/parameters). Using fallback credentials that may expire any time.'
+      );
+      //throw new Error(...)
+    }
 
-  let docToSealJson = {
-    eventType: eventType,
-    request: context.request.json,
-    response:
-      context.response && context.response.json ? context.response.json : null,
-  };
-  let docToSealText = JSON.stringify(docToSealJson);
-  let docToSealBin = Buffer.from(docToSealText);
-  let docToSeal64 = docToSealBin.toString('base64');
-  let response = await api.register(docToSealBin);
-  if (!('apiResult' in response))
-    error =
-      'Missing API result. Possibly the connection to the API server failed.';
-  else if (!('documents' in response.apiResult))
-    error = 'Missing documents in API result.';
-  else {
-    let retrievalId = response.apiResult.documents[0].retrievalId;
-    let docHash = response.docHash;
-    logMsg +=
-      'Sealed text=' +
-      docToSealText /*+" base64="+docToSeal64*/ +
-      ' docHash=' +
-      docHash +
-      ' retrievalId=' +
-      retrievalId;
-    data = {
-      // any additional data you want to return
-      sealedData: docToSealText,
-      sealedDataBase64: docToSeal64,
-      docHash: docHash,
-      retrievalId: retrievalId,
+    let docToSealJson = {
+      eventType: eventType,
+      request: context.request.json,
+      response:
+        context.response && context.response.json
+          ? context.response.json
+          : null,
     };
+    let docToSealText = JSON.stringify(docToSealJson);
+    let docToSealBin = Buffer.from(docToSealText);
+    let docToSeal64 = docToSealBin.toString('base64');
+    let response = await api.register(docToSealBin);
+    if (!('apiResult' in response))
+      errors.push(
+        'Missing API result. Possibly the connection to the API server failed.'
+      );
+    else if (!('documents' in response.apiResult))
+      errors.push('Missing documents in API result.');
+    else {
+      let retrievalId = response.apiResult.documents[0].retrievalId;
+      let docHash = response.docHash;
+      logMsg.push(
+        //'Sealed text=' + docToSealText /*+" base64="+docToSeal64*/ +
+        'Proof created: docHash=' +
+          docHash +
+          ' retrievalId=' +
+          retrievalId +
+          ' verifiable at https://developers.cryptowerk.com/platform/permalink/sealapiverify?retrievalId=' +
+          retrievalId
+      );
+      data = {
+        // any additional data you want to return
+        sealedData: docToSealText,
+        sealedDataBase64: docToSeal64,
+        docHash: docHash,
+        retrievalId: retrievalId,
+      };
+    }
+  } catch (e) {
+    let msg;
+    if (e instanceof Error) msg = e.message;
+    else msg = e.toString();
+    errors.push(msg);
   }
+  const error = errors.length > 0 ? new Error(errors.join(' ')) : null;
   return {
     error: error, // or error object if an error occurred
-    verdict: true, // or false to indicate if the guardrail passed or failed
+    verdict: errors.length == 0, // indicate if the guardrail passed or failed
     data: data,
-    log: logMsg,
+    log: logMsg.join(' '),
   };
 };

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,137 +1,137 @@
-import { handler as defaultregexMatch } from "./default/regexMatch"
-import { handler as defaultallowedRequestTypes } from "./default/allowedRequestTypes"
-import { handler as defaultsentenceCount } from "./default/sentenceCount"
-import { handler as defaultwordCount } from "./default/wordCount"
-import { handler as defaultcharacterCount } from "./default/characterCount"
-import { handler as defaultjsonSchema } from "./default/jsonSchema"
-import { handler as defaultjsonKeys } from "./default/jsonKeys"
-import { handler as defaultcontains } from "./default/contains"
-import { handler as defaultvalidUrls } from "./default/validUrls"
-import { handler as defaultwebhook } from "./default/webhook"
-import { handler as defaultlog } from "./default/log"
-import { handler as defaultcontainsCode } from "./default/containsCode"
-import { handler as defaultalluppercase } from "./default/alluppercase"
-import { handler as defaultendsWith } from "./default/endsWith"
-import { handler as defaultalllowercase } from "./default/alllowercase"
-import { handler as defaultmodelwhitelist } from "./default/modelwhitelist"
-import { handler as defaultmodelRules } from "./default/modelRules"
-import { handler as defaultjwt } from "./default/jwt"
-import { handler as defaultrequiredMetadataKeys } from "./default/requiredMetadataKeys"
-import { handler as defaultaddPrefix } from "./default/addPrefix"
-import { handler as defaultnotNull } from "./default/notNull"
-import { handler as portkeymoderateContent } from "./portkey/moderateContent"
-import { handler as portkeylanguage } from "./portkey/language"
-import { handler as portkeypii } from "./portkey/pii"
-import { handler as portkeygibberish } from "./portkey/gibberish"
-import { handler as qualifirecontentModeration } from "./qualifire/contentModeration"
-import { handler as qualifirehallucinations } from "./qualifire/hallucinations"
-import { handler as qualifirepii } from "./qualifire/pii"
-import { handler as qualifirepromptInjections } from "./qualifire/promptInjections"
-import { handler as qualifiregrounding } from "./qualifire/grounding"
-import { handler as qualifiretoolUseQuality } from "./qualifire/toolUseQuality"
-import { handler as qualifirepolicy } from "./qualifire/policy"
-import { handler as aporiavalidateProject } from "./aporia/validateProject"
-import { handler as sydelabssydeguard } from "./sydelabs/sydeguard"
-import { handler as pillarscanPrompt } from "./pillar/scanPrompt"
-import { handler as pillarscanResponse } from "./pillar/scanResponse"
-import { handler as patronusphi } from "./patronus/phi"
-import { handler as patronuspii } from "./patronus/pii"
-import { handler as patronusisConcise } from "./patronus/isConcise"
-import { handler as patronusisHelpful } from "./patronus/isHelpful"
-import { handler as patronusisPolite } from "./patronus/isPolite"
-import { handler as patronusnoApologies } from "./patronus/noApologies"
-import { handler as patronusnoGenderBias } from "./patronus/noGenderBias"
-import { handler as patronusnoRacialBias } from "./patronus/noRacialBias"
-import { handler as patronusretrievalAnswerRelevance } from "./patronus/retrievalAnswerRelevance"
-import { handler as patronusretrievalHallucination } from "./patronus/retrievalHallucination"
-import { handler as patronustoxicity } from "./patronus/toxicity"
-import { handler as patronuscustom } from "./patronus/custom"
-import { handler as pangeatextGuard } from "./pangea/textGuard"
-import { handler as pangeapii } from "./pangea/pii"
-import { handler as promptsecurityprotectPrompt } from "./promptsecurity/protectPrompt"
-import { handler as promptsecurityprotectResponse } from "./promptsecurity/protectResponse"
-import { handler as panwPrismaAirsintercept } from "./panw-prisma-airs/intercept"
-import { handler as walledaiwalledprotect } from "./walledai/walledprotect"
-import { handler as cryptowerkseal } from "./cryptowerk/seal"
+import { handler as defaultregexMatch } from './default/regexMatch';
+import { handler as defaultallowedRequestTypes } from './default/allowedRequestTypes';
+import { handler as defaultsentenceCount } from './default/sentenceCount';
+import { handler as defaultwordCount } from './default/wordCount';
+import { handler as defaultcharacterCount } from './default/characterCount';
+import { handler as defaultjsonSchema } from './default/jsonSchema';
+import { handler as defaultjsonKeys } from './default/jsonKeys';
+import { handler as defaultcontains } from './default/contains';
+import { handler as defaultvalidUrls } from './default/validUrls';
+import { handler as defaultwebhook } from './default/webhook';
+import { handler as defaultlog } from './default/log';
+import { handler as defaultcontainsCode } from './default/containsCode';
+import { handler as defaultalluppercase } from './default/alluppercase';
+import { handler as defaultendsWith } from './default/endsWith';
+import { handler as defaultalllowercase } from './default/alllowercase';
+import { handler as defaultmodelwhitelist } from './default/modelwhitelist';
+import { handler as defaultmodelRules } from './default/modelRules';
+import { handler as defaultjwt } from './default/jwt';
+import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
+import { handler as defaultaddPrefix } from './default/addPrefix';
+import { handler as defaultnotNull } from './default/notNull';
+import { handler as portkeymoderateContent } from './portkey/moderateContent';
+import { handler as portkeylanguage } from './portkey/language';
+import { handler as portkeypii } from './portkey/pii';
+import { handler as portkeygibberish } from './portkey/gibberish';
+import { handler as qualifirecontentModeration } from './qualifire/contentModeration';
+import { handler as qualifirehallucinations } from './qualifire/hallucinations';
+import { handler as qualifirepii } from './qualifire/pii';
+import { handler as qualifirepromptInjections } from './qualifire/promptInjections';
+import { handler as qualifiregrounding } from './qualifire/grounding';
+import { handler as qualifiretoolUseQuality } from './qualifire/toolUseQuality';
+import { handler as qualifirepolicy } from './qualifire/policy';
+import { handler as aporiavalidateProject } from './aporia/validateProject';
+import { handler as sydelabssydeguard } from './sydelabs/sydeguard';
+import { handler as pillarscanPrompt } from './pillar/scanPrompt';
+import { handler as pillarscanResponse } from './pillar/scanResponse';
+import { handler as patronusphi } from './patronus/phi';
+import { handler as patronuspii } from './patronus/pii';
+import { handler as patronusisConcise } from './patronus/isConcise';
+import { handler as patronusisHelpful } from './patronus/isHelpful';
+import { handler as patronusisPolite } from './patronus/isPolite';
+import { handler as patronusnoApologies } from './patronus/noApologies';
+import { handler as patronusnoGenderBias } from './patronus/noGenderBias';
+import { handler as patronusnoRacialBias } from './patronus/noRacialBias';
+import { handler as patronusretrievalAnswerRelevance } from './patronus/retrievalAnswerRelevance';
+import { handler as patronusretrievalHallucination } from './patronus/retrievalHallucination';
+import { handler as patronustoxicity } from './patronus/toxicity';
+import { handler as patronuscustom } from './patronus/custom';
+import { handler as pangeatextGuard } from './pangea/textGuard';
+import { handler as pangeapii } from './pangea/pii';
+import { handler as promptsecurityprotectPrompt } from './promptsecurity/protectPrompt';
+import { handler as promptsecurityprotectResponse } from './promptsecurity/protectResponse';
+import { handler as panwPrismaAirsintercept } from './panw-prisma-airs/intercept';
+import { handler as walledaiwalledprotect } from './walledai/walledprotect';
+import { handler as cryptowerkseal } from './cryptowerk/seal';
 
 export const plugins = {
-  "default": {
-    "regexMatch": defaultregexMatch,
-    "allowedRequestTypes": defaultallowedRequestTypes,
-    "sentenceCount": defaultsentenceCount,
-    "wordCount": defaultwordCount,
-    "characterCount": defaultcharacterCount,
-    "jsonSchema": defaultjsonSchema,
-    "jsonKeys": defaultjsonKeys,
-    "contains": defaultcontains,
-    "validUrls": defaultvalidUrls,
-    "webhook": defaultwebhook,
-    "log": defaultlog,
-    "containsCode": defaultcontainsCode,
-    "alluppercase": defaultalluppercase,
-    "endsWith": defaultendsWith,
-    "alllowercase": defaultalllowercase,
-    "modelwhitelist": defaultmodelwhitelist,
-    "modelRules": defaultmodelRules,
-    "jwt": defaultjwt,
-    "requiredMetadataKeys": defaultrequiredMetadataKeys,
-    "addPrefix": defaultaddPrefix,
-    "notNull": defaultnotNull
+  default: {
+    regexMatch: defaultregexMatch,
+    allowedRequestTypes: defaultallowedRequestTypes,
+    sentenceCount: defaultsentenceCount,
+    wordCount: defaultwordCount,
+    characterCount: defaultcharacterCount,
+    jsonSchema: defaultjsonSchema,
+    jsonKeys: defaultjsonKeys,
+    contains: defaultcontains,
+    validUrls: defaultvalidUrls,
+    webhook: defaultwebhook,
+    log: defaultlog,
+    containsCode: defaultcontainsCode,
+    alluppercase: defaultalluppercase,
+    endsWith: defaultendsWith,
+    alllowercase: defaultalllowercase,
+    modelwhitelist: defaultmodelwhitelist,
+    modelRules: defaultmodelRules,
+    jwt: defaultjwt,
+    requiredMetadataKeys: defaultrequiredMetadataKeys,
+    addPrefix: defaultaddPrefix,
+    notNull: defaultnotNull,
   },
-  "portkey": {
-    "moderateContent": portkeymoderateContent,
-    "language": portkeylanguage,
-    "pii": portkeypii,
-    "gibberish": portkeygibberish
+  portkey: {
+    moderateContent: portkeymoderateContent,
+    language: portkeylanguage,
+    pii: portkeypii,
+    gibberish: portkeygibberish,
   },
-  "qualifire": {
-    "contentModeration": qualifirecontentModeration,
-    "hallucinations": qualifirehallucinations,
-    "pii": qualifirepii,
-    "promptInjections": qualifirepromptInjections,
-    "grounding": qualifiregrounding,
-    "toolUseQuality": qualifiretoolUseQuality,
-    "policy": qualifirepolicy
+  qualifire: {
+    contentModeration: qualifirecontentModeration,
+    hallucinations: qualifirehallucinations,
+    pii: qualifirepii,
+    promptInjections: qualifirepromptInjections,
+    grounding: qualifiregrounding,
+    toolUseQuality: qualifiretoolUseQuality,
+    policy: qualifirepolicy,
   },
-  "aporia": {
-    "validateProject": aporiavalidateProject
+  aporia: {
+    validateProject: aporiavalidateProject,
   },
-  "sydelabs": {
-    "sydeguard": sydelabssydeguard
+  sydelabs: {
+    sydeguard: sydelabssydeguard,
   },
-  "pillar": {
-    "scanPrompt": pillarscanPrompt,
-    "scanResponse": pillarscanResponse
+  pillar: {
+    scanPrompt: pillarscanPrompt,
+    scanResponse: pillarscanResponse,
   },
-  "patronus": {
-    "phi": patronusphi,
-    "pii": patronuspii,
-    "isConcise": patronusisConcise,
-    "isHelpful": patronusisHelpful,
-    "isPolite": patronusisPolite,
-    "noApologies": patronusnoApologies,
-    "noGenderBias": patronusnoGenderBias,
-    "noRacialBias": patronusnoRacialBias,
-    "retrievalAnswerRelevance": patronusretrievalAnswerRelevance,
-    "retrievalHallucination": patronusretrievalHallucination,
-    "toxicity": patronustoxicity,
-    "custom": patronuscustom
+  patronus: {
+    phi: patronusphi,
+    pii: patronuspii,
+    isConcise: patronusisConcise,
+    isHelpful: patronusisHelpful,
+    isPolite: patronusisPolite,
+    noApologies: patronusnoApologies,
+    noGenderBias: patronusnoGenderBias,
+    noRacialBias: patronusnoRacialBias,
+    retrievalAnswerRelevance: patronusretrievalAnswerRelevance,
+    retrievalHallucination: patronusretrievalHallucination,
+    toxicity: patronustoxicity,
+    custom: patronuscustom,
   },
-  "pangea": {
-    "textGuard": pangeatextGuard,
-    "pii": pangeapii
+  pangea: {
+    textGuard: pangeatextGuard,
+    pii: pangeapii,
   },
-  "promptsecurity": {
-    "protectPrompt": promptsecurityprotectPrompt,
-    "protectResponse": promptsecurityprotectResponse
+  promptsecurity: {
+    protectPrompt: promptsecurityprotectPrompt,
+    protectResponse: promptsecurityprotectResponse,
   },
-  "panw-prisma-airs": {
-    "intercept": panwPrismaAirsintercept
+  'panw-prisma-airs': {
+    intercept: panwPrismaAirsintercept,
   },
-  "walledai": {
-    "walledprotect": walledaiwalledprotect
+  walledai: {
+    walledprotect: walledaiwalledprotect,
   },
-  "cryptowerk": {
-    "seal": cryptowerkseal
-  }
+  cryptowerk: {
+    seal: cryptowerkseal,
+  },
 };

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,137 +1,137 @@
-import { handler as defaultregexMatch } from './default/regexMatch';
-import { handler as defaultallowedRequestTypes } from './default/allowedRequestTypes';
-import { handler as defaultsentenceCount } from './default/sentenceCount';
-import { handler as defaultwordCount } from './default/wordCount';
-import { handler as defaultcharacterCount } from './default/characterCount';
-import { handler as defaultjsonSchema } from './default/jsonSchema';
-import { handler as defaultjsonKeys } from './default/jsonKeys';
-import { handler as defaultcontains } from './default/contains';
-import { handler as defaultvalidUrls } from './default/validUrls';
-import { handler as defaultwebhook } from './default/webhook';
-import { handler as defaultlog } from './default/log';
-import { handler as defaultcontainsCode } from './default/containsCode';
-import { handler as defaultalluppercase } from './default/alluppercase';
-import { handler as defaultendsWith } from './default/endsWith';
-import { handler as defaultalllowercase } from './default/alllowercase';
-import { handler as defaultmodelwhitelist } from './default/modelwhitelist';
-import { handler as defaultmodelRules } from './default/modelRules';
-import { handler as defaultjwt } from './default/jwt';
-import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
-import { handler as defaultaddPrefix } from './default/addPrefix';
-import { handler as defaultnotNull } from './default/notNull';
-import { handler as portkeymoderateContent } from './portkey/moderateContent';
-import { handler as portkeylanguage } from './portkey/language';
-import { handler as portkeypii } from './portkey/pii';
-import { handler as portkeygibberish } from './portkey/gibberish';
-import { handler as qualifirecontentModeration } from './qualifire/contentModeration';
-import { handler as qualifirehallucinations } from './qualifire/hallucinations';
-import { handler as qualifirepii } from './qualifire/pii';
-import { handler as qualifirepromptInjections } from './qualifire/promptInjections';
-import { handler as qualifiregrounding } from './qualifire/grounding';
-import { handler as qualifiretoolUseQuality } from './qualifire/toolUseQuality';
-import { handler as qualifirepolicy } from './qualifire/policy';
-import { handler as aporiavalidateProject } from './aporia/validateProject';
-import { handler as sydelabssydeguard } from './sydelabs/sydeguard';
-import { handler as pillarscanPrompt } from './pillar/scanPrompt';
-import { handler as pillarscanResponse } from './pillar/scanResponse';
-import { handler as patronusphi } from './patronus/phi';
-import { handler as patronuspii } from './patronus/pii';
-import { handler as patronusisConcise } from './patronus/isConcise';
-import { handler as patronusisHelpful } from './patronus/isHelpful';
-import { handler as patronusisPolite } from './patronus/isPolite';
-import { handler as patronusnoApologies } from './patronus/noApologies';
-import { handler as patronusnoGenderBias } from './patronus/noGenderBias';
-import { handler as patronusnoRacialBias } from './patronus/noRacialBias';
-import { handler as patronusretrievalAnswerRelevance } from './patronus/retrievalAnswerRelevance';
-import { handler as patronusretrievalHallucination } from './patronus/retrievalHallucination';
-import { handler as patronustoxicity } from './patronus/toxicity';
-import { handler as patronuscustom } from './patronus/custom';
-import { handler as pangeatextGuard } from './pangea/textGuard';
-import { handler as pangeapii } from './pangea/pii';
-import { handler as promptsecurityprotectPrompt } from './promptsecurity/protectPrompt';
-import { handler as promptsecurityprotectResponse } from './promptsecurity/protectResponse';
-import { handler as panwPrismaAirsintercept } from './panw-prisma-airs/intercept';
-import { handler as walledaiwalledprotect } from './walledai/walledprotect';
-import { handler as cryptowerkseal } from './cryptowerk/seal';
+import { handler as defaultregexMatch } from "./default/regexMatch"
+import { handler as defaultallowedRequestTypes } from "./default/allowedRequestTypes"
+import { handler as defaultsentenceCount } from "./default/sentenceCount"
+import { handler as defaultwordCount } from "./default/wordCount"
+import { handler as defaultcharacterCount } from "./default/characterCount"
+import { handler as defaultjsonSchema } from "./default/jsonSchema"
+import { handler as defaultjsonKeys } from "./default/jsonKeys"
+import { handler as defaultcontains } from "./default/contains"
+import { handler as defaultvalidUrls } from "./default/validUrls"
+import { handler as defaultwebhook } from "./default/webhook"
+import { handler as defaultlog } from "./default/log"
+import { handler as defaultcontainsCode } from "./default/containsCode"
+import { handler as defaultalluppercase } from "./default/alluppercase"
+import { handler as defaultendsWith } from "./default/endsWith"
+import { handler as defaultalllowercase } from "./default/alllowercase"
+import { handler as defaultmodelwhitelist } from "./default/modelwhitelist"
+import { handler as defaultmodelRules } from "./default/modelRules"
+import { handler as defaultjwt } from "./default/jwt"
+import { handler as defaultrequiredMetadataKeys } from "./default/requiredMetadataKeys"
+import { handler as defaultaddPrefix } from "./default/addPrefix"
+import { handler as defaultnotNull } from "./default/notNull"
+import { handler as portkeymoderateContent } from "./portkey/moderateContent"
+import { handler as portkeylanguage } from "./portkey/language"
+import { handler as portkeypii } from "./portkey/pii"
+import { handler as portkeygibberish } from "./portkey/gibberish"
+import { handler as qualifirecontentModeration } from "./qualifire/contentModeration"
+import { handler as qualifirehallucinations } from "./qualifire/hallucinations"
+import { handler as qualifirepii } from "./qualifire/pii"
+import { handler as qualifirepromptInjections } from "./qualifire/promptInjections"
+import { handler as qualifiregrounding } from "./qualifire/grounding"
+import { handler as qualifiretoolUseQuality } from "./qualifire/toolUseQuality"
+import { handler as qualifirepolicy } from "./qualifire/policy"
+import { handler as aporiavalidateProject } from "./aporia/validateProject"
+import { handler as sydelabssydeguard } from "./sydelabs/sydeguard"
+import { handler as pillarscanPrompt } from "./pillar/scanPrompt"
+import { handler as pillarscanResponse } from "./pillar/scanResponse"
+import { handler as patronusphi } from "./patronus/phi"
+import { handler as patronuspii } from "./patronus/pii"
+import { handler as patronusisConcise } from "./patronus/isConcise"
+import { handler as patronusisHelpful } from "./patronus/isHelpful"
+import { handler as patronusisPolite } from "./patronus/isPolite"
+import { handler as patronusnoApologies } from "./patronus/noApologies"
+import { handler as patronusnoGenderBias } from "./patronus/noGenderBias"
+import { handler as patronusnoRacialBias } from "./patronus/noRacialBias"
+import { handler as patronusretrievalAnswerRelevance } from "./patronus/retrievalAnswerRelevance"
+import { handler as patronusretrievalHallucination } from "./patronus/retrievalHallucination"
+import { handler as patronustoxicity } from "./patronus/toxicity"
+import { handler as patronuscustom } from "./patronus/custom"
+import { handler as pangeatextGuard } from "./pangea/textGuard"
+import { handler as pangeapii } from "./pangea/pii"
+import { handler as promptsecurityprotectPrompt } from "./promptsecurity/protectPrompt"
+import { handler as promptsecurityprotectResponse } from "./promptsecurity/protectResponse"
+import { handler as panwPrismaAirsintercept } from "./panw-prisma-airs/intercept"
+import { handler as walledaiwalledprotect } from "./walledai/walledprotect"
+import { handler as cryptowerkseal } from "./cryptowerk/seal"
 
 export const plugins = {
-  default: {
-    regexMatch: defaultregexMatch,
-    allowedRequestTypes: defaultallowedRequestTypes,
-    sentenceCount: defaultsentenceCount,
-    wordCount: defaultwordCount,
-    characterCount: defaultcharacterCount,
-    jsonSchema: defaultjsonSchema,
-    jsonKeys: defaultjsonKeys,
-    contains: defaultcontains,
-    validUrls: defaultvalidUrls,
-    webhook: defaultwebhook,
-    log: defaultlog,
-    containsCode: defaultcontainsCode,
-    alluppercase: defaultalluppercase,
-    endsWith: defaultendsWith,
-    alllowercase: defaultalllowercase,
-    modelwhitelist: defaultmodelwhitelist,
-    modelRules: defaultmodelRules,
-    jwt: defaultjwt,
-    requiredMetadataKeys: defaultrequiredMetadataKeys,
-    addPrefix: defaultaddPrefix,
-    notNull: defaultnotNull,
+  "default": {
+    "regexMatch": defaultregexMatch,
+    "allowedRequestTypes": defaultallowedRequestTypes,
+    "sentenceCount": defaultsentenceCount,
+    "wordCount": defaultwordCount,
+    "characterCount": defaultcharacterCount,
+    "jsonSchema": defaultjsonSchema,
+    "jsonKeys": defaultjsonKeys,
+    "contains": defaultcontains,
+    "validUrls": defaultvalidUrls,
+    "webhook": defaultwebhook,
+    "log": defaultlog,
+    "containsCode": defaultcontainsCode,
+    "alluppercase": defaultalluppercase,
+    "endsWith": defaultendsWith,
+    "alllowercase": defaultalllowercase,
+    "modelwhitelist": defaultmodelwhitelist,
+    "modelRules": defaultmodelRules,
+    "jwt": defaultjwt,
+    "requiredMetadataKeys": defaultrequiredMetadataKeys,
+    "addPrefix": defaultaddPrefix,
+    "notNull": defaultnotNull
   },
-  portkey: {
-    moderateContent: portkeymoderateContent,
-    language: portkeylanguage,
-    pii: portkeypii,
-    gibberish: portkeygibberish,
+  "portkey": {
+    "moderateContent": portkeymoderateContent,
+    "language": portkeylanguage,
+    "pii": portkeypii,
+    "gibberish": portkeygibberish
   },
-  qualifire: {
-    contentModeration: qualifirecontentModeration,
-    hallucinations: qualifirehallucinations,
-    pii: qualifirepii,
-    promptInjections: qualifirepromptInjections,
-    grounding: qualifiregrounding,
-    toolUseQuality: qualifiretoolUseQuality,
-    policy: qualifirepolicy,
+  "qualifire": {
+    "contentModeration": qualifirecontentModeration,
+    "hallucinations": qualifirehallucinations,
+    "pii": qualifirepii,
+    "promptInjections": qualifirepromptInjections,
+    "grounding": qualifiregrounding,
+    "toolUseQuality": qualifiretoolUseQuality,
+    "policy": qualifirepolicy
   },
-  aporia: {
-    validateProject: aporiavalidateProject,
+  "aporia": {
+    "validateProject": aporiavalidateProject
   },
-  sydelabs: {
-    sydeguard: sydelabssydeguard,
+  "sydelabs": {
+    "sydeguard": sydelabssydeguard
   },
-  pillar: {
-    scanPrompt: pillarscanPrompt,
-    scanResponse: pillarscanResponse,
+  "pillar": {
+    "scanPrompt": pillarscanPrompt,
+    "scanResponse": pillarscanResponse
   },
-  patronus: {
-    phi: patronusphi,
-    pii: patronuspii,
-    isConcise: patronusisConcise,
-    isHelpful: patronusisHelpful,
-    isPolite: patronusisPolite,
-    noApologies: patronusnoApologies,
-    noGenderBias: patronusnoGenderBias,
-    noRacialBias: patronusnoRacialBias,
-    retrievalAnswerRelevance: patronusretrievalAnswerRelevance,
-    retrievalHallucination: patronusretrievalHallucination,
-    toxicity: patronustoxicity,
-    custom: patronuscustom,
+  "patronus": {
+    "phi": patronusphi,
+    "pii": patronuspii,
+    "isConcise": patronusisConcise,
+    "isHelpful": patronusisHelpful,
+    "isPolite": patronusisPolite,
+    "noApologies": patronusnoApologies,
+    "noGenderBias": patronusnoGenderBias,
+    "noRacialBias": patronusnoRacialBias,
+    "retrievalAnswerRelevance": patronusretrievalAnswerRelevance,
+    "retrievalHallucination": patronusretrievalHallucination,
+    "toxicity": patronustoxicity,
+    "custom": patronuscustom
   },
-  pangea: {
-    textGuard: pangeatextGuard,
-    pii: pangeapii,
+  "pangea": {
+    "textGuard": pangeatextGuard,
+    "pii": pangeapii
   },
-  promptsecurity: {
-    protectPrompt: promptsecurityprotectPrompt,
-    protectResponse: promptsecurityprotectResponse,
+  "promptsecurity": {
+    "protectPrompt": promptsecurityprotectPrompt,
+    "protectResponse": promptsecurityprotectResponse
   },
-  'panw-prisma-airs': {
-    intercept: panwPrismaAirsintercept,
+  "panw-prisma-airs": {
+    "intercept": panwPrismaAirsintercept
   },
-  walledai: {
-    walledprotect: walledaiwalledprotect,
+  "walledai": {
+    "walledprotect": walledaiwalledprotect
   },
-  cryptowerk: {
-    seal: cryptowerkseal,
-  },
+  "cryptowerk": {
+    "seal": cryptowerkseal
+  }
 };

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,5 +1,4 @@
 import { handler as defaultregexMatch } from './default/regexMatch';
-import { handler as defaultallowedRequestTypes } from './default/allowedRequestTypes';
 import { handler as defaultsentenceCount } from './default/sentenceCount';
 import { handler as defaultwordCount } from './default/wordCount';
 import { handler as defaultcharacterCount } from './default/characterCount';
@@ -11,25 +10,23 @@ import { handler as defaultwebhook } from './default/webhook';
 import { handler as defaultlog } from './default/log';
 import { handler as defaultcontainsCode } from './default/containsCode';
 import { handler as defaultalluppercase } from './default/alluppercase';
-import { handler as defaultendsWith } from './default/endsWith';
 import { handler as defaultalllowercase } from './default/alllowercase';
-import { handler as defaultmodelwhitelist } from './default/modelwhitelist';
-import { handler as defaultmodelRules } from './default/modelRules';
-import { handler as defaultjwt } from './default/jwt';
-import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
-import { handler as defaultaddPrefix } from './default/addPrefix';
+import { handler as defaultendsWith } from './default/endsWith';
+import { handler as defaultmodelWhitelist } from './default/modelWhitelist';
 import { handler as defaultnotNull } from './default/notNull';
+import { handler as qualifireContentModeration } from './qualifire/contentModeration';
+import { handler as qualifireGrounding } from './qualifire/grounding';
+import { handler as qualifirePolicy } from './qualifire/policy';
+import { handler as qualifireToolUseQuality } from './qualifire/toolUseQuality';
+import { handler as qualifireHallucinations } from './qualifire/hallucinations';
+import { handler as qualifirePii } from './qualifire/pii';
+import { handler as qualifirePromptInjections } from './qualifire/promptInjections';
+import { handler as defaultaddPrefix } from './default/addPrefix';
+import { handler as defaultmodelRules } from './default/modelRules';
 import { handler as portkeymoderateContent } from './portkey/moderateContent';
 import { handler as portkeylanguage } from './portkey/language';
 import { handler as portkeypii } from './portkey/pii';
 import { handler as portkeygibberish } from './portkey/gibberish';
-import { handler as qualifirecontentModeration } from './qualifire/contentModeration';
-import { handler as qualifirehallucinations } from './qualifire/hallucinations';
-import { handler as qualifirepii } from './qualifire/pii';
-import { handler as qualifirepromptInjections } from './qualifire/promptInjections';
-import { handler as qualifiregrounding } from './qualifire/grounding';
-import { handler as qualifiretoolUseQuality } from './qualifire/toolUseQuality';
-import { handler as qualifirepolicy } from './qualifire/policy';
 import { handler as aporiavalidateProject } from './aporia/validateProject';
 import { handler as sydelabssydeguard } from './sydelabs/sydeguard';
 import { handler as pillarscanPrompt } from './pillar/scanPrompt';
@@ -43,21 +40,38 @@ import { handler as patronusnoApologies } from './patronus/noApologies';
 import { handler as patronusnoGenderBias } from './patronus/noGenderBias';
 import { handler as patronusnoRacialBias } from './patronus/noRacialBias';
 import { handler as patronusretrievalAnswerRelevance } from './patronus/retrievalAnswerRelevance';
-import { handler as patronusretrievalHallucination } from './patronus/retrievalHallucination';
 import { handler as patronustoxicity } from './patronus/toxicity';
 import { handler as patronuscustom } from './patronus/custom';
+import { mistralGuardrailHandler } from './mistral';
 import { handler as pangeatextGuard } from './pangea/textGuard';
+import { handler as promptfooPii } from './promptfoo/pii';
+import { handler as promptfooHarm } from './promptfoo/harm';
+import { handler as promptfooGuard } from './promptfoo/guard';
 import { handler as pangeapii } from './pangea/pii';
-import { handler as promptsecurityprotectPrompt } from './promptsecurity/protectPrompt';
-import { handler as promptsecurityprotectResponse } from './promptsecurity/protectResponse';
+import { pluginHandler as bedrockHandler } from './bedrock/index';
+import { handler as acuvityScan } from './acuvity/scan';
+import { handler as lassoclassify } from './lasso/classify';
+import { handler as exaonline } from './exa/online';
+import { handler as azurePii } from './azure/pii';
+import { handler as azureContentSafety } from './azure/contentSafety';
+import { handler as promptSecurityProtectPrompt } from './promptsecurity/protectPrompt';
+import { handler as promptSecurityProtectResponse } from './promptsecurity/protectResponse';
 import { handler as panwPrismaAirsintercept } from './panw-prisma-airs/intercept';
-import { handler as walledaiwalledprotect } from './walledai/walledprotect';
+import { handler as defaultjwt } from './default/jwt';
+import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
+import { handler as walledaiguardrails } from './walledai/walledprotect';
+import { handler as defaultregexReplace } from './default/regexReplace';
+import { handler as defaultallowedRequestTypes } from './default/allowedRequestTypes';
+import { handler as javelinguardrails } from './javelin/guardrails';
+import { handler as f5GuardrailsScan } from './f5-guardrails/scan';
+import { handler as azureShieldPrompt } from './azure/shieldPrompt';
+import { handler as azureProtectedMaterial } from './azure/protectedMaterial';
+import { handler as crowdstrikeAidrGuardChatCompletions } from './crowdstrike-aidr/guardChatCompletion';
 import { handler as cryptowerkseal } from './cryptowerk/seal';
 
 export const plugins = {
   default: {
     regexMatch: defaultregexMatch,
-    allowedRequestTypes: defaultallowedRequestTypes,
     sentenceCount: defaultsentenceCount,
     wordCount: defaultwordCount,
     characterCount: defaultcharacterCount,
@@ -69,29 +83,31 @@ export const plugins = {
     log: defaultlog,
     containsCode: defaultcontainsCode,
     alluppercase: defaultalluppercase,
-    endsWith: defaultendsWith,
     alllowercase: defaultalllowercase,
-    modelwhitelist: defaultmodelwhitelist,
+    endsWith: defaultendsWith,
+    modelWhitelist: defaultmodelWhitelist,
     modelRules: defaultmodelRules,
     jwt: defaultjwt,
     requiredMetadataKeys: defaultrequiredMetadataKeys,
     addPrefix: defaultaddPrefix,
+    regexReplace: defaultregexReplace,
+    allowedRequestTypes: defaultallowedRequestTypes,
     notNull: defaultnotNull,
+  },
+  qualifire: {
+    contentModeration: qualifireContentModeration,
+    grounding: qualifireGrounding,
+    policy: qualifirePolicy,
+    toolUseQuality: qualifireToolUseQuality,
+    hallucinations: qualifireHallucinations,
+    pii: qualifirePii,
+    promptInjections: qualifirePromptInjections,
   },
   portkey: {
     moderateContent: portkeymoderateContent,
     language: portkeylanguage,
     pii: portkeypii,
     gibberish: portkeygibberish,
-  },
-  qualifire: {
-    contentModeration: qualifirecontentModeration,
-    hallucinations: qualifirehallucinations,
-    pii: qualifirepii,
-    promptInjections: qualifirepromptInjections,
-    grounding: qualifiregrounding,
-    toolUseQuality: qualifiretoolUseQuality,
-    policy: qualifirepolicy,
   },
   aporia: {
     validateProject: aporiavalidateProject,
@@ -113,23 +129,57 @@ export const plugins = {
     noGenderBias: patronusnoGenderBias,
     noRacialBias: patronusnoRacialBias,
     retrievalAnswerRelevance: patronusretrievalAnswerRelevance,
-    retrievalHallucination: patronusretrievalHallucination,
     toxicity: patronustoxicity,
     custom: patronuscustom,
+  },
+  mistral: {
+    moderateContent: mistralGuardrailHandler,
   },
   pangea: {
     textGuard: pangeatextGuard,
     pii: pangeapii,
   },
+  promptfoo: {
+    pii: promptfooPii,
+    harm: promptfooHarm,
+    guard: promptfooGuard,
+  },
+  bedrock: {
+    guard: bedrockHandler,
+  },
+  acuvity: {
+    scan: acuvityScan,
+  },
+  lasso: {
+    classify: lassoclassify,
+  },
+  exa: {
+    online: exaonline,
+  },
+  azure: {
+    pii: azurePii,
+    contentSafety: azureContentSafety,
+    shieldPrompt: azureShieldPrompt,
+    protectedMaterial: azureProtectedMaterial,
+  },
   promptsecurity: {
-    protectPrompt: promptsecurityprotectPrompt,
-    protectResponse: promptsecurityprotectResponse,
+    protectPrompt: promptSecurityProtectPrompt,
+    protectResponse: promptSecurityProtectResponse,
   },
   'panw-prisma-airs': {
     intercept: panwPrismaAirsintercept,
   },
   walledai: {
-    walledprotect: walledaiwalledprotect,
+    walledprotect: walledaiguardrails,
+  },
+  javelin: {
+    guardrails: javelinguardrails,
+  },
+  'f5-guardrails': {
+    scan: f5GuardrailsScan,
+  },
+  'crowdstrike-aidr': {
+    guardChatCompletions: crowdstrikeAidrGuardChatCompletions,
   },
   cryptowerk: {
     seal: cryptowerkseal,

--- a/plugins/index.ts
+++ b/plugins/index.ts
@@ -1,4 +1,5 @@
 import { handler as defaultregexMatch } from './default/regexMatch';
+import { handler as defaultallowedRequestTypes } from './default/allowedRequestTypes';
 import { handler as defaultsentenceCount } from './default/sentenceCount';
 import { handler as defaultwordCount } from './default/wordCount';
 import { handler as defaultcharacterCount } from './default/characterCount';
@@ -10,23 +11,25 @@ import { handler as defaultwebhook } from './default/webhook';
 import { handler as defaultlog } from './default/log';
 import { handler as defaultcontainsCode } from './default/containsCode';
 import { handler as defaultalluppercase } from './default/alluppercase';
-import { handler as defaultalllowercase } from './default/alllowercase';
 import { handler as defaultendsWith } from './default/endsWith';
-import { handler as defaultmodelWhitelist } from './default/modelWhitelist';
-import { handler as defaultnotNull } from './default/notNull';
-import { handler as qualifireContentModeration } from './qualifire/contentModeration';
-import { handler as qualifireGrounding } from './qualifire/grounding';
-import { handler as qualifirePolicy } from './qualifire/policy';
-import { handler as qualifireToolUseQuality } from './qualifire/toolUseQuality';
-import { handler as qualifireHallucinations } from './qualifire/hallucinations';
-import { handler as qualifirePii } from './qualifire/pii';
-import { handler as qualifirePromptInjections } from './qualifire/promptInjections';
-import { handler as defaultaddPrefix } from './default/addPrefix';
+import { handler as defaultalllowercase } from './default/alllowercase';
+import { handler as defaultmodelwhitelist } from './default/modelwhitelist';
 import { handler as defaultmodelRules } from './default/modelRules';
+import { handler as defaultjwt } from './default/jwt';
+import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
+import { handler as defaultaddPrefix } from './default/addPrefix';
+import { handler as defaultnotNull } from './default/notNull';
 import { handler as portkeymoderateContent } from './portkey/moderateContent';
 import { handler as portkeylanguage } from './portkey/language';
 import { handler as portkeypii } from './portkey/pii';
 import { handler as portkeygibberish } from './portkey/gibberish';
+import { handler as qualifirecontentModeration } from './qualifire/contentModeration';
+import { handler as qualifirehallucinations } from './qualifire/hallucinations';
+import { handler as qualifirepii } from './qualifire/pii';
+import { handler as qualifirepromptInjections } from './qualifire/promptInjections';
+import { handler as qualifiregrounding } from './qualifire/grounding';
+import { handler as qualifiretoolUseQuality } from './qualifire/toolUseQuality';
+import { handler as qualifirepolicy } from './qualifire/policy';
 import { handler as aporiavalidateProject } from './aporia/validateProject';
 import { handler as sydelabssydeguard } from './sydelabs/sydeguard';
 import { handler as pillarscanPrompt } from './pillar/scanPrompt';
@@ -40,37 +43,21 @@ import { handler as patronusnoApologies } from './patronus/noApologies';
 import { handler as patronusnoGenderBias } from './patronus/noGenderBias';
 import { handler as patronusnoRacialBias } from './patronus/noRacialBias';
 import { handler as patronusretrievalAnswerRelevance } from './patronus/retrievalAnswerRelevance';
+import { handler as patronusretrievalHallucination } from './patronus/retrievalHallucination';
 import { handler as patronustoxicity } from './patronus/toxicity';
 import { handler as patronuscustom } from './patronus/custom';
-import { mistralGuardrailHandler } from './mistral';
 import { handler as pangeatextGuard } from './pangea/textGuard';
-import { handler as promptfooPii } from './promptfoo/pii';
-import { handler as promptfooHarm } from './promptfoo/harm';
-import { handler as promptfooGuard } from './promptfoo/guard';
 import { handler as pangeapii } from './pangea/pii';
-import { pluginHandler as bedrockHandler } from './bedrock/index';
-import { handler as acuvityScan } from './acuvity/scan';
-import { handler as lassoclassify } from './lasso/classify';
-import { handler as exaonline } from './exa/online';
-import { handler as azurePii } from './azure/pii';
-import { handler as azureContentSafety } from './azure/contentSafety';
-import { handler as promptSecurityProtectPrompt } from './promptsecurity/protectPrompt';
-import { handler as promptSecurityProtectResponse } from './promptsecurity/protectResponse';
+import { handler as promptsecurityprotectPrompt } from './promptsecurity/protectPrompt';
+import { handler as promptsecurityprotectResponse } from './promptsecurity/protectResponse';
 import { handler as panwPrismaAirsintercept } from './panw-prisma-airs/intercept';
-import { handler as defaultjwt } from './default/jwt';
-import { handler as defaultrequiredMetadataKeys } from './default/requiredMetadataKeys';
-import { handler as walledaiguardrails } from './walledai/walledprotect';
-import { handler as defaultregexReplace } from './default/regexReplace';
-import { handler as defaultallowedRequestTypes } from './default/allowedRequestTypes';
-import { handler as javelinguardrails } from './javelin/guardrails';
-import { handler as f5GuardrailsScan } from './f5-guardrails/scan';
-import { handler as azureShieldPrompt } from './azure/shieldPrompt';
-import { handler as azureProtectedMaterial } from './azure/protectedMaterial';
-import { handler as crowdstrikeAidrGuardChatCompletions } from './crowdstrike-aidr/guardChatCompletion';
+import { handler as walledaiwalledprotect } from './walledai/walledprotect';
+import { handler as cryptowerkseal } from './cryptowerk/seal';
 
 export const plugins = {
   default: {
     regexMatch: defaultregexMatch,
+    allowedRequestTypes: defaultallowedRequestTypes,
     sentenceCount: defaultsentenceCount,
     wordCount: defaultwordCount,
     characterCount: defaultcharacterCount,
@@ -82,31 +69,29 @@ export const plugins = {
     log: defaultlog,
     containsCode: defaultcontainsCode,
     alluppercase: defaultalluppercase,
-    alllowercase: defaultalllowercase,
     endsWith: defaultendsWith,
-    modelWhitelist: defaultmodelWhitelist,
+    alllowercase: defaultalllowercase,
+    modelwhitelist: defaultmodelwhitelist,
     modelRules: defaultmodelRules,
     jwt: defaultjwt,
     requiredMetadataKeys: defaultrequiredMetadataKeys,
     addPrefix: defaultaddPrefix,
-    regexReplace: defaultregexReplace,
-    allowedRequestTypes: defaultallowedRequestTypes,
     notNull: defaultnotNull,
-  },
-  qualifire: {
-    contentModeration: qualifireContentModeration,
-    grounding: qualifireGrounding,
-    policy: qualifirePolicy,
-    toolUseQuality: qualifireToolUseQuality,
-    hallucinations: qualifireHallucinations,
-    pii: qualifirePii,
-    promptInjections: qualifirePromptInjections,
   },
   portkey: {
     moderateContent: portkeymoderateContent,
     language: portkeylanguage,
     pii: portkeypii,
     gibberish: portkeygibberish,
+  },
+  qualifire: {
+    contentModeration: qualifirecontentModeration,
+    hallucinations: qualifirehallucinations,
+    pii: qualifirepii,
+    promptInjections: qualifirepromptInjections,
+    grounding: qualifiregrounding,
+    toolUseQuality: qualifiretoolUseQuality,
+    policy: qualifirepolicy,
   },
   aporia: {
     validateProject: aporiavalidateProject,
@@ -128,56 +113,25 @@ export const plugins = {
     noGenderBias: patronusnoGenderBias,
     noRacialBias: patronusnoRacialBias,
     retrievalAnswerRelevance: patronusretrievalAnswerRelevance,
+    retrievalHallucination: patronusretrievalHallucination,
     toxicity: patronustoxicity,
     custom: patronuscustom,
-  },
-  mistral: {
-    moderateContent: mistralGuardrailHandler,
   },
   pangea: {
     textGuard: pangeatextGuard,
     pii: pangeapii,
   },
-  promptfoo: {
-    pii: promptfooPii,
-    harm: promptfooHarm,
-    guard: promptfooGuard,
-  },
-  bedrock: {
-    guard: bedrockHandler,
-  },
-  acuvity: {
-    scan: acuvityScan,
-  },
-  lasso: {
-    classify: lassoclassify,
-  },
-  exa: {
-    online: exaonline,
-  },
-  azure: {
-    pii: azurePii,
-    contentSafety: azureContentSafety,
-    shieldPrompt: azureShieldPrompt,
-    protectedMaterial: azureProtectedMaterial,
-  },
   promptsecurity: {
-    protectPrompt: promptSecurityProtectPrompt,
-    protectResponse: promptSecurityProtectResponse,
+    protectPrompt: promptsecurityprotectPrompt,
+    protectResponse: promptsecurityprotectResponse,
   },
   'panw-prisma-airs': {
     intercept: panwPrismaAirsintercept,
   },
   walledai: {
-    walledprotect: walledaiguardrails,
+    walledprotect: walledaiwalledprotect,
   },
-  javelin: {
-    guardrails: javelinguardrails,
-  },
-  'f5-guardrails': {
-    scan: f5GuardrailsScan,
-  },
-  'crowdstrike-aidr': {
-    guardChatCompletions: crowdstrikeAidrGuardChatCompletions,
+  cryptowerk: {
+    seal: cryptowerkseal,
   },
 };


### PR DESCRIPTION
**Description:** (required)
- The plugin enables Portkey requests and responses to be routed through Cryptowerk-backed proof and verification logic, making it possible to attach tamper-evident receipts, and preserve an auditable trail of protected execution. Ideal for AI Regulatory Compliance

**Tests Run/Test cases added:** (required)
- [ ] Description of test case: The jest test case performs an actual end-to-end proof creation. I.e., it issues an API request to Cryptowerk's production server. This is as close s a test case can get to the actual use case.

**Type of Change:**
<!-- Put an 'x' in the boxes that apply -->
- [X] New feature (non-breaking change which adds functionality)
