### PR TITLE
fix(fireworks): emit empty choices array when chunk has no choices

### DIFF
--- a/src/providers/fireworks-ai/chatComplete.test.ts
+++ b/src/providers/fireworks-ai/chatComplete.test.ts
@@ -1,4 +1,5 @@
 import { FireworksAIChatCompleteStreamChunkTransform } from './chatComplete';
+import { FireworksAICompleteStreamChunkTransform } from './complete';
 
 describe('FireworksAIChatCompleteStreamChunkTransform', () => {
   const baseChunk = {
@@ -113,5 +114,83 @@ describe('FireworksAIChatCompleteStreamChunkTransform', () => {
       completion_tokens: 5,
       total_tokens: 15,
     });
+  });
+});
+
+describe('FireworksAICompleteStreamChunkTransform', () => {
+  const baseChunk = {
+    id: 'cmpl-test123',
+    object: 'text_completion',
+    created: 1234567890,
+    model: 'accounts/fireworks/models/llama-v3p1-405b-instruct',
+  };
+
+  it('passes through [DONE] sentinel unchanged', () => {
+    const result = FireworksAICompleteStreamChunkTransform('data: [DONE]');
+    expect(result).toBe('data: [DONE]\n\n');
+  });
+
+  it('transforms a normal chunk with a choice', () => {
+    const input = JSON.stringify({
+      ...baseChunk,
+      choices: [
+        {
+          index: 0,
+          text: 'hello',
+          finish_reason: null,
+          logprobs: null,
+        },
+      ],
+      usage: null,
+    });
+
+    const result = FireworksAICompleteStreamChunkTransform(`data: ${input}`);
+
+    expect(result).toMatch(/^data: /);
+    const parsed = JSON.parse(result.replace(/^data: /, '').trimEnd());
+    expect(parsed.choices).toHaveLength(1);
+    expect(parsed.choices[0].text).toBe('hello');
+    expect(parsed.choices[0].finish_reason).toBeNull();
+    expect(parsed).not.toHaveProperty('usage');
+  });
+
+  it('emits an empty choices array when chunk has no choices (usage-only delta)', () => {
+    // Regression test for the same issue as #1627 in the complete endpoint
+    // Fireworks sends usage-only chunks with an empty choices array;
+    // previously parsedChunk.choices[0] threw and dropped the chunk.
+    const input = JSON.stringify({
+      ...baseChunk,
+      choices: [],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+
+    expect(() =>
+      FireworksAICompleteStreamChunkTransform(`data: ${input}`)
+    ).not.toThrow();
+
+    const result = FireworksAICompleteStreamChunkTransform(`data: ${input}`);
+    const parsed = JSON.parse(result.replace(/^data: /, '').trimEnd());
+
+    expect(parsed.choices).toEqual([]);
+    expect(parsed.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+    });
+  });
+
+  it('emits an empty choices array when choices key is missing entirely', () => {
+    const input = JSON.stringify({
+      ...baseChunk,
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+
+    expect(() =>
+      FireworksAICompleteStreamChunkTransform(`data: ${input}`)
+    ).not.toThrow();
+
+    const result = FireworksAICompleteStreamChunkTransform(`data: ${input}`);
+    const parsed = JSON.parse(result.replace(/^data: /, '').trimEnd());
+    expect(parsed.choices).toEqual([]);
   });
 });

--- a/src/providers/fireworks-ai/chatComplete.test.ts
+++ b/src/providers/fireworks-ai/chatComplete.test.ts
@@ -1,0 +1,117 @@
+import { FireworksAIChatCompleteStreamChunkTransform } from './chatComplete';
+
+describe('FireworksAIChatCompleteStreamChunkTransform', () => {
+  const baseChunk = {
+    id: 'chatcmpl-test123',
+    object: 'chat.completion.chunk',
+    created: 1234567890,
+    model: 'accounts/fireworks/models/llama-v3p1-405b-instruct',
+  };
+
+  it('passes through [DONE] sentinel unchanged', () => {
+    const result = FireworksAIChatCompleteStreamChunkTransform('data: [DONE]');
+    expect(result).toBe('data: [DONE]\n\n');
+  });
+
+  it('transforms a normal chunk with a choice', () => {
+    const input = JSON.stringify({
+      ...baseChunk,
+      choices: [
+        {
+          index: 0,
+          delta: { role: 'assistant', content: 'hello' },
+          finish_reason: null,
+          logprobs: null,
+        },
+      ],
+      usage: null,
+    });
+
+    const result = FireworksAIChatCompleteStreamChunkTransform(
+      `data: ${input}`
+    );
+
+    expect(result).toMatch(/^data: /);
+    const parsed = JSON.parse(result.replace(/^data: /, '').trimEnd());
+    expect(parsed.choices).toHaveLength(1);
+    expect(parsed.choices[0].delta.content).toBe('hello');
+    expect(parsed.choices[0].finish_reason).toBeNull();
+    expect(parsed).not.toHaveProperty('usage');
+  });
+
+  it('emits an empty choices array when chunk has no choices (usage-only delta)', () => {
+    // Regression test for https://github.com/Portkey-AI/gateway/issues/1627
+    // Fireworks sends usage-only chunks with an empty choices array;
+    // previously parsedChunk.choices[0] threw and dropped the chunk.
+    const input = JSON.stringify({
+      ...baseChunk,
+      choices: [],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+
+    expect(() =>
+      FireworksAIChatCompleteStreamChunkTransform(`data: ${input}`)
+    ).not.toThrow();
+
+    const result = FireworksAIChatCompleteStreamChunkTransform(
+      `data: ${input}`
+    );
+    const parsed = JSON.parse(result.replace(/^data: /, '').trimEnd());
+
+    expect(parsed.choices).toEqual([]);
+    expect(parsed.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+    });
+  });
+
+  it('emits an empty choices array when choices key is missing entirely', () => {
+    const { choices: _omit, ...chunkWithoutChoices } = {
+      ...baseChunk,
+      choices: [] as any[],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    };
+
+    const input = JSON.stringify({
+      ...baseChunk,
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+
+    expect(() =>
+      FireworksAIChatCompleteStreamChunkTransform(`data: ${input}`)
+    ).not.toThrow();
+
+    const result = FireworksAIChatCompleteStreamChunkTransform(
+      `data: ${input}`
+    );
+    const parsed = JSON.parse(result.replace(/^data: /, '').trimEnd());
+    expect(parsed.choices).toEqual([]);
+  });
+
+  it('includes usage when present in chunk', () => {
+    const input = JSON.stringify({
+      ...baseChunk,
+      choices: [
+        {
+          index: 0,
+          delta: {},
+          finish_reason: 'stop',
+          logprobs: null,
+        },
+      ],
+      usage: { prompt_tokens: 10, completion_tokens: 5, total_tokens: 15 },
+    });
+
+    const result = FireworksAIChatCompleteStreamChunkTransform(
+      `data: ${input}`
+    );
+    const parsed = JSON.parse(result.replace(/^data: /, '').trimEnd());
+
+    expect(parsed.usage).toEqual({
+      prompt_tokens: 10,
+      completion_tokens: 5,
+      total_tokens: 15,
+    });
+  });
+});

--- a/src/providers/fireworks-ai/chatComplete.ts
+++ b/src/providers/fireworks-ai/chatComplete.ts
@@ -222,6 +222,7 @@ export const FireworksAIChatCompleteStreamChunkTransform: (
     return `data: ${chunk}\n\n`;
   }
   const parsedChunk: FireworksAIStreamChunk = JSON.parse(chunk);
+  const choice = parsedChunk.choices?.[0];
   return (
     `data: ${JSON.stringify({
       id: parsedChunk.id,
@@ -229,14 +230,16 @@ export const FireworksAIChatCompleteStreamChunkTransform: (
       created: parsedChunk.created,
       model: parsedChunk.model,
       provider: FIREWORKS_AI,
-      choices: [
-        {
-          index: parsedChunk.choices[0].index,
-          delta: parsedChunk.choices[0].delta,
-          finish_reason: parsedChunk.choices[0].finish_reason,
-          logprobs: parsedChunk.choices[0].logprobs,
-        },
-      ],
+      choices: choice
+        ? [
+            {
+              index: choice.index,
+              delta: choice.delta,
+              finish_reason: choice.finish_reason,
+              logprobs: choice.logprobs,
+            },
+          ]
+        : [],
       ...(parsedChunk.usage ? { usage: parsedChunk.usage } : {}),
     })}` + '\n\n'
   );

--- a/src/providers/fireworks-ai/complete.ts
+++ b/src/providers/fireworks-ai/complete.ts
@@ -157,6 +157,7 @@ export const FireworksAICompleteStreamChunkTransform: (
     return `data: ${chunk}\n\n`;
   }
   const parsedChunk: FireworksAICompleteStreamChunk = JSON.parse(chunk);
+  const choice = parsedChunk.choices?.[0];
   return (
     `data: ${JSON.stringify({
       id: parsedChunk.id,
@@ -164,14 +165,16 @@ export const FireworksAICompleteStreamChunkTransform: (
       created: parsedChunk.created,
       model: parsedChunk.model,
       provider: FIREWORKS_AI,
-      choices: [
-        {
-          index: parsedChunk.choices[0].index ?? 0,
-          text: parsedChunk.choices[0].text,
-          logprobs: null,
-          finish_reason: parsedChunk.choices[0].finish_reason,
-        },
-      ],
+      choices: choice
+        ? [
+            {
+              index: choice.index ?? 0,
+              text: choice.text,
+              logprobs: null,
+              finish_reason: choice.finish_reason,
+            },
+          ]
+        : [],
       ...(parsedChunk.usage ? { usage: parsedChunk.usage } : {}),
     })}` + '\n\n'
   );


### PR DESCRIPTION
## Summary
- Some Fireworks streaming chunks (e.g. usage-only deltas) arrive without a `choices` entry. The previous mapping indexed `parsedChunk.choices[0]` directly, throwing and dropping the chunk.
- Guard with optional chaining (`parsedChunk.choices?.[0]`) and serialize an empty `choices: []` when absent, mirroring the existing groq (#1073) and together-ai (#1321) stream adapters.

## Test plan
- [ ] `pnpm test` (or the gateway stream-tests) passes
- [ ] Manual: stream a Fireworks chat completion that emits a usage-only delta; chunk is forwarded instead of dropped

Closes #1627