### PR TITLE
bug: prevent crash on empty system message content array in Anthropic-family transforms

### DIFF
--- a/src/providers/anthropic/chatComplete.test.ts
+++ b/src/providers/anthropic/chatComplete.test.ts
@@ -1,0 +1,30 @@
+import { AnthropicChatCompleteConfig } from './chatComplete';
+
+const getSystemTransform = () => {
+  const messagesConfig = AnthropicChatCompleteConfig.messages as any[];
+  const systemConfig = messagesConfig.find((c) => c.param === 'system');
+  if (!systemConfig?.transform) {
+    throw new Error('system transform not found');
+  }
+  return systemConfig.transform as (params: any) => any;
+};
+
+describe('AnthropicChatCompleteConfig system message transform', () => {
+  it('does not throw on an empty system content array', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [{ role: 'system', content: [] }],
+    } as any);
+    expect(result).toEqual([]);
+  });
+
+  it('still transforms array-form system content', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [
+        { role: 'system', content: [{ type: 'text', text: 'be concise' }] },
+      ],
+    } as any);
+    expect(result).toEqual([{ text: 'be concise', type: 'text' }]);
+  });
+});

--- a/src/providers/anthropic/chatComplete.test.ts
+++ b/src/providers/anthropic/chatComplete.test.ts
@@ -27,4 +27,78 @@ describe('AnthropicChatCompleteConfig system message transform', () => {
     } as any);
     expect(result).toEqual([{ text: 'be concise', type: 'text' }]);
   });
+
+  it('keeps text that follows a non-text block', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [
+        {
+          role: 'system',
+          content: [
+            { type: 'image', source: { type: 'base64', data: 'x' } },
+            { type: 'text', text: 'be concise' },
+          ],
+        },
+      ],
+    } as any);
+    expect(result).toEqual([{ text: 'be concise', type: 'text' }]);
+  });
+
+  it('keeps text that follows an empty text block', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [
+        {
+          role: 'system',
+          content: [
+            { type: 'text', text: '' },
+            { type: 'text', text: 'be concise' },
+          ],
+        },
+      ],
+    } as any);
+    expect(result).toEqual([{ text: 'be concise', type: 'text' }]);
+  });
+
+  it('does not emit a text block for a trailing non-text block', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [
+        {
+          role: 'system',
+          content: [
+            { type: 'text', text: 'be concise' },
+            { type: 'image', source: { type: 'base64', data: 'x' } },
+          ],
+        },
+      ],
+    } as any);
+    expect(result).toEqual([{ text: 'be concise', type: 'text' }]);
+  });
+
+  it('preserves cache_control on text blocks', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [
+        {
+          role: 'system',
+          content: [
+            { type: 'image', source: { type: 'base64', data: 'x' } },
+            {
+              type: 'text',
+              text: 'be concise',
+              cache_control: { type: 'ephemeral' },
+            },
+          ],
+        },
+      ],
+    } as any);
+    expect(result).toEqual([
+      {
+        text: 'be concise',
+        type: 'text',
+        cache_control: { type: 'ephemeral' },
+      },
+    ]);
+  });
 });

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -336,7 +336,7 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
               SYSTEM_MESSAGE_ROLES.includes(msg.role) &&
               msg.content &&
               typeof msg.content === 'object' &&
-              msg.content[0].text
+              msg.content[0]?.text
             ) {
               msg.content.forEach((_msg) => {
                 systemMessages.push({

--- a/src/providers/anthropic/chatComplete.ts
+++ b/src/providers/anthropic/chatComplete.ts
@@ -335,10 +335,17 @@ export const AnthropicChatCompleteConfig: ProviderConfig = {
             if (
               SYSTEM_MESSAGE_ROLES.includes(msg.role) &&
               msg.content &&
-              typeof msg.content === 'object' &&
-              msg.content[0]?.text
+              Array.isArray(msg.content)
             ) {
               msg.content.forEach((_msg) => {
+                // Anthropic accepts non-text blocks (e.g. images) in system
+                // content, and programmatically built arrays can carry empty
+                // text blocks. Neither can be forwarded as a text block, so
+                // skip them instead of emitting `{ text: undefined }` or an
+                // empty block the API rejects.
+                if (typeof _msg?.text !== 'string' || _msg.text.length === 0) {
+                  return;
+                }
                 systemMessages.push({
                   text: _msg.text,
                   type: 'text',

--- a/src/providers/bedrock/uploadFileUtils.test.ts
+++ b/src/providers/bedrock/uploadFileUtils.test.ts
@@ -1,0 +1,31 @@
+import { BedrockUploadFileTransformerConfig } from './uploadFileUtils';
+
+const getSystemTransform = () => {
+  const anthropicConfig = BedrockUploadFileTransformerConfig.anthropic as any;
+  const messagesConfig = anthropicConfig.messages as any[];
+  const systemConfig = messagesConfig.find((c) => c.param === 'system');
+  if (!systemConfig?.transform) {
+    throw new Error('system transform not found');
+  }
+  return systemConfig.transform as (params: any) => any;
+};
+
+describe('BedrockAnthropic upload-file system message transform', () => {
+  it('does not throw on an empty system content array', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [{ role: 'system', content: [] }],
+    });
+    expect(result).toBe('');
+  });
+
+  it('still reads text from array-form system content', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [
+        { role: 'system', content: [{ type: 'text', text: 'be concise' }] },
+      ],
+    });
+    expect(result).toBe('be concise');
+  });
+});

--- a/src/providers/bedrock/uploadFileUtils.test.ts
+++ b/src/providers/bedrock/uploadFileUtils.test.ts
@@ -28,4 +28,36 @@ describe('BedrockAnthropic upload-file system message transform', () => {
     });
     expect(result).toBe('be concise');
   });
+
+  it('reads text that follows a non-text block', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [
+        {
+          role: 'system',
+          content: [
+            { type: 'image', source: { type: 'base64', data: 'x' } },
+            { type: 'text', text: 'be concise' },
+          ],
+        },
+      ],
+    });
+    expect(result).toBe('be concise');
+  });
+
+  it('skips an empty leading text block', () => {
+    const transform = getSystemTransform();
+    const result = transform({
+      messages: [
+        {
+          role: 'system',
+          content: [
+            { type: 'text', text: '' },
+            { type: 'text', text: 'be concise' },
+          ],
+        },
+      ],
+    });
+    expect(result).toBe('be concise');
+  });
 });

--- a/src/providers/bedrock/uploadFileUtils.ts
+++ b/src/providers/bedrock/uploadFileUtils.ts
@@ -205,7 +205,7 @@ const BedrockAnthropicChatCompleteConfig: ProviderConfig = {
               msg.role === 'system' &&
               msg.content &&
               typeof msg.content === 'object' &&
-              msg.content[0].text
+              msg.content[0]?.text
             ) {
               systemMessage = msg.content[0].text;
             } else if (

--- a/src/providers/bedrock/uploadFileUtils.ts
+++ b/src/providers/bedrock/uploadFileUtils.ts
@@ -204,10 +204,17 @@ const BedrockAnthropicChatCompleteConfig: ProviderConfig = {
             if (
               msg.role === 'system' &&
               msg.content &&
-              typeof msg.content === 'object' &&
-              msg.content[0]?.text
+              Array.isArray(msg.content)
             ) {
-              systemMessage = msg.content[0].text;
+              // Take the first usable text block rather than assuming index 0
+              // is one: system content may legitimately lead with an image or
+              // an empty text block, in which case index 0 has no text.
+              for (const block of msg.content as any[]) {
+                if (typeof block?.text === 'string' && block.text.length > 0) {
+                  systemMessage = block.text;
+                  break;
+                }
+              }
             } else if (
               msg.role === 'system' &&
               typeof msg.content === 'string'


### PR DESCRIPTION
**Description:** (required)

Two Anthropic-family system-message transforms decide whether a system/developer message is array-form by reading `msg.content[0].text` without first checking the array is non-empty:

```ts
if (
  SYSTEM_MESSAGE_ROLES.includes(msg.role) &&
  msg.content &&
  typeof msg.content === 'object' &&
  msg.content[0].text   // indexes [0] with no length check
) { ... }
```

That single expression carries two defects.

**1. Empty content array crashes the request.** When a system or developer message arrives with `content: []`, `msg.content[0]` is `undefined` and the access throws:

```
TypeError: Cannot read properties of undefined (reading 'text')
```

`content` is client-controlled, so a malformed-but-plausible request becomes a 500 instead of being handled. The sibling non-system branches already guard array access with `msg.content.length`, so these two paths are the outliers.

**2. Index 0 is assumed to be a text block.** The guard reads `content[0].text` but system content may legitimately lead with a non-text block (an image) or with an empty text block from a programmatically built array. In both cases the guard is falsy and the whole array is dropped silently, including text blocks sitting behind the first element. On the Anthropic path the opposite case is also wrong: once the guard passed, the inner `forEach` pushed `text: _msg.text` for every block, so a trailing image block became `{ type: 'text', text: undefined }`, which the API rejects.

**Affected paths**

- `src/providers/anthropic/chatComplete.ts`: `AnthropicChatCompleteConfig` system transform. This config is also spread into `VertexAnthropicChatCompleteConfig` and used by `azure-ai-inference`, so both defects reach Claude on Vertex and Azure AI Inference too.
- `src/providers/bedrock/uploadFileUtils.ts`: the `BedrockUploadFileTransformerConfig.anthropic` system transform, used when building Bedrock batch-inference files for Claude.

**The change**

Both guards become `Array.isArray(msg.content)`, which is false for string content and so leaves the string branch untouched, and the per-block decision moves inside the loop:

- `anthropic/chatComplete.ts` skips any block whose `text` is not a non-empty string, so images and empty text blocks are passed over rather than emitted as `{ text: undefined }`. `cache_control` still rides along on the blocks that survive.
- `bedrock/uploadFileUtils.ts` scans for the first usable text block instead of assuming index 0 is one.

Multi-block behaviour is unchanged on both paths. The Anthropic transform emits one text block per source block as it always did; the Bedrock batch transform keeps its existing string shape, where the first usable text block in a message wins and the last system message wins. Changing that is a separate behaviour decision and is not part of this fix.

**Tests Run/Test cases added:** (required)

- [x] `src/providers/anthropic/chatComplete.test.ts`, 6 cases: empty content array returns `[]` instead of throwing; array-form content still transforms; text after a non-text block is kept; text after an empty text block is kept; a trailing non-text block does not emit a bare text block; `cache_control` is preserved.
- [x] `src/providers/bedrock/uploadFileUtils.test.ts`, 4 cases: the same shapes through the exported `BedrockUploadFileTransformerConfig`.
- Full run on this branch is 10 passed across the two suites. Reverting only the two source files, with the tests left in place, gives 6 failed / 4 passed, so the tests are pinned to the behaviour rather than to the implementation.

**Type of Change:**
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
