### PR TITLE
provider: add FriendliAI inference provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -262,6 +262,7 @@ Explore Gateway integrations with [45+ providers](https://portkey.wiki/gh-59) an
 | <img src="https://deepinfra.com/_next/static/media/logo.4a03fd3d.svg" width=35>                                            | [DeepInfra](https://portkey.sh/gh-92)                               | ✅       | ✅      |
 | <img src="https://ollama.com/public/ollama.png" width=35>                                                                  | [Ollama](https://portkey.wiki/gh-72)                           | ✅       | ✅      |
 | <img src="https://novita.ai/favicon.ico" width=35>                                                                         | [Novita AI](https://portkey.wiki/gh-73)                              | ✅       | ✅      | `/chat/completions`, `/completions` |
+| <img src="https://friendli.ai/favicon.ico" width=35>                                                                          | [FriendliAI](https://friendli.ai)                        | ✅       | ✅      |
 
 
 > [View the complete list of 200+ supported models here](https://portkey.wiki/gh-74)

--- a/src/globals.ts
+++ b/src/globals.ts
@@ -113,6 +113,7 @@ export const ORACLE: string = 'oracle';
 export const IO_INTELLIGENCE: string = 'iointelligence';
 export const AIBADGR: string = 'aibadgr';
 export const OVHCLOUD: string = 'ovhcloud';
+export const FRIENDLI: string = 'friendli';
 
 export const VALID_PROVIDERS = [
   ANTHROPIC,
@@ -189,6 +190,7 @@ export const VALID_PROVIDERS = [
   IO_INTELLIGENCE,
   AIBADGR,
   OVHCLOUD,
+  FRIENDLI,
 ];
 
 export const CONTENT_TYPES = {

--- a/src/providers/friendli/api.ts
+++ b/src/providers/friendli/api.ts
@@ -1,0 +1,24 @@
+import { ProviderAPIConfig } from '../types';
+
+const FriendliAPIConfig: ProviderAPIConfig = {
+  getBaseURL: () => 'https://api.friendli.ai/serverless/v1',
+  headers: ({ providerOptions }) => {
+    const headersObj: Record<string, string> = {
+      Authorization: `Bearer ${providerOptions.apiKey}`,
+    };
+    if (providerOptions.friendliTeam) {
+      headersObj['X-Friendli-Team'] = providerOptions.friendliTeam;
+    }
+    return headersObj;
+  },
+  getEndpoint: ({ fn }) => {
+    switch (fn) {
+      case 'chatComplete':
+        return '/chat/completions';
+      default:
+        return '';
+    }
+  },
+};
+
+export default FriendliAPIConfig;

--- a/src/providers/friendli/chatComplete.ts
+++ b/src/providers/friendli/chatComplete.ts
@@ -1,0 +1,267 @@
+import { FRIENDLI } from '../../globals';
+import { Message, Params } from '../../types/requestBody';
+import {
+  ChatChoice,
+  ChatCompletionResponse,
+  ErrorResponse,
+  ProviderConfig,
+} from '../types';
+import { generateInvalidProviderResponseError } from '../utils';
+import { OpenAIErrorResponseTransform } from '../openai/utils';
+
+export const FriendliChatCompleteConfig: ProviderConfig = {
+  model: {
+    param: 'model',
+    required: true,
+  },
+  messages: {
+    param: 'messages',
+    default: '',
+    transform: (params: Params) => {
+      return params.messages?.map((message) => {
+        if (message.role === 'developer') return { ...message, role: 'system' };
+        return message;
+      });
+    },
+  },
+  max_tokens: {
+    param: 'max_tokens',
+    default: 100,
+    min: 0,
+  },
+  max_completion_tokens: {
+    param: 'max_completion_tokens',
+    min: 0,
+  },
+  temperature: {
+    param: 'temperature',
+    default: 1,
+    min: 0,
+    max: 2,
+  },
+  top_p: {
+    param: 'top_p',
+    default: 1,
+    min: 0,
+    max: 1,
+  },
+  n: {
+    param: 'n',
+    default: 1,
+  },
+  stream: {
+    param: 'stream',
+    default: false,
+  },
+  stream_options: {
+    param: 'stream_options',
+  },
+  stop: {
+    param: 'stop',
+  },
+  presence_penalty: {
+    param: 'presence_penalty',
+    min: -2,
+    max: 2,
+  },
+  frequency_penalty: {
+    param: 'frequency_penalty',
+    min: -2,
+    max: 2,
+  },
+  logit_bias: {
+    param: 'logit_bias',
+  },
+  user: {
+    param: 'user',
+  },
+  seed: {
+    param: 'seed',
+  },
+  tools: {
+    param: 'tools',
+  },
+  tool_choice: {
+    param: 'tool_choice',
+  },
+  response_format: {
+    param: 'response_format',
+  },
+  logprobs: {
+    param: 'logprobs',
+    default: false,
+  },
+  top_logprobs: {
+    param: 'top_logprobs',
+    min: 0,
+    max: 20,
+  },
+  chat_template_kwargs: {
+    param: 'chat_template_kwargs',
+  },
+  parse_reasoning: {
+    param: 'parse_reasoning',
+  },
+  include_reasoning: {
+    param: 'include_reasoning',
+  },
+};
+
+interface FriendliChatCompleteResponse {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: (ChatChoice & {
+    message: Message & {
+      reasoning_content?: string;
+    };
+  })[];
+  usage: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+    prompt_tokens_details?: {
+      cached_tokens?: number;
+    };
+  };
+}
+
+interface FriendliStreamChunk {
+  id: string;
+  object: string;
+  created: number;
+  model: string;
+  choices: {
+    delta: {
+      role?: string;
+      content?: string;
+      reasoning_content?: string;
+      tool_calls?: any[];
+    };
+    index: number;
+    finish_reason: string | null;
+  }[];
+  usage?: {
+    prompt_tokens: number;
+    completion_tokens: number;
+    total_tokens: number;
+  };
+}
+
+export const FriendliChatCompleteResponseTransform: (
+  response: FriendliChatCompleteResponse | ErrorResponse,
+  responseStatus: number,
+  _responseHeaders: Headers,
+  strictOpenAiCompliance: boolean
+) => ChatCompletionResponse | ErrorResponse = (
+  response,
+  responseStatus,
+  _responseHeaders,
+  strictOpenAiCompliance
+) => {
+  if (responseStatus !== 200 && 'error' in response) {
+    return OpenAIErrorResponseTransform(response, FRIENDLI);
+  }
+
+  if ('choices' in response) {
+    return {
+      id: response.id,
+      object: response.object,
+      created: response.created,
+      model: response.model,
+      provider: FRIENDLI,
+      choices: response.choices.map((c) => {
+        const content_blocks = [];
+        if (!strictOpenAiCompliance && c.message.reasoning_content) {
+          content_blocks.push({
+            type: 'thinking',
+            thinking: c.message.reasoning_content,
+          });
+        }
+        return {
+          index: c.index,
+          message: {
+            role: c.message.role,
+            content: c.message.content,
+            ...(content_blocks.length && { content_blocks }),
+            ...(c.message.tool_calls && { tool_calls: c.message.tool_calls }),
+          },
+          finish_reason: c.finish_reason,
+        };
+      }),
+      usage: response.usage,
+    };
+  }
+
+  return generateInvalidProviderResponseError(response, FRIENDLI);
+};
+
+export const FriendliChatCompleteStreamChunkTransform: (
+  response: string,
+  fallbackId: string,
+  streamState: Record<string, boolean>,
+  strictOpenAiCompliance: boolean,
+  gatewayRequest: Params
+) => string | string[] = (
+  responseChunk,
+  fallbackId,
+  _streamState,
+  strictOpenAiCompliance,
+  _gatewayRequest
+) => {
+  let chunk = responseChunk.trim();
+  chunk = chunk.replace(/^data: /, '');
+  chunk = chunk.trim();
+  if (chunk === '[DONE]') {
+    return `data: ${chunk}\n\n`;
+  }
+
+  let parsedChunk: FriendliStreamChunk;
+  try {
+    parsedChunk = JSON.parse(chunk);
+  } catch {
+    return `data: ${chunk}\n\n`;
+  }
+
+  const content_blocks = [];
+  if (!strictOpenAiCompliance) {
+    if (parsedChunk.choices?.[0]?.delta?.reasoning_content) {
+      content_blocks.push({
+        index: parsedChunk.choices[0].index,
+        delta: {
+          thinking: parsedChunk.choices[0].delta.reasoning_content,
+        },
+      });
+    }
+    if (parsedChunk.choices?.[0]?.delta?.content) {
+      content_blocks.push({
+        index: parsedChunk.choices[0].index,
+        delta: {
+          text: parsedChunk.choices[0].delta.content,
+        },
+      });
+    }
+  }
+
+  return (
+    `data: ${JSON.stringify({
+      id: parsedChunk.id || fallbackId,
+      object: parsedChunk.object || 'chat.completion.chunk',
+      created: parsedChunk.created || Math.floor(Date.now() / 1000),
+      model: parsedChunk.model || '',
+      provider: FRIENDLI,
+      choices: [
+        {
+          index: parsedChunk.choices?.[0]?.index ?? 0,
+          delta: {
+            ...parsedChunk.choices?.[0]?.delta,
+            ...(content_blocks.length && { content_blocks }),
+          },
+          finish_reason: parsedChunk.choices?.[0]?.finish_reason ?? null,
+        },
+      ],
+      ...(parsedChunk.usage && { usage: parsedChunk.usage }),
+    })}` + '\n\n'
+  );
+};

--- a/src/providers/friendli/chatComplete.ts
+++ b/src/providers/friendli/chatComplete.ts
@@ -13,6 +13,7 @@ export const FriendliChatCompleteConfig: ProviderConfig = {
   model: {
     param: 'model',
     required: true,
+    default: 'zai-org/GLM-5.2',
   },
   messages: {
     param: 'messages',

--- a/src/providers/friendli/index.ts
+++ b/src/providers/friendli/index.ts
@@ -1,0 +1,18 @@
+import { ProviderConfigs } from '../types';
+import FriendliAPIConfig from './api';
+import {
+  FriendliChatCompleteConfig,
+  FriendliChatCompleteResponseTransform,
+  FriendliChatCompleteStreamChunkTransform,
+} from './chatComplete';
+
+const FriendliConfig: ProviderConfigs = {
+  chatComplete: FriendliChatCompleteConfig,
+  api: FriendliAPIConfig,
+  responseTransforms: {
+    chatComplete: FriendliChatCompleteResponseTransform,
+    'stream-chatComplete': FriendliChatCompleteStreamChunkTransform,
+  },
+};
+
+export default FriendliConfig;

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -74,6 +74,7 @@ import OracleConfig from './oracle';
 import IOIntelligenceConfig from './iointelligence';
 import AIBadgrConfig from './aibadgr';
 import OVHcloudConfig from './ovhcloud';
+import FriendliConfig from './friendli';
 
 const Providers: { [key: string]: ProviderConfigs } = {
   openai: OpenAIConfig,
@@ -148,6 +149,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   iointelligence: IOIntelligenceConfig,
   aibadgr: AIBadgrConfig,
   ovhcloud: OVHcloudConfig,
+  friendli: FriendliConfig,
 };
 
 export default Providers;

--- a/src/tests/resources/testVariables.ts
+++ b/src/tests/resources/testVariables.ts
@@ -142,6 +142,10 @@ const testVariables: TestVariables = {
       model: 'Qwen/Qwen2.5-Coder-3B-Instruct',
     },
   },
+  friendli: {
+    apiKey: process.env.FRIENDLI_API_KEY,
+    chatCompletions: { model: 'meta-llama/Meta-Llama-3.1-8B-Instruct' },
+  },
 };
 
 export default testVariables;

--- a/src/tests/resources/testVariables.ts
+++ b/src/tests/resources/testVariables.ts
@@ -144,7 +144,7 @@ const testVariables: TestVariables = {
   },
   friendli: {
     apiKey: process.env.FRIENDLI_API_KEY,
-    chatCompletions: { model: 'meta-llama/Meta-Llama-3.1-8B-Instruct' },
+    chatCompletions: { model: 'zai-org/GLM-5.2' },
   },
 };
 


### PR DESCRIPTION
**Description:**
- Adds FriendliAI as an inference provider. The gateway proxies `/v1/chat/completions` to Friendli's serverless API at `https://api.friendli.ai/serverless/v1`.
- Friendli's API is OpenAI-compatible, but reasoning works differently. When `parse_reasoning` is on, Friendli splits reasoning into `choices[].message.reasoning_content`. This change maps that field to `content_blocks` with type `thinking`, matching how OpenRouter handles it.
- Adds Friendli-specific request params: `chat_template_kwargs` (for `enable_thinking` on controllable reasoning models like GLM-5.2), `parse_reasoning`, and `include_reasoning`.
- Supports optional `X-Friendli-Team` header via `providerOptions.friendliTeam`.
- Registered friendli in `globals.ts`, `providers/index.ts`, test variables, and the README providers table.

A docs page on `portkey.ai/docs/integrations/llms` would be the next step — happy to help with that if the maintainers want it in this PR or a follow-up.

**Tests Run/Test cases added:**
- [x] `npm run build` passes
- [x] `prettier --check` on all modified files
- [x] `eslint` on all new and modified files
- [x] Live API test (requires `FRIENDLI_API_KEY` env var)

**Type of Change:**
- [x] New feature (non-breaking change which adds functionality)