### PR TITLE
feat: add llmman provider

### DIFF
--- a/src/globals.ts
+++ b/src/globals.ts
@@ -59,6 +59,7 @@ export const NCOMPASS: string = 'ncompass';
 export const STABILITY_AI: string = 'stability-ai';
 export const NOMIC: string = 'nomic';
 export const OLLAMA: string = 'ollama';
+export const LLMMAN: string = 'llmman';
 export const AI21: string = 'ai21';
 export const BEDROCK: string = 'bedrock';
 export const GROQ: string = 'groq';
@@ -132,6 +133,7 @@ export const VALID_PROVIDERS = [
   STABILITY_AI,
   NOMIC,
   OLLAMA,
+  LLMMAN,
   AI21,
   BEDROCK,
   GROQ,

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -16,6 +16,7 @@ import PalmAIConfig from './palm';
 import PerplexityAIConfig from './perplexity-ai';
 import TogetherAIConfig from './together-ai';
 import StabilityAIConfig from './stability-ai';
+import LlmmanConfig from './llmman';
 import OllamaAPIConfig from './ollama';
 import { ProviderConfigs } from './types';
 import GroqConfig from './groq';
@@ -93,6 +94,7 @@ const Providers: { [key: string]: ProviderConfigs } = {
   'stability-ai': StabilityAIConfig,
   nomic: NomicConfig,
   ollama: OllamaAPIConfig,
+  llmman: LlmmanConfig,
   ai21: AI21Config,
   bedrock: BedrockConfig,
   groq: GroqConfig,

--- a/src/providers/llmman/api.ts
+++ b/src/providers/llmman/api.ts
@@ -1,0 +1,41 @@
+import { ProviderAPIConfig } from '../types';
+
+// llmman (https://github.com/llmmanorg/llmman) serves OpenAI-, Ollama- and
+// Anthropic-compatible APIs, so the endpoints match the Ollama-API provider.
+// Only the default host differs: llmman listens on 17434.
+const LLMMAN_DEFAULT_HOST = 'http://localhost:17434';
+
+const LlmmanAPIConfig: ProviderAPIConfig = {
+  headers: () => {
+    return {};
+  },
+  getBaseURL: ({ providerOptions }) => {
+    return providerOptions.customHost ?? LLMMAN_DEFAULT_HOST;
+  },
+  getEndpoint: ({ fn, providerOptions }) => {
+    let mappedFn = fn;
+    const { urlToFetch } = providerOptions;
+    if (fn === 'proxy' && urlToFetch && urlToFetch?.indexOf('/api/chat') > -1) {
+      mappedFn = 'chatComplete';
+    } else if (
+      fn === 'proxy' &&
+      urlToFetch &&
+      urlToFetch?.indexOf('/embeddings') > -1
+    ) {
+      mappedFn = 'embed';
+    }
+
+    switch (mappedFn) {
+      case 'chatComplete': {
+        return `/v1/chat/completions`;
+      }
+      case 'embed': {
+        return `/api/embeddings`;
+      }
+      default:
+        return '';
+    }
+  },
+};
+
+export default LlmmanAPIConfig;

--- a/src/providers/llmman/index.ts
+++ b/src/providers/llmman/index.ts
@@ -1,0 +1,26 @@
+import { ProviderConfigs } from '../types';
+import {
+  OllamaEmbedConfig,
+  OllamaEmbedResponseTransform,
+} from '../ollama/embed';
+import LlmmanAPIConfig from './api';
+import {
+  OllamaChatCompleteConfig,
+  OllamaChatCompleteResponseTransform,
+  OllamaChatCompleteStreamChunkTransform,
+} from '../ollama/chatComplete';
+
+// llmman serves the same wire APIs, so the request/response transforms are
+// shared; only the API config (default host) differs.
+const LlmmanConfig: ProviderConfigs = {
+  embed: OllamaEmbedConfig,
+  api: LlmmanAPIConfig,
+  chatComplete: OllamaChatCompleteConfig,
+  responseTransforms: {
+    chatComplete: OllamaChatCompleteResponseTransform,
+    'stream-chatComplete': OllamaChatCompleteStreamChunkTransform,
+    embed: OllamaEmbedResponseTransform,
+  },
+};
+
+export default LlmmanConfig;


### PR DESCRIPTION
Adds [llmman](https://github.com/llmmanorg/llmman), which runs local models distributed as OCI artifacts and serves an **Ollama-compatible API** (alongside OpenAI- and Anthropic-compatible ones).

Because the wire format matches, this **reuses the Ollama provider's transforms by importing them directly** (`../ollama/chatComplete`, `../ollama/embed`) rather than copying them — only `api.ts` differs. That difference is the default host: the Ollama provider returns an empty base URL when `customHost` is unset, whereas llmman has a well-known port (17434) to fall back on.

If you'd rather this were an alias on the existing provider than a separate entry, say so and I'll rework it — the only thing it really adds is the default host.

**Testing:** `tsc --noEmit` reports 9 lines both before and after (verified against a stashed baseline), so nothing introduced. Prettier clean.

Not verified: no request through the gateway to a live server.

> AI-assisted, reviewed before submitting.
